### PR TITLE
feat: Add TokenBucketRateLimiter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,9 @@ target_include_directories(WithResourceLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
 add_library(BloomFilterLib INTERFACE)
 target_include_directories(BloomFilterLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+add_library(CppLibRateLimiter INTERFACE)
+target_include_directories(CppLibRateLimiter INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Future steps will add examples and tests here
 
 # Automatically add executables for all files in the examples/ directory
@@ -121,6 +124,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         DeltaMapLib
         RetainLatestLib
         WithResourceLib # Added for with_resource_example
+        CppLibRateLimiter
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This includes:
 *   **Metaprogramming and Reflection:** `named_struct.h`, `named_tuple.h`, `enum_reflect.h` (compile-time enum reflection), `type_name.h` (get string representation of a type).
 *   **Concurrency, Timing, and Asynchronous Operations:**
     *   Queues: `AsyncEventQueue.h` (thread-safe event queue), `call_queue.h` (queue for function calls).
-    *   Execution Control: `delayed_call.h` (deferred execution), `retry.h` (retry logic for operations), `run_once.h` (ensure a function runs only once).
+    *   Execution Control: `delayed_call.h` (deferred execution), `retry.h` (retry logic for operations), `run_once.h` (ensure a function runs only once), `rate_limiter.h` (token bucket rate limiting).
     *   Timing: `timer_wheel.h` (efficient timer management), `timer_queue.h`, `scoped_timer.h` (measure execution time).
     *   Synchronization: `named_lock.h` (named global locks).
     *   Threading: `thread_pool.h`, `worker_pool.h`.

--- a/docs/README_rate_limiter.md
+++ b/docs/README_rate_limiter.md
@@ -1,0 +1,114 @@
+# Rate Limiter (`rate_limiter.h`)
+
+## Overview
+
+The `rate_limiter.h` header provides a `TokenBucketRateLimiter` class, which implements the token bucket algorithm for rate limiting. Rate limiting is a crucial mechanism for controlling the frequency of operations, such as API requests, logging, or resource access, to prevent overload and ensure fair usage.
+
+## Token Bucket Algorithm
+
+The Token Bucket algorithm is a popular method for rate limiting. It works as follows:
+
+1.  **Bucket Capacity**: A token bucket has a fixed capacity, representing the maximum number of tokens it can hold.
+2.  **Token Refill**: Tokens are added to the bucket at a constant rate (e.g., N tokens per second) until the bucket is full.
+3.  **Operation Request**: When an operation needs to be performed, it must acquire one or more tokens from the bucket.
+    *   If the bucket contains enough tokens, the required number of tokens are consumed, and the operation is permitted.
+    *   If the bucket does not have enough tokens, the operation is denied (rate-limited). Tokens are not consumed in this case.
+
+This algorithm allows for bursts of operations (up to the bucket's capacity) while enforcing an average rate over time.
+
+## `TokenBucketRateLimiter` Class
+
+The `TokenBucketRateLimiter` class provides a thread-safe implementation of this algorithm.
+
+### Public Interface
+
+```cpp
+namespace cpp_utils {
+
+class TokenBucketRateLimiter {
+public:
+    /**
+     * @brief Constructs a TokenBucketRateLimiter.
+     *
+     * @param capacity The maximum number of tokens the bucket can hold. Must be > 0.
+     * @param tokens_per_second The rate at which tokens are added to the bucket. Must be > 0.
+     * @throw std::invalid_argument if capacity or tokens_per_second is non-positive.
+     */
+    TokenBucketRateLimiter(size_t capacity, double tokens_per_second);
+
+    /**
+     * @brief Attempts to acquire a specified number of tokens from the bucket.
+     *
+     * If the bucket contains enough tokens, they are consumed, and the method
+     * returns true. Otherwise, no tokens are consumed, and the method returns
+     * false. This method is thread-safe.
+     *
+     * @param tokens_to_acquire The number of tokens to attempt to acquire. Defaults to 1.
+     * @return True if tokens were successfully acquired, false otherwise.
+     */
+    bool try_acquire(size_t tokens_to_acquire = 1);
+
+    /**
+     * @brief Gets the current capacity of the token bucket.
+     * @return The capacity.
+     */
+    size_t get_capacity() const;
+
+    /**
+     * @brief Gets the configured token refill rate.
+     * @return Tokens per second.
+     */
+    double get_tokens_per_second() const;
+
+    /**
+     * @brief Gets the current number of available tokens.
+     * This method also triggers a token refill before returning the count.
+     * Useful for monitoring or testing.
+     * @return Current number of tokens (after potential refill).
+     */
+    size_t get_current_tokens();
+};
+
+} // namespace cpp_utils
+```
+
+### Thread Safety
+
+All methods of `TokenBucketRateLimiter` that modify or access shared state (like `try_acquire` and internal token refill logic) are thread-safe, typically using `std::mutex`.
+
+## Usage Example
+
+Here's a basic example of how to use `TokenBucketRateLimiter`:
+
+```cpp
+#include "rate_limiter.h"
+#include <iostream>
+#include <thread>
+#include <chrono>
+
+int main() {
+    // Initialize a rate limiter: capacity of 5 tokens, refills 2 tokens per second.
+    cpp_utils::TokenBucketRateLimiter limiter(5, 2.0);
+
+    for (int i = 0; i < 10; ++i) {
+        std::cout << "Attempting operation " << (i + 1) << "... ";
+        if (limiter.try_acquire(1)) {
+            std::cout << "Operation permitted. Current tokens: " << limiter.get_current_tokens() << std::endl;
+            // Perform the actual operation here
+        } else {
+            std::cout << "Operation rate-limited. Current tokens: " << limiter.get_current_tokens() << std::endl;
+        }
+        // Wait for some time before the next attempt
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    }
+    return 0;
+}
+```
+
+In this example:
+-   A limiter is set up to allow bursts of up to 5 operations.
+-   It refills at a rate of 2 tokens per second.
+-   Operations are attempted every 300 milliseconds.
+-   If an operation is attempted when no tokens are available, it will be denied. Over time, as tokens refill, subsequent operations will be permitted.
+
+This component is useful for managing access to shared resources, preventing system abuse, or ensuring smooth service operation under varying loads.

--- a/examples/rate_limiter_example.cpp
+++ b/examples/rate_limiter_example.cpp
@@ -1,0 +1,84 @@
+#include "rate_limiter.h"
+#include <iostream>
+#include <thread>
+#include <chrono>
+#include <iomanip> // For std::fixed and std::setprecision
+
+void print_timestamp() {
+    auto now = std::chrono::system_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+    std::time_t t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm = *std::localtime(&t);
+    std::cout << std::put_time(&tm, "%H:%M:%S") << '.' << std::setfill('0') << std::setw(3) << ms.count() << " - ";
+}
+
+int main() {
+    // Create a rate limiter:
+    // Capacity of 5 tokens.
+    // Refills 2 tokens per second.
+    cpp_utils::TokenBucketRateLimiter limiter(5, 2.0);
+
+    std::cout << "Rate Limiter Example: Capacity=" << limiter.get_capacity()
+              << ", Rate=" << limiter.get_tokens_per_second() << " tokens/sec." << std::endl;
+    std::cout << "Attempting to perform 20 tasks. Some should be rate-limited." << std::endl;
+    std::cout << "-----------------------------------------------------------" << std::endl;
+
+    int tasks_done = 0;
+    int tasks_attempted = 20;
+
+    for (int i = 0; i < tasks_attempted; ++i) {
+        print_timestamp();
+        std::cout << "Attempting task " << (i + 1) << ". ";
+        if (limiter.try_acquire(1)) {
+            tasks_done++;
+            std::cout << "Task permitted. (Tokens remaining: ~" << limiter.get_current_tokens() << ")" << std::endl;
+            // Simulate doing some work
+            // std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        } else {
+            std::cout << "Task rate-limited. (Tokens remaining: ~" << limiter.get_current_tokens() << ")" << std::endl;
+        }
+
+        // Sleep for a short duration to simulate time between task attempts
+        // This also allows tokens to refill over time.
+        // If this sleep is shorter than the token refill interval, we'll see more rate limiting.
+        std::this_thread::sleep_for(std::chrono::milliseconds(300)); // 0.3 seconds between attempts
+    }
+
+    std::cout << "-----------------------------------------------------------" << std::endl;
+    std::cout << "Total tasks attempted: " << tasks_attempted << std::endl;
+    std::cout << "Total tasks permitted: " << tasks_done << std::endl;
+    std::cout << "Expected tasks (approx): Initial (5) + (20 attempts * 0.3s/attempt * 2 tokens/s) = 5 + 12 = 17" << std::endl;
+    std::cout << "Actual result can vary slightly due to timing of operations and refills." << std::endl;
+
+    std::cout << "\nDemonstrating acquiring multiple tokens:" << std::endl;
+    cpp_utils::TokenBucketRateLimiter multi_limiter(10, 5.0); // 10 capacity, 5 tokens/sec
+     print_timestamp();
+    std::cout << "Initial tokens: " << multi_limiter.get_current_tokens() << std::endl;
+
+    print_timestamp();
+    if(multi_limiter.try_acquire(7)) {
+        std::cout << "Acquired 7 tokens. Tokens remaining: " << multi_limiter.get_current_tokens() << std::endl;
+    } else {
+        std::cout << "Failed to acquire 7 tokens. Tokens remaining: " << multi_limiter.get_current_tokens() << std::endl;
+    }
+
+    print_timestamp();
+    if(multi_limiter.try_acquire(4)) { // This should fail as only 3 are left (10-7)
+        std::cout << "Acquired 4 tokens. Tokens remaining: " << multi_limiter.get_current_tokens() << std::endl;
+    } else {
+        std::cout << "Failed to acquire 4 tokens. Tokens remaining: " << multi_limiter.get_current_tokens() << std::endl;
+    }
+
+    std::cout << "Waiting for 1 second to refill..." << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(1)); // Should refill 5 tokens. Current: 3 + 5 = 8
+
+    print_timestamp();
+    std::cout << "Tokens after 1s refill: " << multi_limiter.get_current_tokens() << std::endl;
+    if(multi_limiter.try_acquire(8)) {
+        std::cout << "Acquired 8 tokens. Tokens remaining: " << multi_limiter.get_current_tokens() << std::endl;
+    } else {
+        std::cout << "Failed to acquire 8 tokens. Tokens remaining: " << multi_limiter.get_current_tokens() << std::endl;
+    }
+
+    return 0;
+}

--- a/include/rate_limiter.h
+++ b/include/rate_limiter.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <chrono>
+#include <mutex>
+#include <algorithm> // For std::min
+#include <stdexcept> // For std::invalid_argument
+
+namespace cpp_utils {
+
+/**
+ * @brief Implements a Token Bucket rate limiting algorithm.
+ *
+ * This class allows limiting the rate of operations by requiring tokens to be
+ * acquired before proceeding. Tokens are refilled at a constant rate up to a
+ * specified capacity.
+ *
+ * The implementation is thread-safe.
+ */
+class TokenBucketRateLimiter {
+public:
+    /**
+     * @brief Constructs a TokenBucketRateLimiter.
+     *
+     * @param capacity The maximum number of tokens the bucket can hold. Must be > 0.
+     * @param tokens_per_second The rate at which tokens are added to the bucket. Must be > 0.
+     * @throw std::invalid_argument if capacity or tokens_per_second is non-positive.
+     */
+    TokenBucketRateLimiter(size_t capacity, double tokens_per_second)
+        : capacity_(capacity),
+          tokens_per_second_(tokens_per_second),
+          current_tokens_(capacity),
+          last_refill_timestamp_(std::chrono::steady_clock::now()) {
+        if (capacity == 0) {
+            throw std::invalid_argument("Capacity must be greater than 0.");
+        }
+        if (tokens_per_second <= 0.0) {
+            throw std::invalid_argument("Tokens per second must be greater than 0.");
+        }
+    }
+
+    /**
+     * @brief Attempts to acquire a specified number of tokens from the bucket.
+     *
+     * If the bucket contains enough tokens, they are consumed, and the method
+     * returns true. Otherwise, no tokens are consumed, and the method returns
+     * false.
+     *
+     * This method is thread-safe.
+     *
+     * @param tokens_to_acquire The number of tokens to attempt to acquire.
+     *                          Defaults to 1.
+     * @return True if tokens were successfully acquired, false otherwise.
+     */
+    bool try_acquire(size_t tokens_to_acquire = 1) {
+        if (tokens_to_acquire == 0) {
+            return true; // Successfully "acquired" zero tokens
+        }
+
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        refill_tokens();
+
+        if (current_tokens_ >= tokens_to_acquire) {
+            current_tokens_ -= tokens_to_acquire;
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @brief Gets the current capacity of the token bucket.
+     * @return The capacity.
+     */
+    size_t get_capacity() const {
+        return capacity_;
+    }
+
+    /**
+     * @brief Gets the configured token refill rate.
+     * @return Tokens per second.
+     */
+    double get_tokens_per_second() const {
+        return tokens_per_second_;
+    }
+
+    /**
+     * @brief Gets the current number of available tokens (primarily for testing/monitoring).
+     * This method also triggers a token refill.
+     * @return Current number of tokens.
+     */
+    size_t get_current_tokens() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        refill_tokens();
+        return static_cast<size_t>(current_tokens_);
+    }
+
+private:
+    /**
+     * @brief Refills tokens based on the time elapsed since the last refill.
+     * This method MUST be called with the mutex_ held.
+     */
+    void refill_tokens() {
+        auto now = std::chrono::steady_clock::now();
+        std::chrono::duration<double> time_elapsed = now - last_refill_timestamp_;
+
+        double tokens_to_add = time_elapsed.count() * tokens_per_second_;
+
+        if (tokens_to_add > 0) { // Only update timestamp if there's a potential change
+            current_tokens_ = std::min(static_cast<double>(capacity_), current_tokens_ + tokens_to_add);
+            last_refill_timestamp_ = now;
+        }
+    }
+
+    const size_t capacity_;
+    const double tokens_per_second_;
+
+    double current_tokens_; // Using double for precision in refills
+    std::chrono::steady_clock::time_point last_refill_timestamp_;
+
+    std::mutex mutex_;
+};
+
+} // namespace cpp_utils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         DeltaMapLib
         RetainLatestLib
         WithResourceLib # Added for with_resource_test
+        CppLibRateLimiter
     )
 
     # Specific configurations for certain tests

--- a/tests/rate_limiter_test.cpp
+++ b/tests/rate_limiter_test.cpp
@@ -1,0 +1,271 @@
+#include "rate_limiter.h"
+#include <gtest/gtest.h>
+#include <thread>
+#include <vector>
+#include <numeric> // For std::iota
+#include <set>     // For std::set in concurrent test
+#include <chrono>  // For std::this_thread::sleep_for
+
+using cpp_utils::TokenBucketRateLimiter;
+
+TEST(TokenBucketRateLimiterTest, ConstructorValidation) {
+    EXPECT_THROW(TokenBucketRateLimiter(0, 10.0), std::invalid_argument);
+    EXPECT_THROW(TokenBucketRateLimiter(10, 0.0), std::invalid_argument);
+    EXPECT_THROW(TokenBucketRateLimiter(10, -1.0), std::invalid_argument);
+    EXPECT_NO_THROW(TokenBucketRateLimiter(10, 10.0));
+}
+
+TEST(TokenBucketRateLimiterTest, BasicAcquisition) {
+    TokenBucketRateLimiter limiter(5, 10.0); // 5 tokens capacity, 10 tokens/sec
+    EXPECT_EQ(limiter.get_capacity(), 5);
+    EXPECT_EQ(limiter.get_tokens_per_second(), 10.0);
+
+    EXPECT_EQ(limiter.get_current_tokens(), 5);
+    EXPECT_TRUE(limiter.try_acquire(1));
+    EXPECT_EQ(limiter.get_current_tokens(), 4);
+    EXPECT_TRUE(limiter.try_acquire(3));
+    EXPECT_EQ(limiter.get_current_tokens(), 1);
+    EXPECT_TRUE(limiter.try_acquire(1));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+    EXPECT_FALSE(limiter.try_acquire(1)); // No tokens left
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+}
+
+TEST(TokenBucketRateLimiterTest, AcquireZeroTokens) {
+    TokenBucketRateLimiter limiter(5, 10.0);
+    EXPECT_TRUE(limiter.try_acquire(0));
+    EXPECT_EQ(limiter.get_current_tokens(), 5); // Should not consume any tokens
+}
+
+TEST(TokenBucketRateLimiterTest, ExhaustAndFail) {
+    TokenBucketRateLimiter limiter(2, 1.0);
+    EXPECT_TRUE(limiter.try_acquire(2));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+    EXPECT_FALSE(limiter.try_acquire(1));
+}
+
+TEST(TokenBucketRateLimiterTest, TokenRefillOverTime) {
+    TokenBucketRateLimiter limiter(10, 10.0); // 10 tokens capacity, 10 tokens/sec
+
+    // Consume all tokens
+    EXPECT_TRUE(limiter.try_acquire(10));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+    EXPECT_FALSE(limiter.try_acquire(1));
+
+    // Wait for 0.5 seconds, should refill 5 tokens (10 tokens/sec * 0.5 sec)
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // get_current_tokens() itself calls refill.
+    // Due to timing inaccuracies, we check for a range.
+    // Expecting 5, but could be 4 or 6 due to sleep precision and execution overhead.
+    size_t tokens = limiter.get_current_tokens();
+    EXPECT_GE(tokens, 4);
+    EXPECT_LE(tokens, 6);
+    EXPECT_TRUE(limiter.try_acquire(static_cast<unsigned int>(tokens))); // acquire whatever was refilled
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+
+
+    // Wait for 1 second, should refill 10 tokens (up to capacity)
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    EXPECT_EQ(limiter.get_current_tokens(), 10); // Should be full
+    EXPECT_TRUE(limiter.try_acquire(10));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+
+    // Wait for 2 seconds, should still be at capacity (10)
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    EXPECT_EQ(limiter.get_current_tokens(), 10);
+}
+
+TEST(TokenBucketRateLimiterTest, RefillNotExceedingCapacity) {
+    TokenBucketRateLimiter limiter(5, 100.0); // High refill rate
+    EXPECT_TRUE(limiter.try_acquire(2)); // Current tokens: 3
+    EXPECT_EQ(limiter.get_current_tokens(), 3);
+
+    // Wait long enough to refill more than capacity if it wasn't capped
+    std::this_thread::sleep_for(std::chrono::milliseconds(200)); // 0.2s * 100 = 20 tokens
+    EXPECT_EQ(limiter.get_current_tokens(), 5); // Should be capped at 5
+}
+
+
+TEST(TokenBucketRateLimiterTest, AcquireMultipleChunks) {
+    TokenBucketRateLimiter limiter(10, 1.0); // 10 capacity, 1 token/sec
+    EXPECT_TRUE(limiter.try_acquire(5));
+    EXPECT_EQ(limiter.get_current_tokens(), 5);
+    EXPECT_TRUE(limiter.try_acquire(5));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+    EXPECT_FALSE(limiter.try_acquire(1));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1100)); // Wait >1 sec
+    EXPECT_TRUE(limiter.try_acquire(1)); // Should have 1 token now
+    EXPECT_EQ(limiter.get_current_tokens(), 0); // Assuming 1 token refilled and taken
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(3100)); // Wait >3 sec
+    // Should have refilled 3 tokens.
+    // Depending on exact timing, it might be slightly more or less.
+    size_t tokens_after_3_sec = limiter.get_current_tokens();
+    EXPECT_GE(tokens_after_3_sec, 2); // Expect at least 2 (allowing for some initial debt)
+    EXPECT_LE(tokens_after_3_sec, 4); // Expect at most 4 (allowing for some extra time)
+
+    EXPECT_TRUE(limiter.try_acquire(tokens_after_3_sec));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+}
+
+TEST(TokenBucketRateLimiterTest, ConcurrentAcquisition) {
+    const int num_threads = 10;
+    const int acquisitions_per_thread = 5;
+    const int total_capacity = 20;
+    const double refill_rate = 10.0; // tokens per second
+
+    // Bucket capacity is less than total requests to force some threads to wait/fail if not refilled
+    TokenBucketRateLimiter limiter(total_capacity, refill_rate);
+
+    std::vector<std::thread> threads;
+    std::vector<int> successful_acquisitions(num_threads, 0);
+    std::atomic<int> total_successful_acquisitions(0);
+
+    // Start all threads at roughly the same time
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&, i]() {
+            for (int j = 0; j < acquisitions_per_thread; ++j) {
+                // Try to acquire tokens, with small waits to allow refills
+                // This loop makes it more likely that refills happen and affect outcomes
+                for (int k=0; k < 5; ++k) { // try up to 5 times with delay
+                    if (limiter.try_acquire(1)) {
+                        successful_acquisitions[i]++;
+                        total_successful_acquisitions++;
+                        break;
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(20)); // 20ms wait
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Total acquisitions should be limited by capacity + refills over time.
+    // This test is non-deterministic due to thread scheduling and sleep.
+    // We expect that not all (num_threads * acquisitions_per_thread = 50) requests succeed initially if capacity is low.
+    // However, with refills, more can succeed over time.
+    // The test duration is roughly (acquisitions_per_thread * 5 * 20ms) in the worst case for a thread,
+    // which is 5 * 5 * 20 = 500ms. During this time, ~5 tokens would refill (0.5s * 10 tokens/s).
+    // So, total successful could be initial_capacity + refilled_tokens.
+    // Initial 20 + ~5 = ~25.
+
+    // This is a basic check. A more rigorous test would control time precisely.
+    EXPECT_GT(total_successful_acquisitions.load(), 0); // At least some should succeed
+    // If total_capacity was very small (e.g. 1) and refill rate low, this might be tight.
+    // With capacity 20 and refill 10/s, over ~0.5s, we expect around 20 + 5 = 25 successes.
+    // Max possible is 50.
+    EXPECT_LE(total_successful_acquisitions.load(), num_threads * acquisitions_per_thread);
+
+    // A loose check: more than initial capacity if test ran long enough for refills
+    // but not more than total requests.
+    // If the test runs for approx 0.5s (as estimated above), then ~5 tokens are refilled.
+    // So, total successes should be around initial_capacity (20) + 5 = 25.
+    // This assertion is a bit weak due to timing variability.
+    if (total_capacity < num_threads * acquisitions_per_thread) {
+         EXPECT_GE(total_successful_acquisitions.load(), std::min((size_t)total_capacity, (size_t)num_threads * acquisitions_per_thread));
+    }
+    std::cout << "Total successful acquisitions in concurrent test: " << total_successful_acquisitions.load() << std::endl;
+}
+
+
+TEST(TokenBucketRateLimiterTest, SteadyRateAcquisition) {
+    // Acquire tokens exactly at the refill rate.
+    // Capacity 1, refill 1 token per 100ms (10 tokens/sec)
+    TokenBucketRateLimiter limiter(1, 10.0);
+
+    // Initially full
+    EXPECT_TRUE(limiter.try_acquire(1));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+    EXPECT_FALSE(limiter.try_acquire(1)); // Empty
+
+    // Wait for 100ms to refill 1 token
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    EXPECT_TRUE(limiter.try_acquire(1));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+
+    // Wait for 50ms (not enough to refill)
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_FALSE(limiter.try_acquire(1));
+    EXPECT_EQ(limiter.get_current_tokens(), 0); // still 0, but some fraction of a token has refilled
+
+    // Wait another 50ms (total 100ms since last successful acquisition)
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_TRUE(limiter.try_acquire(1));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+}
+
+TEST(TokenBucketRateLimiterTest, HighPrecisionRefill) {
+    // Capacity 100, refill 1000 tokens/sec.
+    // Acquire 1 token every 1ms.
+    TokenBucketRateLimiter limiter(100, 1000.0);
+
+    // Consume initial tokens to make refills more critical
+    EXPECT_TRUE(limiter.try_acquire(50));
+    EXPECT_EQ(limiter.get_current_tokens(), 50);
+
+    int successful_acquires = 0;
+    for (int i = 0; i < 100; ++i) { // Try 100 times
+        if (limiter.try_acquire(1)) {
+            successful_acquires++;
+        }
+        std::this_thread::sleep_for(std::chrono::microseconds(990)); // Sleep slightly less than 1ms to test precision
+                                                                     // (1ms = 1 token)
+    }
+    // In 100 * ~1ms = ~100ms, we should refill ~100 tokens.
+    // Initial: 50. After 100 acquires, current_tokens should be around 50.
+    // We acquired `successful_acquires` tokens.
+    // Expected successful_acquires is high, near 100, because capacity + refill should cover it.
+    // Initial 50 + 100 (refilled over 100ms) = 150 available over the period.
+    EXPECT_GE(successful_acquires, 95); // Allow for slight timing issues
+    EXPECT_LE(successful_acquires, 100);
+
+    std::cout << "High precision test: " << successful_acquires << "/100 successful acquires." << std::endl;
+    // Check remaining tokens - should be roughly initial (50) + refilled (100) - acquired (successful_acquires)
+    // size_t remaining = limiter.get_current_tokens();
+    // This is tricky because current_tokens also triggers a refill based on the very latest time.
+}
+
+TEST(TokenBucketRateLimiterTest, FractionalTokenAccumulation) {
+    // Low rate: 1 token per second (0.1 token per 100ms)
+    // Capacity: 5
+    TokenBucketRateLimiter limiter(5, 1.0);
+
+    // Empty the bucket
+    EXPECT_TRUE(limiter.try_acquire(5));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+
+    // Wait 500ms. Should accumulate 0.5 tokens. Not enough for 1.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    EXPECT_FALSE(limiter.try_acquire(1));
+    // current_tokens_ (internal double) should be around 0.5. get_current_tokens() returns size_t (0).
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+
+    // Wait another 500ms. Total 1s. Should accumulate 1 token in total.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    EXPECT_TRUE(limiter.try_acquire(1));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+
+    // Wait 2500ms. Should accumulate 2.5 tokens.
+    std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+    EXPECT_TRUE(limiter.try_acquire(1)); // Takes 1, 1.5 left (approx)
+    EXPECT_TRUE(limiter.try_acquire(1)); // Takes 1, 0.5 left (approx)
+    EXPECT_FALSE(limiter.try_acquire(1)); // Not enough
+    // Check current tokens, should be close to 0 after taking 2.
+    // (e.g. if 2.5 tokens were available, 0.5 should be left, so get_current_tokens() is 0)
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+
+    // Wait another 500ms. Total accumulated since last success: 0.5 (from before) + 0.5 = 1.0
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    EXPECT_TRUE(limiter.try_acquire(1));
+    EXPECT_EQ(limiter.get_current_tokens(), 0);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Adds a new thread-safe TokenBucketRateLimiter component.

Includes:
- Implementation in include/rate_limiter.h
- Comprehensive tests in tests/rate_limiter_test.cpp
- Example usage in examples/rate_limiter_example.cpp
- Documentation in docs/README_rate_limiter.md and updates to main README.md
- Updates to CMake build files.