### PR TITLE
feat: Add use_dsu example to CMake and enhance DSU tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(skip_example examples/use_skip.cpp)
 add_executable(tcam_example examples/use_tcam.cpp)
 add_executable(arp_cache_example examples/arp_cache_example.cpp)
 add_executable(nd_cache_example examples/nd_cache_example.cpp)
+add_executable(use_dsu_example examples/use_dsu.cpp)
 
 # Add the tests subdirectory
 # This will process the tests/CMakeLists.txt


### PR DESCRIPTION
This commit introduces two main improvements:

1.  **CMake Update:**
    *   The `examples/use_dsu.cpp` file, which demonstrates the usage of
        both generic `DisjointSetUnion<T>` and `FastDSU`, has been added
        to the root `CMakeLists.txt`. It is now compiled as an executable
        target named `use_dsu_example`.

2.  **DSU Test Enhancements (`tests/dsu_test.cpp`):**
    *   **Generic DSU (`DisjointSetUnion<T>`):**
        *   Added `TYPED_TEST(DSTest, UnionSetsByRankLogic)` to specifically
          verify the union-by-rank strategy, including correct rank
          updates when ranks are equal and when they differ.
        *   Improved `TYPED_TEST(DSTest, ResetOperation)` to cover resetting
          an empty DSU and resetting after a `clear()` operation.
        *   Improved `TYPED_TEST(DSTest, ClearOperation)` to cover clearing
          an already empty DSU and multiple `clear()` calls.
    *   **Fast DSU (`FastDSU`):**
        *   Added `TEST_F(FastDSUTest, UnionSetsByRankLogic)` to verify
          union-by-rank logic, mirroring the enhancements for the generic DSU.
        *   Improved `TEST_F(FastDSUTest, ResetOperation)` to cover resetting
          a `FastDSU(0)` and multiple `reset()` calls.
    *   **General Review:**
        *   Reviewed `PathCompressionExplicit` tests for both DSU types to
          ensure effective use of `getDirectParent_Test` and clear demonstration
          of path compression effects.
        *   Confirmed performance tests are stable and provide informative output.

These changes improve the example's accessibility and strengthen the test coverage for the Disjoint Set Union implementations.

Note: Unrelated test failures in other suites (Trie, ARPCache, NDCache) were observed during this work but are believed to be pre-existing and are not addressed by this commit.