### PR TITLE
feat(variant_vector): Enhance functionality and test coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
 
 # Add include directory for header files (globally for all targets in this directory and subdirectories)
-include_directories(include)
+include_directories(include) # Prefer target_include_directories
+
+# --- Variant Vector Library (Header-Only) ---
+add_library(variant_vector INTERFACE)
+add_library(cpp_library::variant_vector ALIAS variant_vector) # Modern CMake alias
+target_include_directories(variant_vector INTERFACE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+# This makes sure anyone linking against variant_vector gets 'include' in their include path.
 
 # Enable testing (should be global)
 enable_testing()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,13 @@
 # This CMakeLists.txt is in the 'tests' subdirectory.
+cmake_minimum_required(VERSION 3.10) # Or match root
+project(VariantVectorTests CXX)
 
-# GoogleTest is assumed to be available from a higher-level CMake file
-# or system-wide. `include(GoogleTest)` is still needed for gtest_discover_tests.
+# GTest is made available by FetchContent in the parent CMakeLists.txt.
+# Targets like GTest::gtest will be available directly.
+# find_package(GTest REQUIRED) # This is not needed and can conflict with FetchContent
+include(GoogleTest) # For gtest_discover_tests
 
-# Define test executable
+# Define general test executable (if it doesn't use variant_vector, it doesn't need to link it)
 # Source files are now relative to this tests/CMakeLists.txt
 add_executable(run_tests
   trie_test.cpp
@@ -28,7 +32,6 @@ target_link_libraries(run_tests PRIVATE GTest::gtest GTest::gtest_main GTest::gm
 # GTest::gmock should provide the necessary gmock functionalities.
 
 # Discover and add tests to CTest
-include(GoogleTest)
 gtest_discover_tests(run_tests)
 
 
@@ -42,5 +45,14 @@ target_link_libraries(fenwick_tree_test PRIVATE GTest::gtest GTest::gtest_main G
 # Discover and add tests from fenwick_tree_test to CTest
 gtest_discover_tests(fenwick_tree_test)
 
+# Add use_variant_vector example
+add_executable(use_variant_vector use_variant_vector.cpp)
+# target_include_directories(use_variant_vector PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../include") # Should come from library
+target_link_libraries(use_variant_vector PRIVATE cpp_library::variant_vector)
 
-message(STATUS "Test subdirectory CMake configuration complete. 'run_tests' and 'fenwick_tree_test' executables defined and configured for GTest.")
+# Add variant_vector_test executable
+add_executable(variant_vector_test variant_vector_test.cpp)
+target_link_libraries(variant_vector_test PRIVATE GTest::gtest GTest::gmock GTest::gtest_main cpp_library::variant_vector)
+gtest_discover_tests(variant_vector_test)
+
+message(STATUS "Test subdirectory CMake configuration complete. 'run_tests', 'fenwick_tree_test', 'use_variant_vector', and 'variant_vector_test' executables defined and configured.")

--- a/tests/use_variant_vector.cpp
+++ b/tests/use_variant_vector.cpp
@@ -118,11 +118,46 @@ void benchmark_memory_usage() {
     std::cout << "Speedup: " << static_cast<double>(traditional_time.count()) / optimized_time.count() << "x\n";
 }
 
+void demonstrate_new_features() {
+    std::cout << "\n--- Demonstrating new features ---\n";
+    static_variant_vector<SmallData, MediumData, LargeData> s_vec;
+    s_vec.emplace_back<SmallData>(101);
+    s_vec.emplace_back<MediumData>(102, 103, 104.0);
+    std::cout << "Static vec size before pop_back: " << s_vec.size() << std::endl; // Expected: 2
+    s_vec.pop_back(); // Pops MediumData
+    std::cout << "Static vec size after pop_back: " << s_vec.size() << std::endl;  // Expected: 1
+    if (s_vec.size() == 1) {
+        auto val = s_vec[0];
+        if(std::holds_alternative<SmallData>(val)) {
+             std::cout << "Remaining element is SmallData with value: " << std::get<SmallData>(val).x << std::endl;
+        }
+    }
+    s_vec.clear();
+    std::cout << "Static vec size after clear: " << s_vec.size() << std::endl;    // Expected: 0
 
+    dynamic_variant_vector d_vec;
+    d_vec.emplace_back<SmallData>(201);
+    d_vec.emplace_back<LargeData>("example_large");
+    std::cout << "Dynamic vec size before pop_back: " << d_vec.size() << std::endl; // Expected: 2
+    d_vec.pop_back(); // Pops LargeData
+    std::cout << "Dynamic vec size after pop_back: " << d_vec.size() << std::endl;  // Expected: 1
+    if (d_vec.size() == 1) {
+        SmallData& val = d_vec.get_typed<SmallData>(0);
+        std::cout << "Remaining element in dynamic_vec is SmallData with value: " << val.x << std::endl;
+        // Demonstrate std::any at()
+        std::any any_val = d_vec.at(0);
+        if (any_val.type() == typeid(SmallData)) {
+            std::cout << "Dynamic vec at(0) via std::any has SmallData with value: " << std::any_cast<SmallData>(any_val).x << std::endl;
+        }
+    }
+    d_vec.clear();
+    std::cout << "Dynamic vec size after clear: " << d_vec.size() << std::endl;    // Expected: 0
+}
 
 
 int main() {
     benchmark_memory_usage();
+    demonstrate_new_features(); // Call the new function
     return 0;
 }
 


### PR DESCRIPTION
This commit introduces several improvements to static_variant_vector and dynamic_variant_vector:

Features:
- Added `clear()` method to both `static_variant_vector` and `dynamic_variant_vector` to remove all elements.
- Added `pop_back()` method to both vector types to remove the last element.
- Added `at(global_idx) const -> std::any` to `dynamic_variant_vector` for type-agnostic element access.
- Added bounds checking to `static_variant_vector::get_type_index`.

Code Quality:
- Deduplicated headers in `variant_vector.h`.
- Added comments regarding `reserve()` strategy limitations and potential optimizations for `get_variant_at`.
- Clarified that `static_variant_vector::operator[]` does not perform bounds checking, consistent with `std::vector`.

Testing:
- Added comprehensive unit tests for the new `clear()`, `pop_back()`, and `dynamic_variant_vector::at()` methods.
- Corrected the include path for `variant_vector.h` in tests.
- Added comments to performance test assertions indicating they are indicative.
- Updated `use_variant_vector.cpp` to demonstrate the new features.

Build System (CMake):
- Refactored `variant_vector` as a modern CMake INTERFACE library.
- Ensured `variant_vector_test` and `use_variant_vector` link against the interface library, simplifying include path management.
- Integrated `variant_vector_test` with CTest using `gtest_discover_tests`.
- Addressed CMake project() warnings in the tests directory.

The changes ensure the variant_vector components are more complete, robust, and easier to use and integrate into larger projects.