### PR TITLE
Refactor RunOnce, add GTest tests, and documentation

### DIFF
--- a/docs/README_run_once.md
+++ b/docs/README_run_once.md
@@ -1,0 +1,140 @@
+# `RunOnce` and `RunOnceReturn<T>` Utilities
+
+This document describes the `RunOnce` and `RunOnceReturn<T>` utility classes, designed to ensure that a callable object (like a function or lambda) is executed exactly once, even in multi-threaded environments.
+
+## Overview
+
+In many applications, especially those involving concurrency, there's a need to perform an initialization step, a costly computation, or some setup logic precisely once. `RunOnce` and `RunOnceReturn<T>` provide a clean, thread-safe, and exception-aware mechanism to achieve this, offering a more ergonomic alternative to `std::once_flag` and `std::call_once`.
+
+### Features:
+- **Thread-Safe Execution**: Guarantees that the callable is invoked only once across multiple threads.
+- **Exception Safety**: If the callable throws an exception, it's not considered "run," and subsequent attempts will try to execute it again.
+- **Value Return (`RunOnceReturn<T>`)**: The `RunOnceReturn<T>` variant captures and stores the return value of the callable, making it available for subsequent calls without re-computation.
+- **State Introspection**: `has_run()` method allows checking if the callable has successfully completed.
+- **Reset Functionality**: A `reset()` method is provided, primarily for testing purposes, to revert the state and allow re-execution.
+- **Header-Only**: Easy to integrate into any C++17 project.
+
+## `RunOnce`
+
+The `RunOnce` class ensures that a void-returning callable is executed exactly once.
+
+### Usage
+
+```cpp
+#include "run_once.h"
+#include <iostream>
+#include <thread>
+
+static RunOnce global_initializer;
+
+void initialize_shared_resource() {
+    global_initializer([] {
+        std::cout << "Initializing shared resource...\n";
+        // Perform actual initialization
+        std::cout << "Shared resource initialized.\n";
+    });
+}
+
+int main() {
+    std::thread t1(initialize_shared_resource);
+    std::thread t2(initialize_shared_resource);
+
+    t1.join();
+    t2.join();
+
+    // The initialization messages will appear only once.
+    return 0;
+}
+```
+
+### Key Methods:
+- **`RunOnce()`**: Default constructor.
+- **`template <typename Callable> void operator()(Callable&& fn)`**: Executes `fn` if it hasn't been run successfully before. If `fn` throws, `has_run()` remains `false`.
+- **`bool has_run() const noexcept`**: Returns `true` if `fn` has completed successfully, `false` otherwise.
+- **`void reset() noexcept`**: Resets the internal state. **Warning**: Not thread-safe. Use only when you can guarantee no other threads are accessing this instance (e.g., in single-threaded test environments).
+
+## `RunOnceReturn<T>`
+
+The `RunOnceReturn<T>` class extends `RunOnce` to handle callables that return a value of type `T`. It executes the callable once, stores its result, and returns the stored result on subsequent invocations.
+
+### Usage
+
+```cpp
+#include "run_once.h"
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+RunOnceReturn<std::string> config_loader;
+
+const std::string& get_configuration() {
+    return config_loader([] {
+        std::cout << "Loading configuration...\n";
+        // Simulate expensive loading
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        return std::string("LoadedConfigurationData");
+    });
+}
+
+void worker_thread_func() {
+    const std::string& config = get_configuration();
+    std::cout << "Thread " << std::this_thread::get_id()
+              << " using config: " << config << std::endl;
+}
+
+int main() {
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 5; ++i) {
+        threads.emplace_back(worker_thread_func);
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+    // The "Loading configuration..." message appears only once.
+    // All threads will use the same "LoadedConfigurationData".
+
+    // Accessing again will return the cached value
+    std::cout << "Main thread accessing config: " << get_configuration() << std::endl;
+
+    return 0;
+}
+```
+
+### Key Methods:
+- **`RunOnceReturn()`**: Default constructor.
+- **`template <typename Callable> const T& operator()(Callable&& fn)`**: Executes `fn` if it hasn't been run successfully. Stores and returns its result. If `fn` throws, `has_run()` remains `false`, and no value is stored. Subsequent calls will retry `fn`.
+- **`bool has_run() const noexcept`**: Returns `true` if `fn` has completed successfully and the result is available.
+- **`const T& get() const noexcept`**: Returns a reference to the stored result. **Undefined behavior if called before `fn` has successfully run.** Always check `has_run()` first if unsure.
+- **`void reset() noexcept`**: Resets the internal state, clearing any stored value. **Warning**: Not thread-safe. Use with caution.
+
+## Thread Safety
+
+Both `RunOnce` and `RunOnceReturn<T>` are designed to be thread-safe for their main operation: invoking the callable (`operator()`) and checking `has_run()`. Multiple threads can call `operator()` concurrently, and the callable will still execute only once.
+
+The `reset()` method is **not thread-safe**. It should only be called in situations where it's guaranteed that no other thread is concurrently accessing the `RunOnce` or `RunOnceReturn<T>` instance. Its primary use case is for resetting state in unit tests.
+
+The `get()` method in `RunOnceReturn<T>` is thread-safe for reads *after* the callable has successfully executed and the value has been stored. Calling `get()` before `has_run()` is true leads to undefined behavior.
+
+## Exception Handling
+
+If the callable provided to `operator()` throws an exception:
+1. The exception is propagated to the caller of `operator()`.
+2. The `RunOnce` / `RunOnceReturn<T>` instance is **not** marked as "run" (i.e., `has_run()` will return `false`).
+3. For `RunOnceReturn<T>`, no value is stored.
+4. Subsequent calls to `operator()` will attempt to execute the callable again.
+
+This behavior ensures that a transient failure during the one-time execution doesn't permanently prevent the operation from succeeding on a later attempt.
+
+## Non-Copyable and Non-Movable
+
+Due to the use of `std::once_flag`, both `RunOnce` and `RunOnceReturn<T>` are non-copyable and non-movable. If you need to store them in containers or pass them around, consider using pointers (e.g., `std::unique_ptr` or `std::shared_ptr`) or references.
+
+## When to Use
+
+- Initializing singletons or global resources.
+- Performing expensive computations whose results can be cached and reused.
+- Ensuring setup code in a class or module runs only once, regardless of how many times its methods are called.
+- Any scenario requiring a "call exactly once" semantic in a potentially concurrent environment.
+```

--- a/examples/run_once_example.cpp
+++ b/examples/run_once_example.cpp
@@ -11,9 +11,9 @@ static RunOnce global_init;
 
 void initialize_system() {
     global_init([] {
-        std::cout << "🚀 Initializing system resources...\n";
+        std::cout << "Initializing system resources...\n";
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        std::cout << "✅ System initialized!\n";
+        std::cout << "System initialized!\n";
     });
 }
 
@@ -26,10 +26,10 @@ private:
 public:
     static void ensure_initialized() {
         init_once_([] {
-            std::cout << "🔗 Connecting to database...\n";
+            std::cout << "Connecting to database...\n";
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
             initialized_ = true;
-            std::cout << "✅ Database connected!\n";
+            std::cout << "Database connected!\n";
         });
     }
     
@@ -53,7 +53,7 @@ public:
     
     void log(const std::string& message) {
         setup_once_([this] {
-            std::cout << "📝 Setting up logger: " << name_ << "\n";
+            std::cout << "Setting up logger: " << name_ << "\n";
             configured_ = true;
         });
         
@@ -72,7 +72,7 @@ RunOnceReturn<std::string> expensive_config;
 
 const std::string& get_config() {
     return expensive_config([] {
-        std::cout << "💰 Loading expensive configuration...\n";
+        std::cout << "Loading expensive configuration...\n";
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         return std::string("config_value_12345");
     });
@@ -80,7 +80,7 @@ const std::string& get_config() {
 
 // Example 5: Exception handling demonstration
 void demonstrate_exception_handling() {
-    std::cout << "\n🧪 Testing exception handling:\n";
+    std::cout << "\nTesting exception handling:\n";
     
     RunOnce error_prone;
     int attempt = 0;
@@ -93,10 +93,10 @@ void demonstrate_exception_handling() {
                 if (attempt < 3) {
                     throw std::runtime_error("Simulated failure");
                 }
-                std::cout << "✅ Finally succeeded!\n";
+                std::cout << "Finally succeeded!\n";
             });
         } catch (const std::exception& e) {
-            std::cout << "❌ Caught: " << e.what() << "\n";
+            std::cout << "Caught: " << e.what() << "\n";
         }
         
         std::cout << "Has run: " << error_prone.has_run() << "\n";
@@ -105,7 +105,7 @@ void demonstrate_exception_handling() {
 
 // Example 6: Thread safety demonstration
 void demonstrate_thread_safety() {
-    std::cout << "\n🧵 Testing thread safety:\n";
+    std::cout << "\nTesting thread safety:\n";
     
     RunOnce thread_safe_init;
     std::atomic<int> counter{0};
@@ -135,7 +135,7 @@ void demonstrate_thread_safety() {
 
 // Example 7: Using with different callable types
 void demonstrate_callable_types() {
-    std::cout << "\n🔧 Testing different callable types:\n";
+    std::cout << "\nTesting different callable types:\n";
     
     // Lambda
     RunOnce lambda_test;
@@ -162,17 +162,17 @@ int main() {
     std::cout << "=== RunOnce Utility Examples ===\n\n";
     
     // Basic usage
-    std::cout << "1️⃣ Global initialization:\n";
+    std::cout << "1. Global initialization:\n";
     initialize_system();
     initialize_system();  // Should not print again
     initialize_system();  // Should not print again
     
-    std::cout << "\n2️⃣ Database connection:\n";
+    std::cout << "\n2. Database connection:\n";
     DatabaseConnection::ensure_initialized();
     DatabaseConnection::ensure_initialized();  // Should not print again
     std::cout << "Database ready: " << DatabaseConnection::is_ready() << "\n";
     
-    std::cout << "\n3️⃣ Per-instance logger:\n";
+    std::cout << "\n3. Per-instance logger:\n";
     Logger logger1("APP");
     Logger logger2("DB");
     
@@ -180,7 +180,7 @@ int main() {
     logger1.log("Second message");  // Setup should not run again
     logger2.log("Database message");  // Different instance, setup runs
     
-    std::cout << "\n4️⃣ Expensive configuration:\n";
+    std::cout << "\n4. Expensive configuration:\n";
     std::cout << "Config 1: " << get_config() << "\n";
     std::cout << "Config 2: " << get_config() << "\n";  // Should be cached
     
@@ -189,6 +189,6 @@ int main() {
     demonstrate_thread_safety();
     demonstrate_callable_types();
     
-    std::cout << "\n✅ All examples completed successfully!\n";
+    std::cout << "\nAll examples completed successfully!\n";
     return 0;
 }


### PR DESCRIPTION
- Removed emojis from run_once_example.cpp.
- Refactored test_run_once.cpp to use GTest framework.
- Enhanced test cases for RunOnce and RunOnceReturn, including exception handling, reset functionality, and thread safety for RunOnceReturn.
- Created docs/README_run_once.md with detailed usage and API documentation.
- Verified GTest configuration in CMakeLists.txt (no changes needed).
- Build and tests for run_once component passed successfully.