### PR TITLE
feat: Add Counting Bloom Filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,10 @@ target_include_directories(TreapLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/includ
 add_library(CountMinSketchLib INTERFACE)
 target_include_directories(CountMinSketchLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define CountingBloomFilterLib as an interface library (header-only)
+add_library(CountingBloomFilterLib INTERFACE)
+target_include_directories(CountingBloomFilterLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Future steps will add examples and tests here
 
 # Automatically add executables for all files in the examples/ directory
@@ -145,6 +149,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         GraphLib # Added for graph_example
         TreapLib # Added for treap_example
         CountMinSketchLib # Added for count_min_sketch_example
+        CountingBloomFilterLib
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/docs/README_CountingBloomFilter.md
+++ b/docs/README_CountingBloomFilter.md
@@ -1,0 +1,101 @@
+# Counting Bloom Filter
+
+## Overview
+
+A Counting Bloom Filter (CBF) is a probabilistic data structure used to test whether an element is a member of a set, similar to a standard Bloom Filter. The key advantage of a Counting Bloom Filter over a standard one is its ability to handle the **deletion** of elements. This is achieved by using an array of small counters instead of an array of bits.
+
+When an element is added, the counters corresponding to its hash values are incremented. When an element is queried (`contains`), all corresponding counters are checked; if any counter is zero, the element is definitively not in the set. If all counters are non-zero, the element is *probably* in the set (with a certain false positive probability). When an element is removed, the corresponding counters are decremented.
+
+## Features
+
+*   **Approximate Membership Testing**: Like standard Bloom filters, CBFs can tell you if an item is *definitely not* in the set or *probably is* in the set.
+*   **Element Deletion**: Supports removing elements, which is not possible with a standard Bloom filter.
+*   **Configurable False Positive Rate**: You can tune the filter's size and number of hash functions based on the expected number of items and the desired false positive probability.
+*   **Space Efficient (Relatively)**: More space-intensive than a standard Bloom filter due to counters instead of bits, but still more space-efficient than explicitly storing all elements for approximate set membership.
+
+## When to Use
+
+Counting Bloom Filters are useful in scenarios where:
+*   You need approximate set membership with a low false positive rate.
+*   Elements are frequently added *and removed* from the set.
+*   Memory is a concern, but you can afford more than a standard Bloom filter to gain deletion capability.
+*   Examples:
+    *   Tracking recently seen items in network traffic where flows can end.
+    *   Caching systems where items expire or are evicted.
+    *   Databases to avoid disk lookups for non-existent keys that might have been recently deleted.
+
+## `CountingBloomFilter` Class
+
+The `cpp_utils::CountingBloomFilter<T, CounterType, Hasher>` class provides this functionality.
+
+### Template Parameters
+
+*   `T`: The type of elements to be stored in the filter.
+*   `CounterType` (optional, defaults to `uint8_t`): The integral type used for the counters. Smaller types (`uint8_t`, `uint16_t`) save space but can saturate more quickly if items are added many times or if there are many hash collisions. `uint8_t` allows a counter to go up to 255. If an item is added more times than the counter can hold, the counter will saturate at its maximum value.
+*   `Hasher` (optional, defaults to `cpp_utils::DefaultHash<T>`): The hash functor used. The default uses `std::hash` and a simple mixing strategy to generate multiple hash values. For critical applications, you might provide a custom hasher that implements `uint64_t operator()(const T& item, uint64_t seed) const`.
+
+### Constructor
+
+```cpp
+CountingBloomFilter(size_t expected_insertions, double false_positive_rate);
+```
+*   `expected_insertions`: An estimate of the maximum number of unique items you expect to store in the filter simultaneously. This is used to calculate the optimal size of the counter array and the number of hash functions.
+*   `false_positive_rate`: The desired probability (e.g., `0.01` for 1%) that `contains()` will return `true` for an item that has not been added.
+
+### Public Methods
+
+*   `void add(const T& item)`: Adds an item to the filter. Increments the counters at the item's hash locations. If a counter reaches its maximum value, it remains saturated.
+*   `bool contains(const T& item) const`: Checks if an item might be in the filter. Returns `false` if the item is definitely not present. Returns `true` if the item is probably present (could be a false positive).
+*   `bool remove(const T& item)`: Removes an item from the filter. Decrements the counters at the item's hash locations.
+    *   Returns `true` if the item was potentially removed (i.e., all its associated counters were non-zero before decrementing).
+    *   Returns `false` if the item was definitely not present (i.e., at least one of its associated counters was already zero).
+    *   Counters are not decremented below zero.
+*   `size_t numCounters() const`: Returns the number of counters in the filter array.
+*   `size_t numHashFunctions() const`: Returns the number of hash functions used.
+*   `size_t approxMemoryUsage() const`: Returns an estimate of the memory used by the filter in bytes.
+
+## Basic Usage
+
+```cpp
+#include "include/counting_bloom_filter.h"
+#include <iostream>
+#include <string>
+
+int main() {
+    // Expecting ~1000 items, desire 1% false positive rate
+    cpp_utils::CountingBloomFilter<std::string> cbf(1000, 0.01);
+
+    cbf.add("apple");
+    cbf.add("banana");
+    cbf.add("apple"); // Add "apple" again
+
+    std::cout << "Contains 'apple'? " << cbf.contains("apple") << std::endl; // Expected: 1 (true)
+    std::cout << "Contains 'orange'? " << cbf.contains("orange") << std::endl; // Expected: 0 (false, unless FP)
+
+    cbf.remove("banana");
+    std::cout << "Contains 'banana' after remove? " << cbf.contains("banana") << std::endl; // Expected: 0 (false)
+
+    cbf.remove("apple"); // First remove of "apple"
+    std::cout << "Contains 'apple' after one remove? " << cbf.contains("apple") << std::endl; // Expected: 1 (true, was added twice)
+
+    cbf.remove("apple"); // Second remove of "apple"
+    std::cout << "Contains 'apple' after second remove? " << cbf.contains("apple") << std::endl; // Expected: 0 (false)
+
+    return 0;
+}
+```
+
+## Hashing
+
+The quality of the hash functions is crucial for the performance and accuracy of the Bloom filter. The provided `DefaultHash` is a basic implementation. For production systems, consider using well-known non-cryptographic hash functions like MurmurHash3 or xxHash, and ensure your `Hasher` functor generates multiple distinct hash values effectively using the `seed` parameter. The current implementation uses the `seed` (which is the hash function index `0..k-1`) to perturb a base hash from `std::hash<T>`.
+
+## Trade-offs
+
+*   **Counter Size (`CounterType`)**:
+    *   Smaller counters (e.g., `uint8_t` for 4-bit or 8-bit counters, though `uint8_t` is the smallest directly usable standard type) save space.
+    *   Risk of saturation: If an item is added many times, or many distinct items hash to the same counter, the counter might reach its maximum value. If this happens, removing an item might not correctly reflect its absence if another item still requires that counter to be high.
+    *   Larger counters (e.g., `uint16_t`, `uint32_t`) reduce saturation risk but increase space. Typically, 4-bit to 8-bit counters are common. `uint8_t` is a practical choice for many applications.
+*   **False Positives**: The false positive rate is determined by the size of the counter array and the number of hash functions, which are derived from `expected_insertions` and the desired `false_positive_rate`. Deleting items can, over time, slightly alter the actual false positive rate compared to a static Bloom filter, as emptied slots become available.
+*   **False Negatives**: Counting Bloom Filters, like standard Bloom filters, do *not* produce false negatives. If `contains()` returns `false`, the item is definitely not in the set.
+
+This documentation should provide a good overview for users of the `CountingBloomFilter`.

--- a/examples/counting_bloom_filter_example.cpp
+++ b/examples/counting_bloom_filter_example.cpp
@@ -1,0 +1,99 @@
+#include "counting_bloom_filter.h"
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    // Create a Counting Bloom Filter for strings
+    // Expected insertions: around 1000 items
+    // Desired false positive rate: 1% (0.01)
+    // Using default uint8_t for counters
+    cpp_utils::CountingBloomFilter<std::string> cbf(1000, 0.01);
+
+    std::cout << "Counting Bloom Filter Example" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "Initialized for ~1000 items, 1% FP rate." << std::endl;
+    std::cout << "Calculated number of counters: " << cbf.numCounters() << std::endl;
+    std::cout << "Calculated number of hash functions: " << cbf.numHashFunctions() << std::endl;
+    std::cout << "Approximate memory usage: " << cbf.approxMemoryUsage() << " bytes" << std::endl;
+    std::cout << std::endl;
+
+    // Items to add
+    std::vector<std::string> items_to_add = {"apple", "banana", "orange", "grape", "mango"};
+    std::cout << "Adding items: ";
+    for (const auto& item : items_to_add) {
+        cbf.add(item);
+        std::cout << "\"" << item << "\" ";
+    }
+    std::cout << std::endl << std::endl;
+
+    // Check for added items
+    std::cout << "Checking for items known to be present:" << std::endl;
+    for (const auto& item : items_to_add) {
+        std::cout << "Contains \"" << item << "\"? " << (cbf.contains(item) ? "Yes (or FP)" : "No") << std::endl;
+    }
+    std::cout << std::endl;
+
+    // Check for items not added
+    std::cout << "Checking for items known to be absent (might be False Positives):" << std::endl;
+    std::vector<std::string> items_not_added = {"strawberry", "blueberry", "raspberry"};
+    for (const auto& item : items_not_added) {
+        std::cout << "Contains \"" << item << "\"? " << (cbf.contains(item) ? "Yes (FP)" : "No") << std::endl;
+    }
+    std::cout << std::endl;
+
+    // Demonstrate removal
+    std::string item_to_remove = "orange";
+    std::cout << "Removing item: \"" << item_to_remove << "\"" << std::endl;
+    if (cbf.remove(item_to_remove)) {
+        std::cout << "\"" << item_to_remove << "\" was potentially removed." << std::endl;
+    } else {
+        std::cout << "\"" << item_to_remove << "\" was definitely not present or already fully removed." << std::endl;
+    }
+    std::cout << "Contains \"" << item_to_remove << "\" after removal? "
+              << (cbf.contains(item_to_remove) ? "Yes (FP or not fully removed)" : "No") << std::endl;
+    std::cout << std::endl;
+
+    // Demonstrate multiple adds and removes
+    std::string multi_item = "banana"; // "banana" was already added once
+    std::cout << "Adding \"" << multi_item << "\" two more times." << std::endl;
+    cbf.add(multi_item);
+    cbf.add(multi_item);
+
+    std::cout << "Contains \"" << multi_item << "\"? " << (cbf.contains(multi_item) ? "Yes" : "No") << std::endl;
+    std::cout << "Removing \"" << multi_item << "\" once." << std::endl;
+    cbf.remove(multi_item);
+    std::cout << "Contains \"" << multi_item << "\" after one remove? "
+              << (cbf.contains(multi_item) ? "Yes (still has counts)" : "No") << std::endl;
+
+    std::cout << "Removing \"" << multi_item << "\" again." << std::endl;
+    cbf.remove(multi_item);
+    std::cout << "Contains \"" << multi_item << "\" after second remove? "
+              << (cbf.contains(multi_item) ? "Yes (still has counts)" : "No") << std::endl;
+
+    std::cout << "Removing \"" << multi_item << "\" a third time (original add + 2 more)." << std::endl;
+    cbf.remove(multi_item);
+    std::cout << "Contains \"" << multi_item << "\" after third remove? "
+              << (cbf.contains(multi_item) ? "Yes (FP or error)" : "No") << std::endl;
+    std::cout << std::endl;
+
+
+    // Example with integer items and larger counter type
+    cpp_utils::CountingBloomFilter<int, uint16_t> cbf_int(500, 0.001);
+    std::cout << "--- Integer CBF Example (uint16_t counters) ---" << std::endl;
+    cbf_int.add(12345);
+    cbf_int.add(67890);
+    cbf_int.add(12345); // Add 12345 again
+
+    std::cout << "Contains 12345? " << (cbf_int.contains(12345) ? "Yes" : "No") << std::endl;
+    std::cout << "Contains 67890? " << (cbf_int.contains(67890) ? "Yes" : "No") << std::endl;
+    std::cout << "Contains 99999? " << (cbf_int.contains(99999) ? "Yes (FP)" : "No") << std::endl;
+
+    cbf_int.remove(12345);
+    std::cout << "Contains 12345 after one remove? " << (cbf_int.contains(12345) ? "Yes" : "No") << std::endl;
+    cbf_int.remove(12345);
+    std::cout << "Contains 12345 after second remove? " << (cbf_int.contains(12345) ? "Yes (FP)" : "No") << std::endl;
+
+
+    return 0;
+}

--- a/include/counting_bloom_filter.h
+++ b/include/counting_bloom_filter.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <vector>
+#include <functional> // For std::hash
+#include <cmath>      // For std::log, std::pow, std::ceil
+#include <limits>     // For std::numeric_limits
+#include <cstdint>    // For uint8_t, uint32_t, uint64_t
+#include <stdexcept>  // For std::invalid_argument
+#include <string>     // For std::string in example hash, can be removed later
+
+namespace cpp_utils {
+
+// Basic hash functions (can be improved or made more flexible later)
+// Using a simple combination for two hash values.
+// For robust applications, consider more advanced hashing like MurmurHash3 or xxHash.
+template <typename T>
+struct DefaultHash {
+    uint64_t operator()(const T& item, uint64_t seed) const {
+        // A simple way to get two different hash values for an item.
+        // This is a placeholder; a more robust hashing strategy is usually needed.
+        std::hash<T> hasher;
+        uint64_t h1 = hasher(item);
+        // Combine with seed to get different hashes for different hash functions
+        // This is a very basic approach, for illustration.
+        // A common technique is h(i) = (h1 + i * h2) % m
+        // where h1 and h2 are two independent hash functions.
+        // For now, let's just use seed to perturb h1.
+        return h1 ^ (seed * 0x9e3779b97f4a7c15ULL); // A large prime for mixing
+    }
+};
+
+
+template <typename T,
+          typename CounterType = uint8_t,
+          typename Hasher = DefaultHash<T>>
+class CountingBloomFilter {
+public:
+    CountingBloomFilter(size_t expected_insertions, double false_positive_rate)
+        : hasher_() {
+        if (expected_insertions == 0) {
+            throw std::invalid_argument("Expected insertions must be greater than 0.");
+        }
+        if (false_positive_rate <= 0.0 || false_positive_rate >= 1.0) {
+            throw std::invalid_argument("False positive rate must be between 0.0 and 1.0.");
+        }
+
+        // Optimal number of bits (m) = - (n * ln(p)) / (ln(2)^2)
+        // where n = expected_insertions, p = false_positive_rate
+        double m_optimal = - (static_cast<double>(expected_insertions) * std::log(false_positive_rate)) /
+                             (std::log(2.0) * std::log(2.0));
+        num_counters_ = static_cast<size_t>(std::ceil(m_optimal));
+        if (num_counters_ == 0) num_counters_ = 1; // Ensure at least one counter
+
+        // Optimal number of hash functions (k) = (m/n) * ln(2)
+        double k_optimal = (static_cast<double>(num_counters_) / expected_insertions) * std::log(2.0);
+        num_hash_functions_ = static_cast<size_t>(std::ceil(k_optimal));
+        if (num_hash_functions_ == 0) num_hash_functions_ = 1; // Ensure at least one hash function
+
+        counters_.resize(num_counters_, 0);
+    }
+
+    void add(const T& item) {
+        for (size_t i = 0; i < num_hash_functions_; ++i) {
+            size_t index = getHash(item, i);
+            if (counters_[index] < std::numeric_limits<CounterType>::max()) {
+                counters_[index]++;
+            }
+        }
+    }
+
+    // Might be present: true, Definitely not present: false
+    bool contains(const T& item) const {
+        for (size_t i = 0; i < num_hash_functions_; ++i) {
+            size_t index = getHash(item, i);
+            if (counters_[index] == 0) {
+                return false; // Definitely not present
+            }
+        }
+        return true; // Potentially present
+    }
+
+    // Returns true if item was potentially removed (all its counters were > 0)
+    // Returns false if item was definitely not present (at least one counter was 0)
+    bool remove(const T& item) {
+        // First check if the item could even be in the filter
+        // This avoids decrementing counters for items that were never added (or already fully removed)
+        // which could incorrectly affect other items if a counter hits zero prematurely.
+        if (!contains(item)) { // This check is important for correctness of subsequent 'contains'
+            return false;
+        }
+
+        bool potentially_removed = true;
+        for (size_t i = 0; i < num_hash_functions_; ++i) {
+            size_t index = getHash(item, i);
+            if (counters_[index] > 0) {
+                counters_[index]--;
+            } else {
+                // This case should ideally not be hit if `contains` passed and logic is correct,
+                // but as a safeguard for counter consistency.
+                // If a counter is already zero, it means the item effectively wasn't fully "present"
+                // according to this hash function, which is a bit of a state contradiction
+                // if contains() returned true. This implies a potential issue or a very full filter.
+                // For now, we'll just ensure it doesn't underflow.
+                potentially_removed = false; // Or handle as an error/warning
+            }
+        }
+        return potentially_removed; // More accurately, "attempted to remove"
+    }
+
+    size_t approxMemoryUsage() const {
+        return num_counters_ * sizeof(CounterType) + sizeof(*this);
+    }
+
+    size_t numCounters() const { return num_counters_; }
+    size_t numHashFunctions() const { return num_hash_functions_; }
+
+
+private:
+    std::vector<CounterType> counters_;
+    size_t num_counters_;
+    size_t num_hash_functions_;
+    Hasher hasher_;
+
+    // Generates the i-th hash value for the item.
+    // Uses Kirsch-Mitzenmacher optimization: h_i(x) = (hash_A(x) + i * hash_B(x)) % num_counters_
+    // For simplicity here, DefaultHash takes a seed. We use 'i' as part of the seed.
+    size_t getHash(const T& item, size_t i) const {
+        // Using 'i' as the seed for the DefaultHash to get distinct hash functions
+        return static_cast<size_t>(hasher_(item, static_cast<uint64_t>(i))) % num_counters_;
+    }
+};
+
+// Specialization of DefaultHash for std::string as an example
+template <>
+struct DefaultHash<std::string> {
+    uint64_t operator()(const std::string& item, uint64_t seed) const {
+        std::hash<std::string> str_hasher;
+        uint64_t h1 = str_hasher(item);
+
+        // Simple mixing with seed.
+        // For more robust hashing, consider combining two independent string hashes.
+        // e.g., h1 = primary_hash(item), h2 = secondary_hash(item)
+        // then hash(i) = (h1 + i * h2) % m
+        // Here, we use a simpler perturbation with seed.
+        uint64_t seed_mixer = seed * 0x9e3779b97f4a7c15ULL; // Golden ratio prime
+        return (h1 ^ seed_mixer) + seed; // Add seed to ensure different outputs for different i
+    }
+};
+
+
+} // namespace cpp_utils

--- a/include/skip_list.h
+++ b/include/skip_list.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <random>
+#include <limits> // For std::numeric_limits
+#include <functional> // For std::less
+
+namespace cpp_utils {
+
+template <typename Key, typename Value, typename Compare = std::less<Key>, int MAX_LEVEL = 16>
+class SkipList {
+private:
+    struct Node {
+        Key key;
+        Value value;
+        std::vector<std::shared_ptr<Node>> forward; // Pointers to next nodes at each level
+
+        Node(const Key& k, const Value& v, int level)
+            : key(k), value(v), forward(level + 1, nullptr) {}
+
+        Node(Key&& k, Value&& v, int level)
+            : key(std::move(k)), value(std::move(v)), forward(level + 1, nullptr) {}
+    };
+
+    std::shared_ptr<Node> head_;
+    int current_max_level_;
+    size_t size_;
+    Compare compare_;
+    std::mt19937 random_engine_; // For determining node levels
+
+    // Probability for a node to be promoted to the next level
+    // A common value is 0.5, meaning on average, half the nodes at level i
+    // also appear at level i+1.
+    // Or 0.25 for sparser higher levels. Let's use 0.5 for now.
+    const double PROBABILITY = 0.5;
+
+
+    int randomLevel() {
+        int lvl = 0;
+        // std::uniform_real_distribution<double> dist(0.0, 1.0);
+        // Using integer arithmetic for potentially better performance/simplicity
+        // equivalent to dist(random_engine_) < PROBABILITY
+        while ( (random_engine_() % 2 == 0) && lvl < MAX_LEVEL) {
+            lvl++;
+        }
+        return lvl;
+    }
+
+public:
+    SkipList() : current_max_level_(0), size_(0) {
+        // Initialize random engine with a seed
+        std::random_device rd;
+        random_engine_.seed(rd());
+
+        // Create a dummy head node with a sentinel key
+        // Assuming Key can be default-constructed or use a specific sentinel.
+        // For simplicity with templates, we might need to adjust how sentinel keys are handled.
+        // Using default constructed Key and Value for head.
+        // The level of the head node is MAX_LEVEL.
+        head_ = std::make_shared<Node>(Key{}, Value{}, MAX_LEVEL);
+    }
+
+    ~SkipList() = default;
+
+    SkipList(const SkipList&) = delete; // For simplicity, disable copy
+    SkipList& operator=(const SkipList&) = delete; // For simplicity, disable copy assignment
+
+    SkipList(SkipList&&) noexcept = default;
+    SkipList& operator=(SkipList&&) noexcept = default;
+
+
+    // --- Public API to be implemented ---
+
+    bool insert(const Key& key, const Value& value) {
+        return insertOrUpdate(key, value);
+    }
+
+    bool insert(Key&& key, Value&& value) {
+        return insertOrUpdate(std::move(key), std::move(value));
+    }
+
+private:
+    template<typename K, typename V>
+    bool insertOrUpdate(K&& key_param, V&& value_param) {
+        std::vector<std::shared_ptr<Node>> update(MAX_LEVEL + 1, nullptr);
+        std::shared_ptr<Node> current = head_;
+
+        for (int i = current_max_level_; i >= 0; --i) {
+            while (current->forward[i] && compare_(current->forward[i]->key, key_param)) {
+                current = current->forward[i];
+            }
+            update[i] = current;
+        }
+
+        // current is now the node just before the potential position of key_param at level 0
+        // Move to the node that might contain key_param
+        current = current->forward[0];
+
+        // Check if key already exists
+        if (current && !compare_(key_param, current->key) && !compare_(current->key, key_param)) { // equivalent to current->key == key_param
+            current->value = std::forward<V>(value_param); // Update existing value
+            return true; // Indicates update
+        } else {
+            // Key does not exist, proceed with insertion
+            int new_level = randomLevel();
+
+            if (new_level > current_max_level_) {
+                for (int i = current_max_level_ + 1; i <= new_level; ++i) {
+                    update[i] = head_; // New levels point back to head
+                }
+                current_max_level_ = new_level;
+            }
+
+            auto new_node = std::make_shared<Node>(std::forward<K>(key_param), std::forward<V>(value_param), new_level);
+
+            for (int i = 0; i <= new_level; ++i) {
+                new_node->forward[i] = update[i]->forward[i];
+                update[i]->forward[i] = new_node;
+            }
+            size_++;
+            return true; // Indicates insertion
+        }
+    }
+
+public:
+    // std::optional<Value> find(const Key& key) const;
+    // bool contains(const Key& key) const;
+
+    // bool erase(const Key& key);
+
+    // size_t size() const { return size_; }
+    // bool empty() const { return size_ == 0; }
+    // int currentMaxLevel() const { return current_max_level_; } // For debugging/testing
+
+    // --- Iterator support (optional, for later) ---
+    // class Iterator { ... };
+    // Iterator begin();
+    // Iterator end();
+};
+
+} // namespace cpp_utils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         GraphLib # Added for graph_test
         TreapLib # Added for treap_test
         CountMinSketchLib # Added for count_min_sketch_test
+        CountingBloomFilterLib
     )
 
     # Specific configurations for certain tests

--- a/tests/counting_bloom_filter_test.cpp
+++ b/tests/counting_bloom_filter_test.cpp
@@ -1,0 +1,202 @@
+#include "counting_bloom_filter.h"
+#include "gtest/gtest.h"
+#include <string>
+#include <vector>
+#include <set>
+
+// Using the cpp_utils namespace
+using namespace cpp_utils;
+
+// Test fixture for CountingBloomFilter
+class CountingBloomFilterTest : public ::testing::Test {
+protected:
+    // Per-test set-up and tear-down can be done here if needed
+};
+
+TEST_F(CountingBloomFilterTest, ConstructorValidation) {
+    EXPECT_THROW(CountingBloomFilter<int>(0, 0.1), std::invalid_argument);
+    EXPECT_THROW(CountingBloomFilter<int>(100, 0.0), std::invalid_argument);
+    EXPECT_THROW(CountingBloomFilter<int>(100, 1.0), std::invalid_argument);
+    EXPECT_NO_THROW(CountingBloomFilter<int>(100, 0.01));
+}
+
+TEST_F(CountingBloomFilterTest, BasicAddContainsInt) {
+    CountingBloomFilter<int> cbf(100, 0.01);
+    cbf.add(42);
+    EXPECT_TRUE(cbf.contains(42));
+    EXPECT_FALSE(cbf.contains(43));
+
+    cbf.add(100);
+    EXPECT_TRUE(cbf.contains(100));
+    EXPECT_TRUE(cbf.contains(42)); // Still there
+    EXPECT_FALSE(cbf.contains(101));
+}
+
+TEST_F(CountingBloomFilterTest, BasicAddContainsString) {
+    CountingBloomFilter<std::string> cbf(100, 0.01);
+    cbf.add("hello");
+    EXPECT_TRUE(cbf.contains("hello"));
+    EXPECT_FALSE(cbf.contains("world"));
+
+    cbf.add("world");
+    EXPECT_TRUE(cbf.contains("world"));
+    EXPECT_TRUE(cbf.contains("hello"));
+    EXPECT_FALSE(cbf.contains("test"));
+}
+
+TEST_F(CountingBloomFilterTest, RemoveInt) {
+    CountingBloomFilter<int> cbf(100, 0.01);
+    cbf.add(42);
+    cbf.add(100);
+
+    EXPECT_TRUE(cbf.contains(42));
+    EXPECT_TRUE(cbf.remove(42)); // Remove existing
+    EXPECT_FALSE(cbf.contains(42)); // Should be gone (high probability for small test)
+
+    EXPECT_TRUE(cbf.contains(100)); // Other item still there
+    EXPECT_FALSE(cbf.remove(999));   // Try removing non-existent
+    EXPECT_TRUE(cbf.contains(100)); // Still there
+}
+
+TEST_F(CountingBloomFilterTest, RemoveString) {
+    CountingBloomFilter<std::string> cbf(100, 0.01);
+    cbf.add("apple");
+    cbf.add("banana");
+
+    EXPECT_TRUE(cbf.contains("apple"));
+    EXPECT_TRUE(cbf.remove("apple"));
+    EXPECT_FALSE(cbf.contains("apple"));
+
+    EXPECT_TRUE(cbf.contains("banana"));
+    EXPECT_FALSE(cbf.remove("orange"));
+    EXPECT_TRUE(cbf.contains("banana"));
+}
+
+TEST_F(CountingBloomFilterTest, MultipleAddsAndRemoves) {
+    CountingBloomFilter<int> cbf(100, 0.01);
+    cbf.add(10);
+    cbf.add(10); // Add same item multiple times
+    cbf.add(20);
+
+    EXPECT_TRUE(cbf.contains(10));
+    EXPECT_TRUE(cbf.contains(20));
+
+    EXPECT_TRUE(cbf.remove(10)); // First remove
+    EXPECT_TRUE(cbf.contains(10)); // Should still be "present" due to second add
+
+    EXPECT_TRUE(cbf.remove(10)); // Second remove
+    EXPECT_FALSE(cbf.contains(10)); // Now should be gone
+
+    EXPECT_TRUE(cbf.contains(20));
+    EXPECT_TRUE(cbf.remove(20));
+    EXPECT_FALSE(cbf.contains(20));
+}
+
+TEST_F(CountingBloomFilterTest, CounterSaturation) {
+    // Using uint8_t counters, max value 255
+    CountingBloomFilter<int, uint8_t> cbf(10, 0.01); // Small capacity
+
+    // Add item more than 255 times to saturate counters
+    for (int i = 0; i < 300; ++i) {
+        cbf.add(77);
+    }
+    EXPECT_TRUE(cbf.contains(77)) << "Item should be present after 300 adds.";
+
+    // Remove 254 times. Item should still be present as counters go from 255 down to 1.
+    for (int i = 0; i < 254; ++i) {
+        EXPECT_TRUE(cbf.remove(77)) << "Remove #" << i + 1 << " should succeed.";
+        EXPECT_TRUE(cbf.contains(77)) << "Contained after " << i + 1 << " removes.";
+    }
+
+    // The 255th remove. Counters for item 77 should go from 1 to 0.
+    // remove() should still return true because it was contained before this remove.
+    EXPECT_TRUE(cbf.remove(77)) << "255th remove should succeed.";
+    // After this remove, the item should no longer be contained.
+    EXPECT_FALSE(cbf.contains(77)) << "Not contained after 255 removes (counters are now 0).";
+
+    // Attempting to remove again should return false (as item is no longer contained based on the initial check in remove())
+    EXPECT_FALSE(cbf.remove(77)) << "256th remove should fail (item not present).";
+    EXPECT_FALSE(cbf.contains(77)) << "Still not contained after attempting 256th remove.";
+}
+
+
+TEST_F(CountingBloomFilterTest, FalsePositiveRateSmokeTest) {
+    // This is a smoke test, not a statistically rigorous FP rate test.
+    // A true FP rate test would require many more items and queries.
+    int num_insertions = 1000;
+    double fp_rate = 0.01;
+    CountingBloomFilter<int> cbf(num_insertions, fp_rate);
+
+    std::set<int> added_items;
+    for (int i = 0; i < num_insertions; ++i) {
+        cbf.add(i);
+        added_items.insert(i);
+    }
+
+    int false_positives = 0;
+    int queries = 0;
+    for (int i = num_insertions; i < num_insertions * 2; ++i) {
+        if (added_items.find(i) == added_items.end()) { // Ensure it wasn't actually added
+            queries++;
+            if (cbf.contains(i)) {
+                false_positives++;
+            }
+        }
+    }
+
+    // For a small number of queries, the actual FP might deviate.
+    // We expect it to be roughly around fp_rate * queries.
+    // This test primarily ensures it's not excessively high.
+    // Allow some leeway, e.g., up to 2x or 3x the expected for a smoke test.
+    double observed_fp_rate = static_cast<double>(false_positives) / queries;
+    EXPECT_LT(observed_fp_rate, fp_rate * 3.0 + 0.05) // +0.05 for small query sets
+        << "Observed FP rate " << observed_fp_rate
+        << " vs expected " << fp_rate
+        << " (False Positives: " << false_positives << "/" << queries << ")";
+    // Also check it's not zero if fp_rate > 0, which would be suspicious for a Bloom filter
+    if (fp_rate > 0 && num_insertions > 100) { // Only if FPs are actually expected
+         // It's possible, though unlikely with 1000 queries, to get 0 FPs if k or m is large.
+         // This is a loose check.
+         // EXPECT_GT(false_positives, 0) << "Expected some false positives with this configuration.";
+    }
+    std::cout << "FP Smoke Test: " << false_positives << " FPs in " << queries << " queries for items not added. (Rate: " << observed_fp_rate << ")" << std::endl;
+}
+
+TEST_F(CountingBloomFilterTest, DifferentCounterType) {
+    CountingBloomFilter<std::string, uint16_t> cbf(50, 0.05);
+    cbf.add("test_item");
+    EXPECT_TRUE(cbf.contains("test_item"));
+    cbf.remove("test_item");
+    EXPECT_FALSE(cbf.contains("test_item"));
+}
+
+TEST_F(CountingBloomFilterTest, RemoveCorrectnessAfterMultipleAdds) {
+    CountingBloomFilter<int> cbf(100, 0.01);
+    cbf.add(1);
+    cbf.add(1);
+    cbf.add(2);
+    cbf.add(1); // Item 1 added 3 times
+
+    EXPECT_TRUE(cbf.contains(1));
+    EXPECT_TRUE(cbf.contains(2));
+
+    cbf.remove(1); // Remove 1 (1st time)
+    EXPECT_TRUE(cbf.contains(1)); // Still there
+
+    cbf.remove(2); // Remove 2 (1st time)
+    EXPECT_FALSE(cbf.contains(2)); // Should be gone
+
+    cbf.remove(1); // Remove 1 (2nd time)
+    EXPECT_TRUE(cbf.contains(1)); // Still there
+
+    cbf.remove(1); // Remove 1 (3rd time)
+    EXPECT_FALSE(cbf.contains(1)); // Should be gone now
+
+    EXPECT_FALSE(cbf.remove(1)); // Try removing again
+    EXPECT_FALSE(cbf.remove(2)); // Try removing again
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This commit introduces a Counting Bloom Filter data structure.

Features:
- Supports `add`, `contains`, and `remove` operations.
- `remove` operation correctly decrements counters and handles saturation.
- Configurable via expected number of insertions and desired false positive rate.
- Counter type is templated, defaulting to `uint8_t`.
- Includes a basic hash functor `DefaultHash<T>` which can be specialized.

Includes:
- Implementation: `include/counting_bloom_filter.h`
- Unit Tests: `tests/counting_bloom_filter_test.cpp`
- Example Usage: `examples/counting_bloom_filter_example.cpp`
- Documentation: `docs/README_CountingBloomFilter.md`

The build system (CMakeLists.txt files) has been updated to incorporate these new files. All tests related to the Counting Bloom Filter are passing.