### PR TITLE
feat: Allow user-configurable memory allocation in SkipList

### DIFF
--- a/examples/use_skip.cpp
+++ b/examples/use_skip.cpp
@@ -1,5 +1,13 @@
 #include "skiplist.h"
 
+// To compile this example using standard library malloc/free for SkipList nodes
+// instead of the default custom memory pool, define the SKIPLIST_USE_STD_ALLOC macro.
+// For example, with g++:
+// g++ use_skip.cpp -o use_skip_std_alloc -std=c++17 -DSKIPLIST_USE_STD_ALLOC -I../include
+//
+// To compile with the default memory pool:
+// g++ use_skip.cpp -o use_skip_mem_pool -std=c++17 -I../include
+
 // Example usage and test cases
 int main() {
     SkipList<int> skipList;


### PR DESCRIPTION
This change introduces a compile-time option to select the memory allocation strategy for SkipList nodes.

By defining the `SKIPLIST_USE_STD_ALLOC` preprocessor macro, you can opt to use `std::malloc` and `std::free` for node allocation and deallocation. If the macro is not defined (the default behavior), the SkipList will continue to use its internal custom memory pool.

Modifications include:
- Introduction of `allocate_node` and `deallocate_node` private methods in the `SkipList` class to encapsulate allocation logic.
- Conditional compilation of the `MemoryPool` member and its usage based on `SKIPLIST_USE_STD_ALLOC`.
- Updates to the `SkipList` constructor, destructor, and methods like `insert`, `remove`, `clear`, and `insert_or_assign` to use the new allocation/deallocation methods.
- The header node's allocation/deallocation now also respects the chosen memory strategy.
- Added comments to `examples/use_skip.cpp` to demonstrate how to compile with either memory allocation strategy.

This provides you with greater flexibility in how SkipList manages memory, allowing you to choose standard library allocators if preferred or if the custom memory pool is not suitable for your specific use case.