### PR TITLE
Fix PerformanceTest in topic_filter_test

### DIFF
--- a/tests/topic_filter_test.cpp
+++ b/tests/topic_filter_test.cpp
@@ -164,8 +164,8 @@ TEST(TopicFilterTest, PerformanceTest)
                                 std::to_string((i % NUM_RULES) * 100 + 50));
             break;
         case 3:
-            // Ensure this regex key is one that was added
-            test_keys.push_back("REGEX_" + std::to_string((i % (NUM_RULES / 10)) * 10) + "_123");
+            // Modify this case to generate non-matching keys
+            test_keys.push_back("NOMATCH_" + std::to_string(i)); // This key is unlikely to match
             break;
         }
     }


### PR DESCRIPTION
The PerformanceTest was failing because all generated test keys were designed to match a rule, causing the assertion `EXPECT_LT(matches, NUM_TESTS)` to fail.

This change modifies the test key generation logic in PerformanceTest to ensure that a portion of the keys (1/4) do not match any existing rules. This is achieved by generating "NOMATCH_*" keys for one of the cases in the test data generation loop.

This ensures that the test correctly verifies the filter's selectivity and that the number of matches is less than the total number of tests. All tests now pass.