### PR TITLE
feat: Implement generic thread-safe LRUCache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,13 @@ foreach(SOURCE_FILE ${EXAMPLE_SOURCES})
         set(EXECUTABLE_NAME "example_${BASE_NAME}")
         add_executable(${EXECUTABLE_NAME} ${SOURCE_FILE})
         # Link common libraries if needed by examples
-        target_link_libraries(${EXECUTABLE_NAME} PRIVATE cpp_library::variant_vector cpp_library::Counter)
+        # Added Threads::Threads for examples that might use threading features from components like LRUCache
+        target_link_libraries(${EXECUTABLE_NAME} PRIVATE cpp_library::variant_vector cpp_library::Counter Threads::Threads)
     endif()
 endforeach()
 
 # --- SPSC Queue Example ---
+# This example already links Threads::Threads, so the change above is consistent.
 add_executable(use_spsc_example examples/use_spsc.cpp)
 target_include_directories(use_spsc_example PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/examples/lru_cache_example.cpp
+++ b/examples/lru_cache_example.cpp
@@ -1,0 +1,114 @@
+#include <iostream>
+#include <string>
+#include <vector> // For std::vector to show eviction callback storing items
+#include "lru_cache.h" // Assuming lru_cache.h is accessible via include paths
+
+// A simple struct to use as a value in the cache
+struct ComplexData {
+    int id;
+    std::string name;
+    double value;
+
+    // For easy printing
+    friend std::ostream& operator<<(std::ostream& os, const ComplexData& data) {
+        os << "ID: " << data.id << ", Name: "" << data.name << "", Value: " << data.value;
+        return os;
+    }
+};
+
+int main() {
+    // --- Example 1: Basic usage with int keys and string values ---
+    std::cout << "--- Example 1: Basic Integer Keys, String Values ---" << std::endl;
+    LRUCache<int, std::string> cache1(3); // Cache with max size 3
+
+    cache1.put(1, "Apple");
+    cache1.put(2, "Banana");
+    cache1.put(3, "Cherry");
+
+    std::cout << "Cache size: " << cache1.size() << std::endl; // Expected: 3
+
+    if (auto val = cache1.get(2)) {
+        std::cout << "Got key 2: " << val.value() << std::endl; // Expected: Banana
+    } else {
+        std::cout << "Key 2 not found." << std::endl;
+    }
+
+    // Adding a new item, "Date", should evict the LRU item (1, "Apple")
+    // because "Banana" (key 2) was most recently accessed.
+    // Current order (MRU to LRU): 2, 3, 1
+    cache1.put(4, "Date");
+    std::cout << "Cache size after adding 4 ('Date'): " << cache1.size() << std::endl; // Expected: 3
+
+    std::cout << "Contains key 1? " << (cache1.contains(1) ? "Yes" : "No") << std::endl; // Expected: No
+    std::cout << "Contains key 4? " << (cache1.contains(4) ? "Yes" : "No") << std::endl; // Expected: Yes
+
+    if (auto val = cache1.get(1)) {
+        std::cout << "Got key 1: " << val.value() << std::endl;
+    } else {
+        std::cout << "Key 1 not found (evicted)." << std::endl; // Expected
+    }
+     if (auto val = cache1.get(3)) { // Accessing 3 makes it MRU
+        std::cout << "Got key 3: " << val.value() << std::endl; // Expected: Cherry
+    }
+
+    // Cache order (MRU to LRU): 3, 4, 2
+    cache1.put(5, "Elderberry"); // Evicts 2 ("Banana")
+    std::cout << "Contains key 2 after adding 5 ('Elderberry')? " << (cache1.contains(2) ? "Yes" : "No") << std::endl; // Expected: No
+
+    std::cout << "Current cache items (order might vary due to internal map):" << std::endl;
+    if(auto v = cache1.get(5)) std::cout << "Key 5: " << v.value() << std::endl;
+    if(auto v = cache1.get(3)) std::cout << "Key 3: " << v.value() << std::endl;
+    if(auto v = cache1.get(4)) std::cout << "Key 4: " << v.value() << std::endl;
+
+
+    // --- Example 2: String keys and custom struct values with Eviction Callback ---
+    std::cout << "\n--- Example 2: String Keys, Custom Struct Values, Eviction Callback ---" << std::endl;
+
+    std::vector<std::pair<std::string, ComplexData>> evicted_items;
+    auto eviction_logger =
+        [&evicted_items](const std::string& key, const ComplexData& value) {
+        std::cout << "Eviction callback: Key "" << key << "" with value {" << value << "} was evicted." << std::endl;
+        evicted_items.push_back({key, value});
+    };
+
+    LRUCache<std::string, ComplexData> cache2(2, eviction_logger);
+
+    cache2.put("alpha", {1, "Object Alpha", 10.5});
+    cache2.put("beta",  {2, "Object Beta",  20.2});
+
+    if (auto val = cache2.get("alpha")) { // alpha becomes MRU
+        std::cout << "Got key 'alpha': " << val.value() << std::endl;
+    }
+
+    // Order: alpha (MRU), beta (LRU)
+    cache2.put("gamma", {3, "Object Gamma", 30.9}); // Evicts "beta"
+    // Order: gamma (MRU), alpha (LRU)
+    cache2.put("delta", {4, "Object Delta", 40.4}); // Evicts "alpha"
+
+    std::cout << "Cache size: " << cache2.size() << std::endl; // Expected: 2
+    std::cout << "Contains 'alpha'? " << (cache2.contains("alpha") ? "Yes" : "No") << std::endl; // Expected: No
+    std::cout << "Contains 'beta'? "  << (cache2.contains("beta") ? "Yes" : "No") << std::endl;  // Expected: No
+    std::cout << "Contains 'gamma'? " << (cache2.contains("gamma") ? "Yes" : "No") << std::endl; // Expected: Yes
+    std::cout << "Contains 'delta'? " << (cache2.contains("delta") ? "Yes" : "No") << std::endl; // Expected: Yes
+
+    std::cout << "\nEvicted items log:" << std::endl;
+    for (const auto& item : evicted_items) {
+        std::cout << "- Key: " << item.first << ", Value: { " << item.second << " }" << std::endl;
+    }
+    // Expected evicted items: beta, then alpha.
+
+    cache2.erase("gamma");
+    std::cout << "\nCache size after erasing 'gamma': " << cache2.size() << std::endl; // Expected: 1
+    std::cout << "Contains 'gamma' after erase? " << (cache2.contains("gamma") ? "Yes" : "No") << std::endl; // Expected: No
+
+    cache2.clear();
+    std::cout << "\nCache size after clear: " << cache2.size() << std::endl; // Expected: 0
+    std::cout << "Is cache empty after clear? " << (cache2.empty() ? "Yes" : "No") << std::endl; // Expected: Yes
+
+    // Eviction callback is not called for erase or clear.
+    std::cout << "Total items in eviction log after erase/clear: " << evicted_items.size() << std::endl; // Expected: 2
+
+    std::cout << "\n--- Example Finished ---" << std::endl;
+
+    return 0;
+}

--- a/include/lru_cache.h
+++ b/include/lru_cache.h
@@ -1,0 +1,119 @@
+#ifndef LRU_CACHE_H
+#define LRU_CACHE_H
+
+#include <list>
+#include <unordered_map>
+#include <functional>
+#include <mutex>
+#include <optional> // For std::optional
+#include <utility>  // For std::pair
+#include <stdexcept> // For std::runtime_error (though not strictly needed by spec, good for constructor)
+
+template <typename Key, typename Value>
+class LRUCache {
+public:
+    using EvictCallback = std::function<void(const Key&, const Value&)>;
+
+    explicit LRUCache(size_t max_size, EvictCallback on_evict = nullptr)
+        : max_size_(max_size), on_evict_(on_evict) {
+        if (max_size == 0) {
+            // Or handle as a special case where cache is always empty / disabled
+            // For now, let's consider it an invalid argument.
+            throw std::invalid_argument("LRUCache max_size must be greater than 0");
+        }
+    }
+
+    // Returns true if the key is found in the cache, false otherwise.
+    // The value corresponding to the key is copied into the 'value' parameter.
+    // This operation marks the accessed item as most recently used.
+    std::optional<Value> get(const Key& key) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = cache_items_map_.find(key);
+        if (it == cache_items_map_.end()) {
+            return std::nullopt;
+        }
+        // Move accessed item to the front of the list (most recently used)
+        cache_items_list_.splice(cache_items_list_.begin(), cache_items_list_, it->second);
+        return it->second->second; // Value part of std::pair<Key, Value>
+    }
+
+    // Inserts a key-value pair into the cache.
+    // If the key already exists, its value is updated, and it's marked as most recently used.
+    // If the cache is full, the least recently used item is evicted.
+    void put(const Key& key, const Value& value) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = cache_items_map_.find(key);
+
+        if (it != cache_items_map_.end()) {
+            // Key exists, update value and move to front (MRU)
+            it->second->second = value;
+            cache_items_list_.splice(cache_items_list_.begin(), cache_items_list_, it->second);
+            return;
+        }
+
+        // Key does not exist, insert new item
+        if (cache_items_list_.size() == max_size_) {
+            // Cache is full, evict LRU item (last element in the list)
+            std::pair<Key, Value> lru_item = cache_items_list_.back();
+            if (on_evict_) {
+                on_evict_(lru_item.first, lru_item.second);
+            }
+            cache_items_map_.erase(lru_item.first);
+            cache_items_list_.pop_back();
+        }
+
+        // Insert new item at the front (MRU)
+        cache_items_list_.emplace_front(key, value);
+        cache_items_map_[key] = cache_items_list_.begin();
+    }
+
+    // Checks if the cache contains the given key.
+    // This operation does NOT affect the LRU order.
+    bool contains(const Key& key) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return cache_items_map_.count(key) > 0;
+    }
+
+    // Removes the entry associated with the given key from the cache.
+    // Returns true if an element was removed, false otherwise.
+    bool erase(const Key& key) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = cache_items_map_.find(key);
+        if (it == cache_items_map_.end()) {
+            return false; // Key not found
+        }
+        cache_items_list_.erase(it->second);
+        cache_items_map_.erase(it);
+        return true;
+    }
+
+    // Removes all entries from the cache.
+    void clear() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        cache_items_map_.clear();
+        cache_items_list_.clear();
+        // Note: Eviction callback is not typically called on clear(),
+        // as this is a deliberate removal of all items, not capacity-triggered eviction.
+    }
+
+    // Returns the current number of items in the cache.
+    size_t size() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return cache_items_map_.size();
+    }
+
+    // Returns true if the cache is empty, false otherwise.
+    bool empty() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return cache_items_map_.empty();
+    }
+
+private:
+    size_t max_size_;
+    std::list<std::pair<Key, Value>> cache_items_list_; // Stores items. Front is MRU, back is LRU.
+    std::unordered_map<Key, typename std::list<std::pair<Key, Value>>::iterator> cache_items_map_; // Maps keys to list iterators.
+    EvictCallback on_evict_;
+    mutable std::mutex mutex_; // Mutex for thread safety.
+};
+
+#endif // LRU_CACHE_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,9 @@ project(VariantVectorTests CXX)
 # find_package(GTest REQUIRED) # This is not needed and can conflict with FetchContent
 include(GoogleTest) # For gtest_discover_tests
 
+# Find threads package for std::mutex, std::thread, etc.
+find_package(Threads REQUIRED)
+
 # Define sources for the combined 'run_tests' target
 # Glob all *_test.cpp files, then exclude those meant to be standalone.
 # All .cpp files in tests/ are considered potential test sources.
@@ -38,8 +41,8 @@ add_executable(run_tests ${RUN_TESTS_SOURCES_LIST})
 # CMAKE_CURRENT_SOURCE_DIR is tests/
 target_include_directories(run_tests PRIVATE "${CMAKE_SOURCE_DIR}/include")
 
-# Link GTest to the test executable
-target_link_libraries(run_tests PRIVATE GTest::gtest GTest::gtest_main GTest::gmock cpp_library::Counter)
+# Link GTest and Threads to the test executable
+target_link_libraries(run_tests PRIVATE GTest::gtest GTest::gtest_main GTest::gmock cpp_library::Counter Threads::Threads)
 # GTest::gmock_main is usually not needed if GTest::gtest_main is already linked.
 # GTest::gmock should provide the necessary gmock functionalities.
 
@@ -54,7 +57,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
     get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
     add_executable(${TEST_NAME} ${TEST_FILE})
     target_include_directories(${TEST_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/include")
-    target_link_libraries(${TEST_NAME} PRIVATE GTest::gtest GTest::gtest_main GTest::gmock)
+    target_link_libraries(${TEST_NAME} PRIVATE GTest::gtest GTest::gtest_main GTest::gmock Threads::Threads)
     if(TEST_NAME STREQUAL "counter_test")
         target_link_libraries(${TEST_NAME} PRIVATE cpp_library::Counter)
     endif()

--- a/tests/lru_cache_test.cpp
+++ b/tests/lru_cache_test.cpp
@@ -1,0 +1,401 @@
+#include "gtest/gtest.h"
+#include "../include/lru_cache.h" // Adjust path as necessary
+#include <string>
+#include <vector>
+#include <thread> // For thread safety tests
+#include <atomic> // For counters in thread safety tests
+#include <set>    // For checking evicted items
+
+// Test fixture for LRUCache tests
+class LRUCacheTest : public ::testing::Test {
+protected:
+    // You can put common setup code here if needed,
+    // but for many LRUCache tests, direct instantiation is clearer.
+};
+
+// Test basic construction and empty/size
+TEST_F(LRUCacheTest, ConstructorAndBasicState) {
+    LRUCache<int, std::string> cache(3);
+    EXPECT_TRUE(cache.empty());
+    EXPECT_EQ(0, cache.size());
+    EXPECT_THROW((LRUCache<int, int>(0)), std::invalid_argument);
+}
+
+// Test Put and Get operations
+TEST_F(LRUCacheTest, PutAndGet) {
+    LRUCache<int, std::string> cache(2);
+    cache.put(1, "one");
+    cache.put(2, "two");
+
+    EXPECT_EQ(2, cache.size());
+    ASSERT_TRUE(cache.get(1).has_value());
+    EXPECT_EQ("one", cache.get(1).value());
+    ASSERT_TRUE(cache.get(2).has_value());
+    EXPECT_EQ("two", cache.get(2).value());
+
+    // Test updating an existing key
+    cache.put(1, "new_one");
+    EXPECT_EQ(2, cache.size());
+    ASSERT_TRUE(cache.get(1).has_value());
+    EXPECT_EQ("new_one", cache.get(1).value());
+
+    // Test getting a non-existent key
+    EXPECT_FALSE(cache.get(3).has_value());
+}
+
+// Test LRU eviction policy
+TEST_F(LRUCacheTest, EvictionPolicy) {
+    LRUCache<int, std::string> cache(2);
+    cache.put(1, "one");
+    cache.put(2, "two");
+    cache.put(3, "three"); // Should evict (1, "one")
+
+    EXPECT_EQ(2, cache.size());
+    EXPECT_FALSE(cache.get(1).has_value()); // 1 should be evicted
+    EXPECT_FALSE(cache.contains(1));
+    ASSERT_TRUE(cache.get(2).has_value());
+    EXPECT_EQ("two", cache.get(2).value());
+    ASSERT_TRUE(cache.get(3).has_value());
+    EXPECT_EQ("three", cache.get(3).value());
+
+    // Accessing 2 should make it MRU, so 3 should be evicted next
+    cache.get(2);
+    cache.put(4, "four"); // Should evict (3, "three")
+
+    EXPECT_EQ(2, cache.size());
+    EXPECT_FALSE(cache.get(3).has_value());
+    EXPECT_FALSE(cache.contains(3));
+    ASSERT_TRUE(cache.get(2).has_value());
+    EXPECT_EQ("two", cache.get(2).value());
+    ASSERT_TRUE(cache.get(4).has_value());
+    EXPECT_EQ("four", cache.get(4).value());
+}
+
+// Test Contains operation
+TEST_F(LRUCacheTest, Contains) {
+    LRUCache<int, std::string> cache(2);
+    cache.put(1, "one");
+
+    EXPECT_TRUE(cache.contains(1));
+    EXPECT_FALSE(cache.contains(2));
+
+    cache.put(2, "two");
+    EXPECT_TRUE(cache.contains(1));
+    EXPECT_TRUE(cache.contains(2));
+
+    cache.put(3, "three"); // Evicts 1
+    EXPECT_FALSE(cache.contains(1));
+    EXPECT_TRUE(cache.contains(2));
+    EXPECT_TRUE(cache.contains(3));
+}
+
+// Test Erase operation
+TEST_F(LRUCacheTest, Erase) {
+    LRUCache<int, std::string> cache(2);
+    cache.put(1, "one");
+    cache.put(2, "two");
+
+    EXPECT_TRUE(cache.erase(1));
+    EXPECT_EQ(1, cache.size());
+    EXPECT_FALSE(cache.contains(1));
+    EXPECT_FALSE(cache.get(1).has_value());
+    ASSERT_TRUE(cache.get(2).has_value()); // 2 should still be there
+
+    EXPECT_FALSE(cache.erase(1)); // Erasing non-existent key
+
+    EXPECT_TRUE(cache.erase(2));
+    EXPECT_TRUE(cache.empty());
+    EXPECT_EQ(0, cache.size());
+
+    // Erase from a full cache then add
+    cache.put(3, "three");
+    cache.put(4, "four");
+    EXPECT_TRUE(cache.erase(3));
+    cache.put(5, "five");
+    EXPECT_EQ(2, cache.size());
+    EXPECT_FALSE(cache.contains(3));
+    EXPECT_TRUE(cache.contains(4));
+    EXPECT_TRUE(cache.contains(5));
+}
+
+// Test Clear operation
+TEST_F(LRUCacheTest, Clear) {
+    LRUCache<int, std::string> cache(2);
+    cache.put(1, "one");
+    cache.put(2, "two");
+
+    cache.clear();
+    EXPECT_TRUE(cache.empty());
+    EXPECT_EQ(0, cache.size());
+    EXPECT_FALSE(cache.contains(1));
+    EXPECT_FALSE(cache.contains(2));
+
+    // Clear an already empty cache
+    cache.clear();
+    EXPECT_TRUE(cache.empty());
+    EXPECT_EQ(0, cache.size());
+}
+
+// Test Eviction Callback
+TEST_F(LRUCacheTest, EvictionCallback) {
+    std::vector<std::pair<int, std::string>> evicted_items;
+    auto on_evict_cb = [&](const int& key, const std::string& value) {
+        evicted_items.push_back({key, value});
+    };
+
+    LRUCache<int, std::string> cache(2, on_evict_cb);
+    cache.put(1, "one");
+    cache.put(2, "two");
+    cache.put(3, "three"); // Evicts (1, "one")
+
+    ASSERT_EQ(1, evicted_items.size());
+    EXPECT_EQ(1, evicted_items[0].first);
+    EXPECT_EQ("one", evicted_items[0].second);
+
+    cache.get(2); // Make 2 MRU
+    cache.put(4, "four"); // Evicts (3, "three")
+
+    ASSERT_EQ(2, evicted_items.size());
+    EXPECT_EQ(3, evicted_items[1].first);
+    EXPECT_EQ("three", evicted_items[1].second);
+
+    // Erase should not trigger eviction callback
+    cache.erase(2);
+    ASSERT_EQ(2, evicted_items.size()); // Still 2, erase doesn't use on_evict_
+
+    // Clear should not trigger eviction callback
+    cache.clear();
+    ASSERT_EQ(2, evicted_items.size()); // Still 2
+}
+
+// Test Get promotes item to MRU
+TEST_F(LRUCacheTest, GetPromotesToMRU) {
+    LRUCache<int, std::string> cache(3);
+    cache.put(1, "one");
+    cache.put(2, "two");
+    cache.put(3, "three"); // Order: 3 (MRU), 2, 1 (LRU)
+
+    cache.get(1); // Access 1, should become MRU. Order: 1 (MRU), 3, 2 (LRU)
+    cache.put(4, "four"); // Should evict 2
+
+    EXPECT_EQ(3, cache.size());
+    EXPECT_FALSE(cache.contains(2));
+    EXPECT_TRUE(cache.contains(1));
+    EXPECT_TRUE(cache.contains(3));
+    EXPECT_TRUE(cache.contains(4));
+}
+
+// Test Put updates item and promotes it to MRU
+TEST_F(LRUCacheTest, PutUpdatesAndPromotesToMRU) {
+    LRUCache<int, std::string> cache(3);
+    cache.put(1, "one");
+    cache.put(2, "two");
+    cache.put(3, "three"); // Order: 3 (MRU), 2, 1 (LRU)
+
+    cache.put(1, "new_one"); // Update 1, should become MRU. Order: 1 (MRU), 3, 2 (LRU)
+    cache.put(4, "four");    // Should evict 2
+
+    EXPECT_EQ(3, cache.size());
+    EXPECT_FALSE(cache.contains(2));
+    ASSERT_TRUE(cache.get(1).has_value());
+    EXPECT_EQ("new_one", cache.get(1).value());
+    EXPECT_TRUE(cache.contains(3));
+    EXPECT_TRUE(cache.contains(4));
+}
+
+// Test with capacity 1
+TEST_F(LRUCacheTest, CapacityOne) {
+    std::vector<std::pair<int, std::string>> evicted_items;
+    auto on_evict_cb = [&](const int& key, const std::string& value) {
+        evicted_items.push_back({key, value});
+    };
+    LRUCache<int, std::string> cache(1, on_evict_cb);
+
+    cache.put(1, "one");
+    EXPECT_EQ(1, cache.size());
+    EXPECT_TRUE(cache.contains(1));
+
+    cache.put(2, "two"); // Evicts (1, "one")
+    EXPECT_EQ(1, cache.size());
+    EXPECT_FALSE(cache.contains(1));
+    EXPECT_TRUE(cache.contains(2));
+    ASSERT_EQ(1, evicted_items.size());
+    EXPECT_EQ(1, evicted_items[0].first);
+    EXPECT_EQ("one", evicted_items[0].second);
+
+    ASSERT_TRUE(cache.get(2).has_value()); // Access 2, no change in LRU since it's the only one
+    cache.put(3, "three"); // Evicts (2, "two")
+    EXPECT_EQ(1, cache.size());
+    EXPECT_FALSE(cache.contains(2));
+    EXPECT_TRUE(cache.contains(3));
+    ASSERT_EQ(2, evicted_items.size());
+    EXPECT_EQ(2, evicted_items[1].first);
+    EXPECT_EQ("two", evicted_items[1].second);
+}
+
+// Stress test for basic operations and eviction
+TEST_F(LRUCacheTest, StressTest) {
+    const int num_operations = 10000;
+    std::vector<int> evicted_keys;
+    LRUCache<int, int> cache(100, [&](const int&k, const int&){ evicted_keys.push_back(k); });
+    std::atomic<int> successful_erasures(0);
+
+    for (int i = 0; i < num_operations; ++i) {
+        cache.put(i, i * 2);
+        if (i % 10 == 0) {
+            int key_to_get = i - (rand() % 100);
+            if (key_to_get >= 0) {
+                 cache.get(key_to_get);
+            }
+        }
+        if (i % 20 == 0) {
+            int key_to_erase = i - 50 - (rand() % 50);
+             if (key_to_erase >=0 && cache.erase(key_to_erase)) {
+                successful_erasures++;
+             }
+        }
+    }
+
+    EXPECT_LE(cache.size(), 100);
+    // Check if items are generally what we expect (more recent items)
+    int found_count = 0;
+    for (int i = num_operations - 1; i >= num_operations - 100 && i >= 0; --i) {
+        if (cache.contains(i)) {
+            found_count++;
+        }
+    }
+    // This is a loose check, depends on erase pattern
+    EXPECT_GE(found_count, 0); // At least some recent items should be there if not erased.
+    EXPECT_EQ(evicted_keys.size(), num_operations - cache.size() - successful_erasures.load());
+}
+
+
+// Thread safety tests
+TEST_F(LRUCacheTest, ThreadSafety) {
+    LRUCache<int, int> cache(100);
+    std::vector<std::thread> threads;
+    const int num_threads = 10;
+    const int ops_per_thread = 1000;
+    std::atomic<int> successful_puts(0);
+    std::atomic<int> successful_gets(0);
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&, i]() {
+            for (int j = 0; j < ops_per_thread; ++j) {
+                int key = (i * ops_per_thread) + j;
+                cache.put(key, key * 2);
+                successful_puts++;
+
+                // Interleave some get operations
+                int key_to_get = rand() % ( (i+1) * ops_per_thread);
+                if (cache.get(key_to_get).has_value()) {
+                    successful_gets++;
+                }
+                 // Interleave some erase
+                if (j % 10 == 0) {
+                    int key_to_erase = rand() % ((i+1) * ops_per_thread);
+                    cache.erase(key_to_erase);
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_LE(cache.size(), 100); // Should not exceed max_size
+    // We can't easily verify specific values due to concurrent nature and evictions,
+    // but we check that operations completed and cache size is bounded.
+    // The main test here is absence of crashes or hangs, indicating basic thread safety.
+    // More rigorous thread safety testing (e.g., with specific interleavings or known race conditions)
+    // would require more specialized tools or techniques.
+    EXPECT_GT(successful_puts, 0); // Make sure some puts happened
+
+    // Final check: put some known values and get them
+    cache.put(1000000, 1);
+    cache.put(1000001, 2);
+    ASSERT_TRUE(cache.get(1000000).has_value());
+    EXPECT_EQ(cache.get(1000000).value(), 1);
+    ASSERT_TRUE(cache.get(1000001).has_value());
+    EXPECT_EQ(cache.get(1000001).value(), 2);
+}
+
+// Test for custom types (e.g. std::string keys and custom struct values)
+struct MyValue {
+    int id;
+    std::string data;
+    bool operator==(const MyValue& other) const {
+        return id == other.id && data == other.data;
+    }
+};
+
+// Required for unordered_map if MyKey is a custom type not supported by std::hash by default
+struct MyKey {
+    int part1;
+    std::string part2;
+     bool operator==(const MyKey& other) const {
+        return part1 == other.part1 && part2 == other.part2;
+    }
+};
+
+namespace std {
+    template <> struct hash<MyKey> {
+        size_t operator()(const MyKey& k) const {
+            return hash<int>()(k.part1) ^ (hash<string>()(k.part2) << 1);
+        }
+    };
+}
+
+
+TEST_F(LRUCacheTest, CustomTypes) {
+    LRUCache<std::string, MyValue> cache(2);
+    cache.put("key1", {1, "data1"});
+    cache.put("key2", {2, "data2"});
+
+    ASSERT_TRUE(cache.get("key1").has_value()); // This makes "key1" MRU
+    EXPECT_EQ(cache.get("key1").value().id, 1);
+    EXPECT_EQ(cache.get("key1").value().data, "data1");
+
+    // Cache state after get("key1"): key1 (MRU), key2 (LRU)
+    cache.put("key3", {3, "data3"}); // Evicts "key2"
+
+    // Cache state: key3 (MRU), key1 (LRU)
+    EXPECT_TRUE(cache.contains("key1"));   // "key1" should still be there
+    EXPECT_FALSE(cache.contains("key2"));  // "key2" should be evicted
+    ASSERT_TRUE(cache.get("key3").has_value());
+    EXPECT_EQ(cache.get("key3").value(), (MyValue{3, "data3"}));
+    // Verify "key1" is indeed the other item.
+    ASSERT_TRUE(cache.get("key1").has_value());
+    EXPECT_EQ(cache.get("key1").value(), (MyValue{1, "data1"}));
+
+
+    LRUCache<MyKey, int> cacheCustomKey(2);
+    MyKey mk1 = {10, "apple"};
+    MyKey mk2 = {20, "banana"};
+    MyKey mk3 = {30, "cherry"};
+
+    cacheCustomKey.put(mk1, 100); // mk1 is MRU {mk1}
+    cacheCustomKey.put(mk2, 200); // mk2 is MRU, mk1 is LRU {mk2, mk1}
+
+    ASSERT_TRUE(cacheCustomKey.get(mk1).has_value()); // mk1 becomes MRU, mk2 is LRU {mk1, mk2}
+    EXPECT_EQ(cacheCustomKey.get(mk1).value(), 100);
+
+    cacheCustomKey.put(mk3, 300); // mk3 is MRU. mk2 (LRU) is evicted. {mk3, mk1}
+
+    EXPECT_TRUE(cacheCustomKey.contains(mk1));    // mk1 should still be in the cache.
+    EXPECT_FALSE(cacheCustomKey.contains(mk2));   // mk2 should have been evicted.
+    ASSERT_TRUE(cacheCustomKey.get(mk3).has_value());
+    EXPECT_EQ(cacheCustomKey.get(mk3).value(), 300);
+    // Verify mk1 is indeed the other item and accessible.
+    ASSERT_TRUE(cacheCustomKey.get(mk1).has_value());
+    EXPECT_EQ(cacheCustomKey.get(mk1).value(), 100);
+}
+
+// It's good practice to have a main function in one of the test files
+// or link with GTest_main if it's not already handled by the build system.
+// For this project structure, it's likely handled by tests/CMakeLists.txt
+// int main(int argc, char **argv) {
+//     ::testing::InitGoogleTest(&argc, argv);
+//     return RUN_ALL_TESTS();
+// }


### PR DESCRIPTION
This commit introduces a generic, thread-safe LRU (Least Recently Used) Cache component, `LRUCache<Key, Value>`, implemented as a header-only C++ template.

The `LRUCache` provides O(1) average time complexity for core operations (`put`, `get`, `erase`, `contains`) by using `std::unordered_map` for quick lookups and `std::list` to maintain the LRU order of items.

Key Features:
- Configurable maximum capacity (`max_size`).
- Thread safety is ensured through the use of `std::mutex` protecting all public methods.
- An optional `EvictCallback` can be provided to the constructor, which is invoked when an item is evicted due to capacity constraints.
- `get(key)` returns `std::optional<Value>`, promoting the accessed item to the Most Recently Used (MRU) position.
- `put(key, value)` inserts or updates an item, also promoting it to the MRU position. If capacity is exceeded, the Least Recently Used (LRU) item is evicted.
- `erase(key)` removes an item and returns `true` if successful.
- `contains(key)` checks for an item's existence without altering its LRU status.
- `clear()`, `size()`, and `empty()` methods are provided for cache management.
- The implementation is header-only (`include/lru_cache.h`).

Unit tests using Google Test (`tests/lru_cache_test.cpp`) have been added, covering:
- Basic operations (put, get, erase, clear, contains).
- LRU eviction policy and MRU promotion on access/update.
- Eviction callback functionality.
- Thread safety through concurrent operations.
- Usage with custom key/value types (requiring `std::hash` specialization for custom keys if not standard).

An example program (`examples/lru_cache_example.cpp`) demonstrates the usage of the `LRUCache` with various features.

CMake build files (`CMakeLists.txt` and `tests/CMakeLists.txt`) have been updated to:
- Compile the new example.
- Build and register the new tests.
- Link necessary threading libraries for both tests and examples that use the LRUCache.