### PR TITLE
Add Count-Min Sketch data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,10 @@ target_include_directories(GraphLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/includ
 add_library(TreapLib INTERFACE)
 target_include_directories(TreapLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define CountMinSketchLib as an interface library (header-only)
+add_library(CountMinSketchLib INTERFACE)
+target_include_directories(CountMinSketchLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Future steps will add examples and tests here
 
 # Automatically add executables for all files in the examples/ directory
@@ -140,6 +144,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         TrieLib # Added for trie_example
         GraphLib # Added for graph_example
         TreapLib # Added for treap_example
+        CountMinSketchLib # Added for count_min_sketch_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -20,8 +20,8 @@ cmake ..
 echo "--- Building all targets ---"
 make -j2 # Build all targets with reduced parallelism
 
-# echo "--- Running CTest ---"
-# ctest --output-on-failure # Run all tests and show output on failure
-echo "--- CTest commented out for now to isolate build issues ---"
+echo "--- Running CTest ---"
+ctest --output-on-failure # Run all tests and show output on failure
+# echo "--- CTest commented out for now to isolate build issues ---"
 
-echo "--- Finished build_and_test.sh (Build Only) ---"
+echo "--- Finished build_and_test.sh ---"

--- a/docs/README_count_min_sketch.md
+++ b/docs/README_count_min_sketch.md
@@ -1,0 +1,125 @@
+# Count-Min Sketch (`count_min_sketch.h`)
+
+## Overview
+
+The `count_min_sketch.h` header provides a C++ implementation of a Count-Min Sketch, a probabilistic data structure used for estimating the frequency of items in a data stream. It is particularly useful when dealing with large amounts of data where storing exact frequencies for all items is infeasible due to memory constraints.
+
+Key properties:
+- **Frequency Estimation:** Provides an estimate of how many times an item has appeared.
+- **Overestimation:** Estimates are always greater than or equal to the true frequency. The sketch never underestimates.
+- **Error Bounds:** The amount of overestimation is bounded. With a user-specified probability (1 - `delta`), the estimated frequency `est_freq(item)` is within the range:
+  `true_freq(item) <= est_freq(item) <= true_freq(item) + epsilon * N`
+  where `N` is the sum of all counts inserted into the sketch (total number of items if all counts are 1).
+- **Space-Efficient:** Uses sub-linear space relative to the number of distinct items or the domain size.
+- **No Deletion (Standard):** This standard implementation does not support decreasing counts or removing items.
+
+The implementation allows you to configure the sketch based on two parameters:
+- `epsilon (ε)`: Controls the error factor. Smaller `epsilon` means the estimate is closer to the true frequency (less overestimation), but requires more memory (wider sketch).
+- `delta (δ)`: Controls the probability that the error bound is met. Smaller `delta` means higher confidence in the error bound, but requires more hash functions (deeper sketch), increasing computation per operation and memory.
+
+## Template Parameters
+
+The `CountMinSketch` class is templated:
+
+```cpp
+template <typename T>
+class CountMinSketch {
+    // ...
+};
+```
+
+- `T`: The type of items whose frequencies are to be estimated. The internal hashing mechanism is designed for fundamental types and `std::string`. For custom types, they should be trivially copyable or standard layout for the default FNV-1a based hashing to work on their byte representation.
+
+## Constructor
+
+```cpp
+CountMinSketch(double epsilon, double delta);
+```
+
+- `epsilon (double)`: The desired maximum additive error factor relative to the total sum of counts in the sketch. For example, if `epsilon` is 0.01, the error will be at most 1% of the total sum of counts. Must be greater than 0.0 and less than 1.0.
+- `delta (double)`: The desired probability that the error guarantee (as defined by `epsilon`) is *not* met. For example, if `delta` is 0.01, there is a 99% probability that the estimate adheres to the error bound. Must be greater than 0.0 and less than 1.0.
+
+Throws `std::invalid_argument` if `epsilon` or `delta` are not within the range `(0.0, 1.0)`.
+
+The constructor calculates the optimal `width` (number of counters per hash function, `w = ceil(e / epsilon)`) and `depth` (number of hash functions, `d = ceil(ln(1 / delta))`) for the sketch.
+
+## Public Methods
+
+### `void add(const T& item, unsigned int count = 1)`
+Increments the estimated frequency of `item` by `count`. If `count` is 0, the operation has no effect. If the internal counters reach their maximum value (`std::numeric_limits<unsigned int>::max()`), they will be capped at that value.
+
+### `unsigned int estimate(const T& item) const`
+Returns the estimated frequency of `item`. This estimate is always greater than or equal to the true frequency.
+
+### `size_t get_width() const`
+Returns the width (`w`) of the sketch's internal counter table (number of counters associated with each hash function).
+
+### `size_t get_depth() const`
+Returns the depth (`d`) of the sketch (which is also the number of hash functions used).
+
+### `double get_error_factor_epsilon() const`
+Returns the `epsilon` value provided at construction.
+
+### `double get_error_probability_delta() const`
+Returns the `delta` value provided at construction.
+
+## Usage Example
+
+```cpp
+#include "count_min_sketch.h"
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    // Epsilon = 0.01 (error up to 1% of total counts)
+    // Delta = 0.01 (99% confidence in this error bound)
+    CountMinSketch<std::string> word_freq_sketch(0.01, 0.01);
+
+    std::cout << "Sketch created with: width=" << word_freq_sketch.get_width()
+              << ", depth=" << word_freq_sketch.get_depth() << std::endl;
+
+    std::vector<std::string> words = {"hello", "world", "hello", "count", "min", "sketch", "hello", "world"};
+    unsigned int total_counts = 0;
+    for (const std::string& word : words) {
+        word_freq_sketch.add(word, 1);
+        total_counts++;
+    }
+
+    std::string test_word = "hello"; // True frequency is 3
+    unsigned int estimated_freq = word_freq_sketch.estimate(test_word);
+    std::cout << "Estimated frequency of \"" << test_word << "\": " << estimated_freq << std::endl;
+    // Expected: estimate >= 3. With 99% prob, estimate <= 3 + 0.01 * total_counts.
+
+    std::string absent_word = "CPlusPlus"; // True frequency is 0
+    unsigned int estimated_absent_freq = word_freq_sketch.estimate(absent_word);
+    std::cout << "Estimated frequency of \"" << absent_word << "\": " << estimated_absent_freq << std::endl;
+    // Expected: estimate >= 0. With 99% prob, estimate <= 0 + 0.01 * total_counts.
+    // For absent items, the estimate is often a small non-zero value due to collisions.
+
+    return 0;
+}
+```
+
+## Trade-offs and Considerations
+
+- **Accuracy vs. Memory/Computation:**
+    - Smaller `epsilon` (higher accuracy for error factor) leads to a larger `width`, increasing memory usage.
+    - Smaller `delta` (higher probability of meeting the error bound) leads to a larger `depth`, increasing memory usage and the number of hash computations per `add`/`estimate` operation.
+- **Total Sum of Counts (N):** The error bound `epsilon * N` depends on the total sum of all counts inserted. If `N` is very large, `epsilon` must be chosen to be very small to achieve a low absolute error.
+- **Hashing:** The quality of hash functions is important. This implementation uses FNV-1a based hashing, which is generally good.
+- **Counter Size:** The counters are `unsigned int`. If individual item counts or the sum of counts hitting a single counter cell are expected to exceed `std::numeric_limits<unsigned int>::max()`, this implementation will cap the count. For extremely high frequency items, a sketch with `uint64_t` counters might be necessary.
+- **No Deletion:** This is a standard Count-Min Sketch. If decrementing counts or item deletion is required, variations like Count-Mean-Min Sketch or Conservative Update Count-Min Sketch would be needed, which are more complex.
+
+## When to Use Count-Min Sketch
+
+Count-Min Sketch is suitable for:
+- Estimating frequencies of events in high-volume data streams.
+- Identifying frequent items (heavy hitters) in a stream.
+- Applications where some overestimation is acceptable and exact counts are too costly to maintain.
+- Network traffic monitoring (e.g., estimating flows sizes).
+- Database query optimization (e.g., estimating cardinalities).
+- Web analytics (e.g., counting page views for popular pages).
+
+It's a good alternative to exact frequency counting when memory is limited and probabilistic estimates are sufficient.
+It complements structures like Bloom Filters: Bloom Filters tell you if an item *might* be in a set, while Count-Min Sketches estimate *how often* an item has appeared.

--- a/examples/count_min_sketch_example.cpp
+++ b/examples/count_min_sketch_example.cpp
@@ -1,0 +1,68 @@
+#include "count_min_sketch.h" // Assuming it's in the include path via CMake
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    // Create a Count-Min Sketch
+    // Epsilon (error factor): 0.01 (estimate is within true_count +/- 0.01 * total_sum_counts)
+    // Delta (error probability): 0.01 (99% confidence in the error bound)
+    double epsilon = 0.01;
+    double delta = 0.01;
+    CountMinSketch<std::string> sketch(epsilon, delta);
+
+    std::cout << "Count-Min Sketch created with:" << std::endl;
+    std::cout << "  Epsilon (error factor): " << sketch.get_error_factor_epsilon() << std::endl;
+    std::cout << "  Delta (error probability): " << sketch.get_error_probability_delta() << std::endl;
+    std::cout << "  Width (counters per hash function): " << sketch.get_width() << std::endl;
+    std::cout << "  Depth (number of hash functions): " << sketch.get_depth() << std::endl;
+    std::cout << std::endl;
+
+    // Items to add (simulating a stream of words)
+    std::vector<std::string> stream = {
+        "apple", "banana", "orange", "apple", "grape",
+        "banana", "apple", "banana", "mango", "apple",
+        "orange", "grape", "grape", "apple", "banana"
+    };
+
+    std::cout << "Adding items to the sketch:" << std::endl;
+    for (const std::string& item : stream) {
+        sketch.add(item); // Add with count 1
+        // std::cout << "Added: " << item << std::endl;
+    }
+    std::cout << "Finished adding items." << std::endl << std::endl;
+
+    // Items to estimate
+    std::vector<std::string> items_to_estimate = {
+        "apple", "banana", "orange", "grape", "mango", "pear" // "pear" was not added
+    };
+
+    std::cout << "Estimating item frequencies:" << std::endl;
+    for (const std::string& item : items_to_estimate) {
+        unsigned int estimated_count = sketch.estimate(item);
+        std::cout << "  Item: \"" << item << "\", Estimated Freq: " << estimated_count << std::endl;
+    }
+    std::cout << std::endl;
+
+    std::cout << "Explanation of results:" << std::endl;
+    std::cout << "- Estimates are always >= true frequency." << std::endl;
+    std::cout << "- Estimates can be higher than true frequency due to hash collisions." << std::endl;
+    std::cout << "- The parameters epsilon and delta control the accuracy:" << std::endl;
+    std::cout << "  With high probability (1 - delta), the error in estimation "
+                 "(estimate - true_frequency) is at most epsilon * (total sum of all counts added)." << std::endl;
+    std::cout << "- For items not added (like \"pear\"), the estimate might be > 0 due to collisions, "
+                 "but it's typically low if the sketch is not overly full." << std::endl;
+
+    // Example with integer keys
+    CountMinSketch<int> int_sketch(0.05, 0.05); // Different params for variety
+    std::cout << "\n--- Integer Key Example ---" << std::endl;
+    int_sketch.add(101, 50);
+    int_sketch.add(202, 75);
+    int_sketch.add(101, 30); // Add more to 101, total 80
+
+    std::cout << "Estimate for 101 (true 80): " << int_sketch.estimate(101) << std::endl;
+    std::cout << "Estimate for 202 (true 75): " << int_sketch.estimate(202) << std::endl;
+    std::cout << "Estimate for 303 (true 0): " << int_sketch.estimate(303) << std::endl;
+
+    return 0;
+}

--- a/include/count_min_sketch.h
+++ b/include/count_min_sketch.h
@@ -1,0 +1,196 @@
+#ifndef COUNT_MIN_SKETCH_H
+#define COUNT_MIN_SKETCH_H
+
+#include <vector>
+#include <string>
+#include <cmath>      // For std::log, std::ceil, std::exp (for M_E)
+#include <functional> // For std::hash (though we'll use custom hashing)
+#include <limits>     // For std::numeric_limits
+#include <stdexcept>  // For std::invalid_argument
+#include <algorithm>  // For std::min
+
+// Hashing utilities within detail namespace, adapted from bloom_filter.h
+namespace detail {
+
+// FNV-1a constants for size_t
+#if defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined(__aarch64__)
+constexpr size_t CMS_FNV_PRIME = 1099511628211ULL;
+constexpr size_t CMS_FNV_OFFSET_BASIS = 14695981039346656037ULL;
+#else // 32-bit
+constexpr size_t CMS_FNV_PRIME = 16777619U;
+constexpr size_t CMS_FNV_OFFSET_BASIS = 2166136261U;
+#endif
+
+// A secondary basis for generating a second hash function (h2)
+// Derived by XORing with a constant pattern.
+constexpr size_t CMS_FNV_OFFSET_BASIS_2 = CMS_FNV_OFFSET_BASIS ^
+    (sizeof(size_t) == 8 ? 0x5A5A5A5A5A5A5A5AULL : 0x5A5A5A5AU);
+
+
+// Helper to apply FNV-1a to a block of memory
+inline size_t cms_fnv1a_hash_bytes(const unsigned char* data, size_t len, size_t basis, size_t prime) {
+    size_t hash_val = basis;
+    for (size_t i = 0; i < len; ++i) {
+        hash_val ^= static_cast<size_t>(data[i]);
+        hash_val *= prime;
+    }
+    return hash_val;
+}
+
+// Generic CountMinSketchHash for arithmetic types (integers, float, double, etc.)
+// and any type T where taking its address and sizeof(T) is meaningful for hashing.
+// This uses the h(x) = h1(x) + seed * h2(x) construction.
+template <typename T>
+struct CountMinSketchHash {
+    size_t operator()(const T& item, size_t seed) const {
+        // Ensure T is trivially copyable or that this approach is safe.
+        static_assert(std::is_trivially_copyable<T>::value || std::is_standard_layout<T>::value,
+                      "CountMinSketchHash<T> default implementation relies on byte representation. Ensure T is suitable.");
+
+        const unsigned char* item_bytes = reinterpret_cast<const unsigned char*>(&item);
+        size_t item_len = sizeof(T);
+
+        size_t h1 = cms_fnv1a_hash_bytes(item_bytes, item_len, CMS_FNV_OFFSET_BASIS, CMS_FNV_PRIME);
+        size_t h2 = cms_fnv1a_hash_bytes(item_bytes, item_len, CMS_FNV_OFFSET_BASIS_2, CMS_FNV_PRIME);
+
+        return h1 + seed * h2;
+    }
+};
+
+// Specialization for std::string
+template <>
+struct CountMinSketchHash<std::string> {
+    size_t operator()(const std::string& item, size_t seed) const {
+        const unsigned char* item_bytes = reinterpret_cast<const unsigned char*>(item.data());
+        size_t item_len = item.length();
+
+        size_t h1 = cms_fnv1a_hash_bytes(item_bytes, item_len, CMS_FNV_OFFSET_BASIS, CMS_FNV_PRIME);
+        size_t h2 = cms_fnv1a_hash_bytes(item_bytes, item_len, CMS_FNV_OFFSET_BASIS_2, CMS_FNV_PRIME);
+
+        return h1 + seed * h2;
+    }
+};
+
+} // namespace detail
+
+template <typename T>
+class CountMinSketch {
+public:
+    /**
+     * @brief Constructs a Count-Min Sketch.
+     *
+     * The sketch estimates item frequencies with errors bounded by `epsilon`
+     * with a probability of `1 - delta`.
+     *
+     * @param epsilon The maximum additive error factor for estimates.
+     *                Must be > 0.0 and < 1.0. Smaller epsilon means lower error but more memory.
+     *                Error is `epsilon * total_items_count`.
+     * @param delta The probability that the error guarantee is not met.
+     *              Must be > 0.0 and < 1.0. Smaller delta means higher confidence but more hash functions (depth).
+     */
+    CountMinSketch(double epsilon, double delta)
+        : epsilon_(epsilon), delta_(delta) {
+        if (epsilon <= 0.0 || epsilon >= 1.0) {
+            throw std::invalid_argument("Epsilon must be between 0.0 and 1.0 (exclusive).");
+        }
+        if (delta <= 0.0 || delta >= 1.0) {
+            throw std::invalid_argument("Delta must be between 0.0 and 1.0 (exclusive).");
+        }
+
+        // Calculate width (w) and depth (d)
+        // w = ceil(e / epsilon) where e is Euler's number
+        width_ = static_cast<size_t>(std::ceil(std::exp(1.0) / epsilon_));
+        // d = ceil(ln(1 / delta))
+        depth_ = static_cast<size_t>(std::ceil(std::log(1.0 / delta_)));
+
+        if (width_ == 0) width_ = 1; // Ensure at least 1 counter
+        if (depth_ == 0) depth_ = 1; // Ensure at least 1 hash function
+
+        // Initialize counters_ table
+        counters_.resize(depth_, std::vector<unsigned int>(width_, 0));
+    }
+
+    /**
+     * @brief Adds an item to the sketch, incrementing its count.
+     *
+     * @param item The item to add.
+     * @param count The amount by which to increment the item's count (default is 1).
+     */
+    void add(const T& item, unsigned int count = 1) {
+        if (count == 0) return; // Adding zero has no effect
+        for (size_t i = 0; i < depth_; ++i) {
+            size_t hash_val = hasher_(item, i);
+            // Check for potential overflow before adding.
+            // If counters_[i][hash_val % width_] + count > max_val, cap it.
+            // This is a simple way to handle it; more sophisticated applications
+            // might need to signal this or use larger counter types.
+            unsigned int current_val = counters_[i][hash_val % width_];
+            if (std::numeric_limits<unsigned int>::max() - count < current_val) {
+                counters_[i][hash_val % width_] = std::numeric_limits<unsigned int>::max();
+            } else {
+                counters_[i][hash_val % width_] += count;
+            }
+        }
+    }
+
+    /**
+     * @brief Estimates the frequency of an item.
+     *
+     * The estimate is guaranteed to be not less than the true frequency.
+     * The estimate is `true_frequency + epsilon * N` with probability `1 - delta`,
+     * where N is the sum of all counts inserted into the sketch.
+     *
+     * @param item The item to estimate.
+     * @return The estimated frequency of the item.
+     */
+    unsigned int estimate(const T& item) const {
+        if (width_ == 0 || depth_ == 0) return 0; // Should not happen with constructor guards
+
+        unsigned int min_count = std::numeric_limits<unsigned int>::max();
+        for (size_t i = 0; i < depth_; ++i) {
+            size_t hash_val = hasher_(item, i);
+            min_count = std::min(min_count, counters_[i][hash_val % width_]);
+        }
+        return min_count;
+    }
+
+    /**
+     * @brief Returns the width (w) of the sketch's counter table.
+     * This is the number of counters per hash function.
+     */
+    size_t get_width() const {
+        return width_;
+    }
+
+    /**
+     * @brief Returns the depth (d) of the sketch (number of hash functions).
+     */
+    size_t get_depth() const {
+        return depth_;
+    }
+
+    /**
+     * @brief Returns the configured error factor epsilon.
+     */
+    double get_error_factor_epsilon() const {
+        return epsilon_;
+    }
+
+    /**
+     * @brief Returns the configured error probability delta.
+     */
+    double get_error_probability_delta() const {
+        return delta_;
+    }
+
+private:
+    double epsilon_;
+    double delta_;
+    size_t width_;    // w
+    size_t depth_;    // d
+
+    std::vector<std::vector<unsigned int>> counters_;
+    detail::CountMinSketchHash<T> hasher_;
+};
+
+#endif // COUNT_MIN_SKETCH_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         TrieLib # Added for trie_test
         GraphLib # Added for graph_test
         TreapLib # Added for treap_test
+        CountMinSketchLib # Added for count_min_sketch_test
     )
 
     # Specific configurations for certain tests

--- a/tests/count_min_sketch_test.cpp
+++ b/tests/count_min_sketch_test.cpp
@@ -1,0 +1,271 @@
+#include "gtest/gtest.h"
+#include "count_min_sketch.h" // Assuming it's in the include path
+#include <string>
+#include <vector>
+#include <cmath> // For std::exp, std::log, std::ceil
+
+// Test fixture for CountMinSketch tests
+class CountMinSketchTest : public ::testing::Test {
+protected:
+    // You can define helper functions or setup/teardown logic here if needed
+};
+
+// Test constructor with valid parameters and check calculated width/depth
+TEST_F(CountMinSketchTest, ConstructorValidParameters) {
+    double epsilon = 0.01; // Error factor
+    double delta = 0.01;   // Error probability
+
+    CountMinSketch<int> sketch(epsilon, delta);
+
+    size_t expected_width = static_cast<size_t>(std::ceil(std::exp(1.0) / epsilon));
+    size_t expected_depth = static_cast<size_t>(std::ceil(std::log(1.0 / delta)));
+
+    EXPECT_EQ(sketch.get_width(), expected_width);
+    EXPECT_EQ(sketch.get_depth(), expected_depth);
+    EXPECT_EQ(sketch.get_error_factor_epsilon(), epsilon);
+    EXPECT_EQ(sketch.get_error_probability_delta(), delta);
+}
+
+// Test constructor with invalid epsilon
+TEST_F(CountMinSketchTest, ConstructorInvalidEpsilon) {
+    EXPECT_THROW(CountMinSketch<int>(0.0, 0.1), std::invalid_argument);
+    EXPECT_THROW(CountMinSketch<int>(1.0, 0.1), std::invalid_argument);
+    EXPECT_THROW(CountMinSketch<int>(-0.1, 0.1), std::invalid_argument);
+    EXPECT_THROW(CountMinSketch<int>(1.1, 0.1), std::invalid_argument);
+}
+
+// Test constructor with invalid delta
+TEST_F(CountMinSketchTest, ConstructorInvalidDelta) {
+    EXPECT_THROW(CountMinSketch<int>(0.1, 0.0), std::invalid_argument);
+    EXPECT_THROW(CountMinSketch<int>(0.1, 1.0), std::invalid_argument);
+    EXPECT_THROW(CountMinSketch<int>(0.1, -0.1), std::invalid_argument);
+    EXPECT_THROW(CountMinSketch<int>(0.1, 1.1), std::invalid_argument);
+}
+
+// Test adding a single item and estimating its count
+TEST_F(CountMinSketchTest, AddAndEstimateSingleItemInt) {
+    CountMinSketch<int> sketch(0.01, 0.01);
+    sketch.add(123, 5);
+    EXPECT_GE(sketch.estimate(123), 5); // Estimate must be >= true count
+}
+
+TEST_F(CountMinSketchTest, AddAndEstimateSingleItemString) {
+    CountMinSketch<std::string> sketch(0.01, 0.01);
+    std::string item = "test_string";
+    sketch.add(item, 10);
+    EXPECT_GE(sketch.estimate(item), 10);
+}
+
+// Test estimating an item not added
+TEST_F(CountMinSketchTest, EstimateItemNotAdded) {
+    CountMinSketch<int> sketch(0.01, 0.01);
+    sketch.add(123, 5);
+    // Item 456 was not added. Its estimate could be > 0 due to collisions,
+    // but it's often 0 for a sparse sketch.
+    // We can't guarantee 0, but we know it shouldn't be related to item 123's count.
+    // For a very high epsilon (e.g., 0.5, width ~5), collisions are more likely.
+    // For low epsilon (e.g., 0.001, width ~2718), collisions for non-added items are less likely to be high.
+    EXPECT_GE(sketch.estimate(456), 0); // Must be non-negative
+}
+
+// Test adding the same item multiple times
+TEST_F(CountMinSketchTest, AddSameItemMultipleTimes) {
+    CountMinSketch<int> sketch(0.01, 0.01);
+    sketch.add(789, 3);
+    sketch.add(789, 4);
+    sketch.add(789, 2); // Total count = 9
+    EXPECT_GE(sketch.estimate(789), 9);
+}
+
+// Test adding multiple distinct items
+TEST_F(CountMinSketchTest, AddMultipleDistinctItems) {
+    CountMinSketch<std::string> sketch(0.001, 0.001); // More precision
+    std::string item_apple = "apple";
+    std::string item_banana = "banana";
+    std::string item_cherry = "cherry";
+
+    sketch.add(item_apple, 100);
+    sketch.add(item_banana, 200);
+    sketch.add(item_cherry, 50);
+
+    EXPECT_GE(sketch.estimate(item_apple), 100);
+    EXPECT_GE(sketch.estimate(item_banana), 200);
+    EXPECT_GE(sketch.estimate(item_cherry), 50);
+
+    // Check that estimates are not wildly off due to collisions (probabilistic)
+    // This is harder to assert definitively without knowing total sum of counts.
+    // We expect estimate(X) >= count(X)
+    // And estimate(X) <= count(X) + epsilon * TotalCountsInSketch
+    // For now, just checking lower bound.
+}
+
+// Test with default count value for add method
+TEST_F(CountMinSketchTest, AddWithDefaultCount) {
+    CountMinSketch<int> sketch(0.01, 0.01);
+    sketch.add(111); // Default count is 1
+    sketch.add(111);
+    EXPECT_GE(sketch.estimate(111), 2);
+}
+
+// Test adding with count 0 (should have no effect)
+TEST_F(CountMinSketchTest, AddWithZeroCount) {
+    CountMinSketch<int> sketch(0.01, 0.01);
+    sketch.add(222, 5);
+    sketch.add(222, 0); // Adding 0
+    EXPECT_GE(sketch.estimate(222), 5);
+    // It should ideally be exactly 5 if no other items cause collisions on these specific hashes.
+    // To be more precise, we can check if it's less than 5 + some error margin, but that's complex.
+    // For now, ensuring it's at least 5 and not excessively more is a basic check.
+    // A more direct test: estimate, add 0, estimate again.
+    unsigned int estimate_before = sketch.estimate(222);
+    sketch.add(222, 0);
+    unsigned int estimate_after = sketch.estimate(222);
+    EXPECT_EQ(estimate_before, estimate_after);
+}
+
+// Test counter overflow capping
+TEST_F(CountMinSketchTest, CounterOverflow) {
+    CountMinSketch<int> sketch(0.1, 0.1); // Smaller sketch to make it easier to hit same cells
+    unsigned int max_val = std::numeric_limits<unsigned int>::max();
+
+    // Pick an item. Its hashes will hit certain cells.
+    int item_to_overflow = 12345;
+
+    // Add a large value close to max_val to one item.
+    // This requires knowing which cells it hashes to, or adding it many times.
+    // A simpler way: add max_val, then add 1. It should be capped at max_val.
+    sketch.add(item_to_overflow, max_val - 10);
+    sketch.add(item_to_overflow, 5); // Now at max_val - 5
+    EXPECT_GE(sketch.estimate(item_to_overflow), max_val - 10); // Should be at least original
+
+    sketch.add(item_to_overflow, 20); // This should cause overflow and cap at max_val
+    EXPECT_EQ(sketch.estimate(item_to_overflow), max_val);
+
+    // Add more, should remain capped
+    sketch.add(item_to_overflow, 100);
+    EXPECT_EQ(sketch.estimate(item_to_overflow), max_val);
+}
+
+// Test with minimal width/depth (epsilon/delta close to 1)
+TEST_F(CountMinSketchTest, MinimalSketchParameters) {
+    // Epsilon very high (e.g., 0.99) -> width should be ceil(e/0.99) approx ceil(2.718/0.99) = 3
+    // Delta very high (e.g., 0.99) -> depth should be ceil(ln(1/0.99)) approx ceil(ln(1.01)) = 1
+    CountMinSketch<int> sketch(0.9, 0.9); // Should result in small w, d
+
+    size_t expected_width = static_cast<size_t>(std::ceil(std::exp(1.0) / 0.9)); // approx 3
+    size_t expected_depth = static_cast<size_t>(std::ceil(std::log(1.0 / 0.9))); // approx 1
+
+    EXPECT_EQ(sketch.get_width(), expected_width);
+    EXPECT_EQ(sketch.get_depth(), expected_depth);
+
+    sketch.add(1, 10);
+    sketch.add(2, 20); // High chance of collision in such a small sketch
+
+    EXPECT_GE(sketch.estimate(1), 10);
+    EXPECT_GE(sketch.estimate(2), 20);
+    // With depth 1, estimate(1) will be exactly counter[0][h(1)%width]
+    // estimate(2) will be exactly counter[0][h(2)%width]
+    // If h(1)%width == h(2)%width, then estimate(1) would be sum of counts.
+}
+
+
+// Test with custom struct (needs is_trivially_copyable or is_standard_layout for default hash)
+struct MyStruct {
+    int id;
+    double value;
+
+    // Equality operator for potential use in tests, not strictly needed by sketch itself if not used as key in map
+    bool operator==(const MyStruct& other) const {
+        return id == other.id && value == other.value;
+    }
+};
+
+// Ensure MyStruct is suitable for the default hasher
+static_assert(std::is_trivially_copyable<MyStruct>::value || std::is_standard_layout<MyStruct>::value,
+              "MyStruct must be trivially copyable or standard layout for default CountMinSketchHash.");
+
+
+TEST_F(CountMinSketchTest, CustomStructBasic) {
+    CountMinSketch<MyStruct> sketch(0.01, 0.01);
+    MyStruct s1 = {1, 10.5};
+    MyStruct s2 = {2, 20.5};
+
+    sketch.add(s1, 5);
+    sketch.add(s2, 8);
+
+    EXPECT_GE(sketch.estimate(s1), 5);
+    EXPECT_GE(sketch.estimate(s2), 8);
+
+    MyStruct s3 = {1, 10.5}; // Same as s1
+    EXPECT_GE(sketch.estimate(s3), 5);
+
+    MyStruct s4 = {3, 30.5}; // Not added
+    EXPECT_GE(sketch.estimate(s4), 0);
+}
+
+// A more involved test to observe error bounds (qualitatively)
+// This is hard to assert strictly without knowing total counts and specific hash values
+TEST_F(CountMinSketchTest, ErrorBoundObservation) {
+    double epsilon = 0.1; // 10% error factor relative to total count sum
+    double delta = 0.1;   // 90% confidence
+    CountMinSketch<int> sketch(epsilon, delta);
+
+    int num_items = 100;
+    unsigned int count_per_item = 10;
+    unsigned int total_sum_of_counts = 0;
+
+    for (int i = 0; i < num_items; ++i) {
+        sketch.add(i, count_per_item);
+        total_sum_of_counts += count_per_item;
+    }
+
+    // For each item, estimate should be >= count_per_item
+    // And with probability 1-delta, estimate <= count_per_item + epsilon * total_sum_of_counts
+    unsigned int error_margin = static_cast<unsigned int>(std::ceil(epsilon * total_sum_of_counts));
+
+    int items_within_bounds = 0;
+    int items_overestimated_correctly = 0; // estimate >= true_count
+
+    for (int i = 0; i < num_items; ++i) {
+        unsigned int estimate = sketch.estimate(i);
+        EXPECT_GE(estimate, count_per_item);
+        if (estimate >= count_per_item) {
+            items_overestimated_correctly++;
+        }
+        // This is the probabilistic part
+        if (estimate <= count_per_item + error_margin) {
+            items_within_bounds++;
+        }
+        // For debugging:
+        // if (estimate > count_per_item + error_margin) {
+        //     std::cout << "Item " << i << ": estimate " << estimate
+        //               << " > true_count " << count_per_item
+        //               << " + error_margin " << error_margin << std::endl;
+        // }
+    }
+    EXPECT_EQ(items_overestimated_correctly, num_items); // This must hold
+
+    // We expect most items (around (1-delta)*num_items) to be within the error bound.
+    // This is a probabilistic assertion, so it might flake in rare cases.
+    // A common way is to check if it's a high percentage, e.g., > (1-delta-buffer)*num_items
+    double expected_min_within_bounds = (1.0 - delta - 0.05) * num_items; // allow a small buffer for test flakiness
+    EXPECT_GE(items_within_bounds, expected_min_within_bounds)
+        << "Items within bounds: " << items_within_bounds << "/" << num_items
+        << ", expected at least " << expected_min_within_bounds;
+
+    // Check a non-existent item
+    unsigned int estimate_non_existent = sketch.estimate(num_items + 100);
+    EXPECT_GE(estimate_non_existent, 0);
+    // With probability 1-delta, its estimate should be <= epsilon * total_sum_of_counts
+    // This is harder to assert strictly for a single non-existent item.
+    // Typically, estimates for non-existent items are low.
+    EXPECT_LE(estimate_non_existent, error_margin)
+        << "Estimate for non-existent item " << estimate_non_existent
+        << " exceeded error margin " << error_margin;
+}
+
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This commit introduces the Count-Min Sketch, a probabilistic data structure for estimating item frequencies in a stream.

Features:
- Calculates optimal width (w) and depth (d) based on user-defined error factor (epsilon) and error probability (delta).
- `add(item, count)`: Increments the count for an item.
- `estimate(item)`: Provides an estimate of the item's frequency.
- Uses FNV-1a based hashing, similar to the existing BloomFilter.

Includes:
- Header file: `include/count_min_sketch.h`
- Unit tests: `tests/count_min_sketch_test.cpp` (all passing)
- Example usage: `examples/count_min_sketch_example.cpp`
- Documentation: `docs/README_count_min_sketch.md`

The build system (CMakeLists.txt files) has been updated to include the new component, example, and tests.