### PR TITLE
I've added a SlotMap container, along with examples and tests.

### DIFF
--- a/examples/slotmap_example.cpp
+++ b/examples/slotmap_example.cpp
@@ -1,0 +1,117 @@
+#include "SlotMap.h" // Adjust path if needed, assuming SlotMap.h is in include/ and examples/ is at the same level as include/
+#include <iostream>
+#include <string>
+#include <vector>
+
+// Helper function to print key
+void print_key(const utils::SlotMap<std::string>::Key& key) {
+    std::cout << "Key(index: " << key.index << ", gen: " << key.generation << ")";
+}
+
+int main() {
+    utils::SlotMap<std::string> map;
+
+    std::cout << "Initial map size: " << map.size() << ", empty: " << map.empty() << std::endl;
+
+    // Insert elements
+    std::cout << "\n--- Inserting elements ---" << std::endl;
+    utils::SlotMap<std::string>::Key key1 = map.insert("Hello");
+    std::cout << "Inserted \"Hello\", got "; print_key(key1); std::cout << std::endl;
+
+    utils::SlotMap<std::string>::Key key2 = map.insert("World");
+    std::cout << "Inserted \"World\", got "; print_key(key2); std::cout << std::endl;
+
+    utils::SlotMap<std::string>::Key key3 = map.insert("SlotMap");
+    std::cout << "Inserted \"SlotMap\", got "; print_key(key3); std::cout << std::endl;
+
+    std::cout << "Map size after inserts: " << map.size() << ", empty: " << map.empty() << std::endl;
+
+    // Retrieve elements
+    std::cout << "\n--- Retrieving elements ---" << std::endl;
+    if (const std::string* val1 = map.get(key1)) {
+        std::cout << "Value for key1: " << *val1 << std::endl;
+    }
+    if (const std::string* val2 = map.get(key2)) {
+        std::cout << "Value for key2: " << *val2 << std::endl;
+    }
+    if (const std::string* val3 = map.get(key3)) {
+        std::cout << "Value for key3: " << *val3 << std::endl;
+    }
+
+    // Check contains
+    std::cout << "\n--- Checking contains ---" << std::endl;
+    std::cout << "map.contains(key1): " << map.contains(key1) << std::endl;
+    std::cout << "map.contains(key2): " << map.contains(key2) << std::endl;
+
+    // Erase an element
+    std::cout << "\n--- Erasing an element ---" << std::endl;
+    std::cout << "Erasing key2 (World)..." << std::endl;
+    bool erased = map.erase(key2);
+    std::cout << "Erase successful: " << erased << std::endl;
+    std::cout << "Map size after erase: " << map.size() << std::endl;
+
+    std::cout << "map.contains(key1) after erasing key2: " << map.contains(key1) << std::endl;
+    std::cout << "map.contains(key2) after erasing key2: " << map.contains(key2) << std::endl;
+
+    // Try to get erased element
+    std::cout << "\n--- Retrieving erased element ---" << std::endl;
+    if (const std::string* val2_after_erase = map.get(key2)) {
+        std::cout << "Value for key2 after erase: " << *val2_after_erase << " (Error, should not happen!)" << std::endl;
+    } else {
+        std::cout << "Value for key2 after erase: nullptr (Correct!)" << std::endl;
+    }
+
+    // Stale key (key2 has old generation)
+    utils::SlotMap<std::string>::Key stale_key2 = key2; // generation is now outdated
+
+    // Insert more elements (should reuse slot from key2)
+    std::cout << "\n--- Inserting after erase (reuse) ---" << std::endl;
+    utils::SlotMap<std::string>::Key key4 = map.insert("Reusable");
+    std::cout << "Inserted \"Reusable\", got "; print_key(key4); std::cout << " (Note if index is same as key2's index)" << std::endl;
+
+    std::cout << "Map size: " << map.size() << std::endl;
+
+    if (const std::string* val4 = map.get(key4)) {
+        std::cout << "Value for key4: " << *val4 << std::endl;
+    }
+
+    // Try to get with stale key
+    std::cout << "\n--- Retrieving with stale key ---" << std::endl;
+    if (const std::string* val_stale = map.get(stale_key2)) {
+        std::cout << "Value for stale_key2: " << *val_stale << " (Error, should not happen!)" << std::endl;
+    } else {
+        std::cout << "Value for stale_key2: nullptr (Correct!)" << std::endl;
+    }
+    std::cout << "map.contains(stale_key2): " << map.contains(stale_key2) << " (Should be false)" << std::endl;
+    std::cout << "map.contains(key4): " << map.contains(key4) << std::endl;
+
+
+    std::cout << "\n--- Testing with more complex types (struct) ---" << std::endl;
+    struct MyStruct {
+        int id;
+        std::string name;
+
+        bool operator==(const MyStruct& other) const {
+            return id == other.id && name == other.name;
+        }
+    };
+
+    utils::SlotMap<MyStruct> struct_map;
+    auto s_key1 = struct_map.insert({1, "StructA"});
+    auto s_key2 = struct_map.insert({2, "StructB"});
+
+    if(const MyStruct* s_val1 = struct_map.get(s_key1)) {
+        std::cout << "StructA: id=" << s_val1->id << ", name=" << s_val1->name << std::endl;
+    }
+    struct_map.erase(s_key1);
+    std::cout << "struct_map.contains(s_key1) after erase: " << struct_map.contains(s_key1) << std::endl;
+    auto s_key3 = struct_map.insert({3, "StructC"}); // Potentially reuses s_key1's slot
+     if(const MyStruct* s_val3 = struct_map.get(s_key3)) {
+        std::cout << "StructC: id=" << s_val3->id << ", name=" << s_val3->name << std::endl;
+    }
+    std::cout << "Struct map size: " << struct_map.size() << std::endl;
+
+    std::cout << "\n--- Done ---" << std::endl;
+
+    return 0;
+}

--- a/include/SlotMap.h
+++ b/include/SlotMap.h
@@ -1,0 +1,124 @@
+#ifndef SLOTMAP_H
+#define SLOTMAP_H
+
+#include <vector>
+#include <cstdint>
+#include <limits> // Required for std::numeric_limits
+
+namespace utils { // Assuming a namespace based on other files in the repo, adjust if necessary
+
+template <typename T>
+class SlotMap {
+public:
+    struct Key {
+        uint32_t index;
+        uint32_t generation;
+
+        bool operator==(const Key& other) const = default;
+        // It's good practice to also provide operator!= if operator== is provided.
+        bool operator!=(const Key& other) const = default;
+    };
+
+    // Forward declare methods to be implemented later
+    Key insert(T value);
+    bool erase(Key key);
+    T* get(Key key);
+    const T* get(Key key) const;
+    bool contains(Key key) const;
+    size_t size() const;
+    bool empty() const;
+
+private:
+    std::vector<T> data_; // Changed to data_ to avoid conflict with potential member functions named data
+    std::vector<uint32_t> generations_;
+    std::vector<size_t> free_list_;
+
+    // Helper to check if a key is potentially valid (index in bounds)
+    bool is_valid_index(uint32_t index) const {
+        return index < data_.size();
+    }
+};
+
+// Implementation of SlotMap methods
+
+template <typename T>
+typename SlotMap<T>::Key SlotMap<T>::insert(T value) {
+    uint32_t index;
+    if (!free_list_.empty()) {
+        index = free_list_.back();
+        free_list_.pop_back();
+        data_[index] = std::move(value);
+        // The generation for this slot was already incremented in erase().
+        // We just use it as is.
+        // generations_[index] already holds the correct new generation.
+    } else {
+        index = data_.size();
+        data_.push_back(std::move(value));
+        generations_.push_back(0); // Initial generation is 0 for a brand new slot
+    }
+    return Key{index, generations_[index]};
+}
+
+template <typename T>
+bool SlotMap<T>::erase(Key key) {
+    if (!is_valid_index(key.index) || generations_[key.index] != key.generation) {
+        return false; // Key is invalid or generation mismatch
+    }
+
+    // Add index to free list
+    free_list_.push_back(key.index);
+
+    // Increment generation to invalidate old keys
+    // Check for wrapping around, though highly unlikely with uint32_t.
+    if (generations_[key.index] == std::numeric_limits<uint32_t>::max()) {
+        generations_[key.index] = 0; // Or handle error/warning
+    } else {
+        generations_[key.index]++;
+    }
+
+    // Optional: Destruct or reset the object at data_[key.index]
+    // if T is a complex type. For simple types, this might not be necessary.
+    // For example: data_[key.index] = T{}; // Reset to default value
+    // Or if T is a pointer, you might need to delete it: delete data_[key.index]; data_[key.index] = nullptr;
+
+    return true;
+}
+
+template <typename T>
+T* SlotMap<T>::get(Key key) {
+    if (!is_valid_index(key.index) || generations_[key.index] != key.generation) {
+        return nullptr; // Invalid key or generation mismatch
+    }
+    // Check if the slot is active (not in the free_list conceptually, though erase handles generation)
+    // This check is implicitly handled by the generation check.
+    // If an element was erased, its generation would have been incremented,
+    // so a key with an old generation is invalid.
+    return &data_[key.index];
+}
+
+template <typename T>
+const T* SlotMap<T>::get(Key key) const {
+    if (!is_valid_index(key.index) || generations_[key.index] != key.generation) {
+        return nullptr; // Invalid key or generation mismatch
+    }
+    return &data_[key.index];
+}
+
+template <typename T>
+bool SlotMap<T>::contains(Key key) const {
+    return is_valid_index(key.index) && generations_[key.index] == key.generation;
+}
+
+template <typename T>
+size_t SlotMap<T>::size() const {
+    return data_.size() - free_list_.size();
+}
+
+template <typename T>
+bool SlotMap<T>::empty() const {
+    return size() == 0;
+}
+
+} // namespace utils
+
+#endif // SLOTMAP_H

--- a/tests/slotmap_test.cpp
+++ b/tests/slotmap_test.cpp
@@ -1,0 +1,307 @@
+#include "SlotMap.h" // Assuming SlotMap.h is in include/ and tests/ is at the same level
+#include "gtest/gtest.h"
+#include <string>
+#include <vector> // For testing with vectors as values or similar
+
+// Define a simple struct for testing
+struct TestStruct {
+    int id;
+    std::string data;
+
+    bool operator==(const TestStruct& other) const {
+        return id == other.id && data == other.data;
+    }
+};
+
+// Test fixture for SlotMap tests
+class SlotMapTest : public ::testing::Test {
+protected:
+    utils::SlotMap<std::string> string_map;
+    utils::SlotMap<int> int_map;
+    utils::SlotMap<TestStruct> struct_map;
+};
+
+TEST_F(SlotMapTest, InitialState) {
+    EXPECT_EQ(string_map.size(), 0);
+    EXPECT_TRUE(string_map.empty());
+    EXPECT_EQ(int_map.size(), 0);
+    EXPECT_TRUE(int_map.empty());
+    EXPECT_EQ(struct_map.size(), 0);
+    EXPECT_TRUE(struct_map.empty());
+}
+
+TEST_F(SlotMapTest, BasicInsertAndGet) {
+    auto key1 = string_map.insert("Hello");
+    EXPECT_EQ(string_map.size(), 1);
+    ASSERT_NE(string_map.get(key1), nullptr);
+    EXPECT_EQ(*string_map.get(key1), "Hello");
+    EXPECT_TRUE(string_map.contains(key1));
+
+    auto key2 = string_map.insert("World");
+    EXPECT_EQ(string_map.size(), 2);
+    ASSERT_NE(string_map.get(key2), nullptr);
+    EXPECT_EQ(*string_map.get(key2), "World");
+    EXPECT_TRUE(string_map.contains(key2));
+
+    // Check previous key still valid
+    ASSERT_NE(string_map.get(key1), nullptr);
+    EXPECT_EQ(*string_map.get(key1), "Hello");
+}
+
+TEST_F(SlotMapTest, InsertAndGetWithInts) {
+    auto key1 = int_map.insert(100);
+    EXPECT_EQ(int_map.size(), 1);
+    ASSERT_NE(int_map.get(key1), nullptr);
+    EXPECT_EQ(*int_map.get(key1), 100);
+
+    auto key2 = int_map.insert(200);
+    EXPECT_EQ(int_map.size(), 2);
+    ASSERT_NE(int_map.get(key2), nullptr);
+    EXPECT_EQ(*int_map.get(key2), 200);
+}
+
+TEST_F(SlotMapTest, InsertAndGetWithStructs) {
+    TestStruct ts1{1, "Data1"};
+    TestStruct ts2{2, "Data2"};
+
+    auto key1 = struct_map.insert(ts1);
+    EXPECT_EQ(struct_map.size(), 1);
+    ASSERT_NE(struct_map.get(key1), nullptr);
+    EXPECT_EQ(*struct_map.get(key1), ts1);
+
+    auto key2 = struct_map.insert(ts2);
+    EXPECT_EQ(struct_map.size(), 2);
+    ASSERT_NE(struct_map.get(key2), nullptr);
+    EXPECT_EQ(*struct_map.get(key2), ts2);
+}
+
+TEST_F(SlotMapTest, EraseAndGet) {
+    auto key1 = string_map.insert("TestErase");
+    EXPECT_EQ(string_map.size(), 1);
+    EXPECT_TRUE(string_map.contains(key1));
+
+    bool erased = string_map.erase(key1);
+    EXPECT_TRUE(erased);
+    EXPECT_EQ(string_map.size(), 0);
+    EXPECT_FALSE(string_map.contains(key1));
+    EXPECT_EQ(string_map.get(key1), nullptr);
+
+    // Try erasing again
+    bool erased_again = string_map.erase(key1);
+    EXPECT_FALSE(erased_again); // Should fail as key is no longer valid
+}
+
+TEST_F(SlotMapTest, InsertAfterEraseReusesSlotAndIncrementsGeneration) {
+    auto key1 = string_map.insert("First");
+    uint32_t initial_index = key1.index;
+    uint32_t initial_gen = key1.generation;
+
+    string_map.erase(key1);
+    EXPECT_FALSE(string_map.contains(key1));
+
+    auto key2 = string_map.insert("Second"); // Should reuse slot from key1
+    EXPECT_EQ(string_map.size(), 1);
+    EXPECT_TRUE(string_map.contains(key2));
+    ASSERT_NE(string_map.get(key2), nullptr);
+    EXPECT_EQ(*string_map.get(key2), "Second");
+
+    EXPECT_EQ(key2.index, initial_index); // Index should be reused
+    EXPECT_EQ(key2.generation, initial_gen + 1); // Generation should be incremented
+}
+
+TEST_F(SlotMapTest, StaleKeyRetrieval) {
+    auto key1 = string_map.insert("Original");
+    utils::SlotMap<std::string>::Key stale_key = key1; // Copy the key
+
+    string_map.erase(key1); // Erase the element, invalidating key1 and stale_key
+
+    auto key2 = string_map.insert("NewData"); // This might reuse the slot
+
+    EXPECT_FALSE(string_map.contains(stale_key));
+    EXPECT_EQ(string_map.get(stale_key), nullptr);
+
+    // Ensure new key is valid if it reused the slot
+    if (key2.index == stale_key.index) {
+        EXPECT_NE(key2.generation, stale_key.generation);
+        EXPECT_TRUE(string_map.contains(key2));
+        ASSERT_NE(string_map.get(key2), nullptr);
+        EXPECT_EQ(*string_map.get(key2), "NewData");
+    }
+}
+
+TEST_F(SlotMapTest, ContainsFunctionality) {
+    auto key_valid = string_map.insert("Valid");
+    EXPECT_TRUE(string_map.contains(key_valid));
+
+    auto key_to_erase = string_map.insert("EraseMe");
+    EXPECT_TRUE(string_map.contains(key_to_erase));
+    string_map.erase(key_to_erase);
+    EXPECT_FALSE(string_map.contains(key_to_erase)); // After erase
+
+    // Stale key (generation mismatch)
+    utils::SlotMap<std::string>::Key stale_key = key_to_erase; // Has old generation
+    auto key_reused = string_map.insert("Reused");
+    if (key_reused.index == stale_key.index) {
+       EXPECT_FALSE(string_map.contains(stale_key));
+    }
+
+    utils::SlotMap<std::string>::Key non_existent_key = {999, 0}; // Index out of bounds
+    EXPECT_FALSE(string_map.contains(non_existent_key));
+
+    utils::SlotMap<std::string>::Key key_valid_gen_mismatch = {key_valid.index, key_valid.generation + 1};
+    EXPECT_FALSE(string_map.contains(key_valid_gen_mismatch));
+}
+
+TEST_F(SlotMapTest, SizeAndEmpty) {
+    EXPECT_TRUE(string_map.empty());
+    EXPECT_EQ(string_map.size(), 0);
+
+    auto key1 = string_map.insert("1");
+    EXPECT_FALSE(string_map.empty());
+    EXPECT_EQ(string_map.size(), 1);
+
+    auto key2 = string_map.insert("2");
+    EXPECT_EQ(string_map.size(), 2);
+
+    string_map.erase(key1);
+    EXPECT_EQ(string_map.size(), 1);
+
+    string_map.erase(key2);
+    EXPECT_TRUE(string_map.empty());
+    EXPECT_EQ(string_map.size(), 0);
+}
+
+TEST_F(SlotMapTest, MultipleErasures) {
+    auto k1 = string_map.insert("A");
+    auto k2 = string_map.insert("B");
+    auto k3 = string_map.insert("C");
+    EXPECT_EQ(string_map.size(), 3);
+
+    string_map.erase(k1);
+    EXPECT_EQ(string_map.size(), 2);
+    EXPECT_FALSE(string_map.contains(k1));
+    EXPECT_TRUE(string_map.contains(k2));
+    EXPECT_TRUE(string_map.contains(k3));
+
+    string_map.erase(k3);
+    EXPECT_EQ(string_map.size(), 1);
+    EXPECT_FALSE(string_map.contains(k1));
+    EXPECT_TRUE(string_map.contains(k2));
+    EXPECT_FALSE(string_map.contains(k3));
+
+    ASSERT_NE(string_map.get(k2), nullptr);
+    EXPECT_EQ(*string_map.get(k2), "B");
+
+    string_map.erase(k2);
+    EXPECT_EQ(string_map.size(), 0);
+    EXPECT_TRUE(string_map.empty());
+    EXPECT_FALSE(string_map.contains(k2));
+}
+
+TEST_F(SlotMapTest, InsertEraseInsertSequence) {
+    std::vector<utils::SlotMap<std::string>::Key> keys;
+    for (int i = 0; i < 5; ++i) {
+        keys.push_back(string_map.insert("Item " + std::to_string(i)));
+    }
+    EXPECT_EQ(string_map.size(), 5);
+
+    // Erase some
+    string_map.erase(keys[1]);
+    string_map.erase(keys[3]);
+    EXPECT_EQ(string_map.size(), 3);
+    EXPECT_FALSE(string_map.contains(keys[1]));
+    EXPECT_TRUE(string_map.contains(keys[0]));
+
+    // Insert more
+    auto k_new1 = string_map.insert("New Item 1");
+    auto k_new2 = string_map.insert("New Item 2");
+    EXPECT_EQ(string_map.size(), 5);
+    EXPECT_TRUE(string_map.contains(k_new1));
+    EXPECT_TRUE(string_map.contains(k_new2));
+
+    // Check reused indices and new generations
+    EXPECT_EQ(k_new1.index, keys[3].index); // Should reuse last erased slot first (LIFO from free_list)
+    EXPECT_EQ(k_new1.generation, keys[3].generation + 1);
+
+    EXPECT_EQ(k_new2.index, keys[1].index);
+    EXPECT_EQ(k_new2.generation, keys[1].generation + 1);
+}
+
+
+TEST_F(SlotMapTest, GenerationIncrementDetails) {
+    auto key1 = string_map.insert("gen_test_1");
+    ASSERT_EQ(key1.generation, 0); // First insert in a new slot
+
+    string_map.erase(key1); // Generation becomes 1 for this slot
+
+    auto key2 = string_map.insert("gen_test_2"); // Reuses slot
+    ASSERT_EQ(key2.index, key1.index);
+    ASSERT_EQ(key2.generation, 1);
+
+    string_map.erase(key2); // Generation becomes 2
+
+    auto key3 = string_map.insert("gen_test_3"); // Reuses slot
+    ASSERT_EQ(key3.index, key2.index);
+    ASSERT_EQ(key3.generation, 2);
+}
+
+
+TEST_F(SlotMapTest, EmptyMapOperations) {
+    utils::SlotMap<int>::Key dummy_key = {0, 0}; // A plausible key
+
+    EXPECT_FALSE(int_map.contains(dummy_key));
+    EXPECT_EQ(int_map.get(dummy_key), nullptr);
+    EXPECT_FALSE(int_map.erase(dummy_key));
+
+    utils::SlotMap<int>::Key invalid_key = {100, 0}; // Index out of bounds for empty map
+    EXPECT_FALSE(int_map.contains(invalid_key));
+    EXPECT_EQ(int_map.get(invalid_key), nullptr);
+    EXPECT_FALSE(int_map.erase(invalid_key));
+}
+
+
+TEST_F(SlotMapTest, FillAndEmptyMultipleTimes) {
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        std::vector<utils::SlotMap<int>::Key> current_keys;
+        for (int i = 0; i < 10; ++i) {
+            current_keys.push_back(int_map.insert(i * 10 + cycle));
+        }
+        ASSERT_EQ(int_map.size(), 10);
+
+        for(const auto& k : current_keys) {
+            ASSERT_TRUE(int_map.contains(k));
+        }
+
+        for (size_t i = 0; i < current_keys.size(); ++i) {
+            bool erased = int_map.erase(current_keys[i]);
+            ASSERT_TRUE(erased);
+            ASSERT_FALSE(int_map.contains(current_keys[i]));
+        }
+        ASSERT_TRUE(int_map.empty());
+        ASSERT_EQ(int_map.size(), 0);
+    }
+}
+
+// This test is more conceptual for uint32_t max generation.
+// It just checks if generation increments past 0, which is already covered.
+// Actually hitting max would take too long.
+TEST_F(SlotMapTest, GenerationIncrementsPastZero) {
+    auto key = int_map.insert(1); // Gen 0
+    EXPECT_EQ(key.generation, 0);
+    int_map.erase(key); // Slot gen becomes 1
+
+    key = int_map.insert(2); // Gen 1 for this key
+    EXPECT_EQ(key.generation, 1);
+    int_map.erase(key); // Slot gen becomes 2
+
+    key = int_map.insert(3); // Gen 2 for this key
+    EXPECT_EQ(key.generation, 2);
+}
+
+// main function is provided by GTest::gtest_main when linked,
+// so it's not needed here for individual test file to be linkable
+// with other tests into a single 'run_tests' executable or for ctest discovery.
+// int main(int argc, char **argv) {
+//     ::testing::InitGoogleTest(&argc, argv);
+//     return RUN_ALL_TESTS();
+// }


### PR DESCRIPTION
I implemented `utils::SlotMap<T>`, a high-performance associative container that uses opaque, versioned handles (Key) for O(1) insertion, deletion, and lookup of elements.

Key features:
- `Key` struct with `index` and `generation` for safe access.
- Dense storage of values in `std::vector<T> data_`.
- `std::vector<uint32_t> generations_` to track slot versions.
- `std::vector<size_t> free_list_` for efficient reuse of empty slots.

API includes:
- `insert(T value)`: Returns a Key. Reuses slots from `free_list_` or expands.
- `erase(Key key)`: Invalidates the key by incrementing generation and adds slot to `free_list_`.
- `get(Key key)` (const and non-const): Returns `T*` or `nullptr`.
- `contains(Key key)`: Checks key validity (index and generation).
- `size()`, `empty()`: Utility functions.

The implementation ensures:
- Keys remain valid until erasure.
- Stale keys are rejected.
- New entries reuse empty slots.

Includes:
- `include/SlotMap.h`: Header-only implementation.
- `examples/slotmap_example.cpp`: Demonstrates usage with strings and custom structs.
- `tests/slotmap_test.cpp`: Comprehensive GTest suite covering all core functionalities, edge cases, and different data types.

A bug related to double-incrementing generation during insert-on-reuse was identified by the tests and subsequently fixed. The `erase` operation is now solely responsible for incrementing the generation of a freed slot, and `insert` correctly uses this pre-incremented generation when reusing the slot.