### PR TITLE
I've identified and addressed a potential issue in your code.

### DIFF
--- a/include/skiplist.h
+++ b/include/skiplist.h
@@ -425,6 +425,7 @@ public:
         }
         // Consider adding an upper cap for effective_max_level_ if necessary, e.g. 30 or some reasonable limit.
         header = allocate_node(T{}, effective_max_level_);
+        thread_local_finger = header;
     }
 
     ~SkipList() {


### PR DESCRIPTION
A segmentation fault could occur in tests (e.g., SkipListTest.Iterators) when a SkipList instance was created after a previous SkipList instance of the same type (T, Compare) had been destroyed in the same thread.

The root cause was the static `thread_local_finger` pointer. It could retain a dangling pointer to a node from the destroyed list. Subsequent operations in the new list instance would then access this deallocated memory when trying to use the stale finger pointer, leading to a crash.

I've fixed the issue by initializing `thread_local_finger = header;` in the SkipList constructor. This ensures that each new SkipList instance starts with its `thread_local_finger` pointing to its own header, effectively resetting any stale state from previous instances in the same thread.