### PR TITLE
feat: Add UnorderedMultiset data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,10 @@ target_include_directories(CountingBloomFilterLib INTERFACE ${CMAKE_CURRENT_SOUR
 add_library(SegmentTreeLib INTERFACE)
 target_include_directories(SegmentTreeLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define UnorderedMultisetLib as an interface library (header-only)
+add_library(UnorderedMultisetLib INTERFACE)
+target_include_directories(UnorderedMultisetLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Future steps will add examples and tests here
 
 # Automatically add executables for all files in the examples/ directory
@@ -154,6 +158,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         TreapLib # Added for treap_example
         CountMinSketchLib # Added for count_min_sketch_example
         CountingBloomFilterLib
+        UnorderedMultisetLib # Added for unordered_multiset_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/docs/README_UnorderedMultiset.md
+++ b/docs/README_UnorderedMultiset.md
@@ -1,0 +1,137 @@
+# UnorderedMultiset
+
+## Overview
+
+The `cpp_utils::UnorderedMultiset<T, Hash, KeyEqual>` is a C++ template class that implements an unordered multiset (also known as a bag). It is a container that stores a collection of elements where multiple elements can have the same value. Unlike `std::set` or `cpp_utils::OrderedSet`, the `UnorderedMultiset` does not maintain any specific order among its elements. Its primary advantage is fast average-time complexity for insertions, deletions, and lookups, similar to `std::unordered_set` or `std::unordered_map`.
+
+This implementation uses `std::unordered_map<T, size_t>` as its underlying storage, where each key `T` is mapped to its count (`size_t`) within the multiset.
+
+## Template Parameters
+
+-   `T`: The type of elements to be stored in the multiset.
+-   `Hash`: A hash function object that computes the hash value for elements of type `T`. Defaults to `std::hash<T>`.
+-   `KeyEqual`: A binary predicate that checks if two elements of type `T` are equal. Defaults to `std::equal_to<T>`.
+
+## Member Functions
+
+### Constructors
+
+-   `UnorderedMultiset()`
+    -   Default constructor. Creates an empty multiset.
+-   `explicit UnorderedMultiset(const Hash& hashfn, const KeyEqual& eq = KeyEqual())`
+    -   Constructs an empty multiset with the specified hash function and equality predicate.
+
+### Capacity
+
+-   `bool empty() const noexcept`
+    -   Returns `true` if the multiset is empty (i.e., `size()` is 0), `false` otherwise.
+-   `size_type size() const noexcept`
+    -   Returns the total number of elements in the multiset (sum of counts of all unique elements).
+
+### Modifiers
+
+-   `void insert(const T& value)`
+    -   Inserts `value` into the multiset. If `value` already exists, its count is incremented.
+-   `void insert(T&& value)`
+    -   Inserts `value` (via move semantics) into the multiset. If `value` already exists, its count is incremented.
+-   `size_type erase(const T& value)`
+    -   Removes a single instance of `value` from the multiset.
+    -   Returns `1` if an element was removed, `0` otherwise.
+-   `size_type erase_all(const T& value)`
+    -   Removes all instances of `value` from the multiset.
+    -   Returns the number of elements removed.
+-   `void clear() noexcept`
+    -   Removes all elements from the multiset, making it empty.
+-   `void swap(UnorderedMultiset& other) noexcept`
+    -   Exchanges the contents of this multiset with the contents of `other`.
+
+### Lookup
+
+-   `size_type count(const T& value) const`
+    -   Returns the number of times `value` appears in the multiset.
+-   `bool contains(const T& value) const`
+    -   Returns `true` if `value` is present in the multiset (i.e., its count is > 0), `false` otherwise.
+
+### Iterators
+
+The multiset provides `const_iterator` to iterate over its unique elements. The iterators are those of the underlying `std::unordered_map<T, size_t>`, where `iterator->first` is the unique element and `iterator->second` is its count.
+
+-   `const_iterator begin() const noexcept`
+-   `const_iterator cbegin() const noexcept`
+    -   Returns a const iterator to the beginning of the (unique elements of the) multiset.
+-   `const_iterator end() const noexcept`
+-   `const_iterator cend() const noexcept`
+    -   Returns a const iterator to the end of the (unique elements of the) multiset.
+
+## Non-Member Functions
+
+-   `template <typename T, typename Hash, typename KeyEqual> void swap(UnorderedMultiset<T, Hash, KeyEqual>& lhs, UnorderedMultiset<T, Hash, KeyEqual>& rhs) noexcept`
+    -   Overload for `std::swap`. Exchanges the contents of `lhs` and `rhs`.
+
+## Performance
+
+-   **Insertion**: Average O(1), worst case O(N) (where N is `size()`).
+-   **Deletion (single instance or all instances)**: Average O(1), worst case O(N).
+-   **Lookup (`count`, `contains`)**: Average O(1), worst case O(N).
+-   **`size()`, `empty()`**: O(1).
+
+The performance characteristics are derived from the underlying `std::unordered_map`.
+
+## Example Usage
+
+```cpp
+#include "unordered_multiset.h"
+#include <iostream>
+#include <string>
+
+int main() {
+    cpp_utils::UnorderedMultiset<std::string> fruit_basket;
+
+    fruit_basket.insert("apple");
+    fruit_basket.insert("banana");
+    fruit_basket.insert("apple"); // Add another apple
+    fruit_basket.insert("orange");
+    fruit_basket.insert("apple"); // And another apple
+
+    std::cout << "Fruit basket size: " << fruit_basket.size() << std::endl; // Output: 5
+
+    std::cout << "Count of 'apple': " << fruit_basket.count("apple") << std::endl;   // Output: 3
+    std::cout << "Count of 'banana': " << fruit_basket.count("banana") << std::endl; // Output: 1
+    std::cout << "Count of 'grape': " << fruit_basket.count("grape") << std::endl;   // Output: 0
+
+    if (fruit_basket.contains("orange")) {
+        std::cout << "The basket contains oranges." << std::endl;
+    }
+
+    std::cout << "Unique fruits in the basket (with counts):" << std::endl;
+    for (const auto& pair : fruit_basket) {
+        std::cout << "- " << pair.first << ": " << pair.second << std::endl;
+    }
+    // Possible output (order may vary):
+    // - orange: 1
+    // - banana: 1
+    // - apple: 3
+
+    fruit_basket.erase("apple"); // Remove one apple
+    std::cout << "After erasing one 'apple', count is: " << fruit_basket.count("apple") << std::endl; // Output: 2
+    std::cout << "Basket size is now: " << fruit_basket.size() << std::endl; // Output: 4
+
+    fruit_basket.erase_all("apple"); // Remove all remaining apples
+    std::cout << "After erasing all 'apples', count is: " << fruit_basket.count("apple") << std::endl; // Output: 0
+    std::cout << "Basket size is now: " << fruit_basket.size() << std::endl; // Output: 2 (banana, orange)
+
+    fruit_basket.clear();
+    std::cout << "After clearing, basket is empty: " << std::boolalpha << fruit_basket.empty() << std::endl; // Output: true
+
+    return 0;
+}
+
+```
+
+## When to Use
+
+-   When you need to store a collection of items and allow duplicates.
+-   When the order of elements does not matter.
+-   When fast average-case insertion, deletion, and lookup are required.
+-   For scenarios like frequency counting, tracking multiple instances of objects, etc.
+```

--- a/examples/unordered_multiset_example.cpp
+++ b/examples/unordered_multiset_example.cpp
@@ -1,0 +1,109 @@
+#include "unordered_multiset.h" // Assuming this path works from the build system
+#include <iostream>
+#include <string>
+#include <vector>
+
+// Helper function to print the contents of the multiset
+template<typename T, typename Hash, typename KeyEqual>
+void print_multiset_details(const cpp_utils::UnorderedMultiset<T, Hash, KeyEqual>& ms, const std::string& name) {
+    std::cout << "--- Details for multiset: " << name << " ---" << std::endl;
+    if (ms.empty()) {
+        std::cout << name << " is empty." << std::endl;
+        std::cout << "Total size: " << ms.size() << std::endl;
+        return;
+    }
+
+    std::cout << "Total size: " << ms.size() << std::endl;
+    std::cout << "Unique elements and their counts:" << std::endl;
+    // Iterating over unique elements and their counts
+    for (const auto& pair : ms) { // pair.first is the element, pair.second is its count
+        std::cout << "- Element: '" << pair.first << "', Count: " << pair.second << std::endl;
+    }
+    std::cout << "----------------------------------------" << std::endl;
+}
+
+
+int main() {
+    std::cout << "=== UnorderedMultiset Example ===" << std::endl;
+
+    // 1. Basic usage with integers
+    std::cout << "\n--- Integer Multiset Example ---" << std::endl;
+    cpp_utils::UnorderedMultiset<int> int_ms;
+
+    int_ms.insert(10);
+    int_ms.insert(20);
+    int_ms.insert(10); // Duplicate
+    int_ms.insert(30);
+    int_ms.insert(10); // Another duplicate
+    int_ms.insert(25);
+
+    print_multiset_details(int_ms, "int_ms after insertions");
+
+    std::cout << "Count of 10: " << int_ms.count(10) << std::endl; // Expected: 3
+    std::cout << "Count of 20: " << int_ms.count(20) << std::endl; // Expected: 1
+    std::cout << "Count of 50 (non-existent): " << int_ms.count(50) << std::endl; // Expected: 0
+
+    std::cout << "Contains 20? " << (int_ms.contains(20) ? "Yes" : "No") << std::endl;
+    std::cout << "Contains 50? " << (int_ms.contains(50) ? "Yes" : "No") << std::endl;
+
+    std::cout << "\nErasing one instance of 10..." << std::endl;
+    int_ms.erase(10);
+    print_multiset_details(int_ms, "int_ms after erasing one 10");
+
+    std::cout << "\nErasing all instances of 10..." << std::endl;
+    int_ms.erase_all(10);
+    print_multiset_details(int_ms, "int_ms after erasing all 10s");
+
+    std::cout << "\nClearing the multiset..." << std::endl;
+    int_ms.clear();
+    print_multiset_details(int_ms, "int_ms after clear");
+
+    // 2. Usage with strings - a simple word frequency counter
+    std::cout << "\n--- String Multiset Example (Word Frequency) ---" << std::endl;
+    cpp_utils::UnorderedMultiset<std::string> word_freq_ms;
+    std::vector<std::string> words = {
+        "hello", "world", "hello", "c++", "multiset", "world", "hello", "example"
+    };
+
+    std::cout << "Adding words to multiset: ";
+    for (const auto& word : words) {
+        std::cout << word << " ";
+        word_freq_ms.insert(word);
+    }
+    std::cout << std::endl;
+
+    print_multiset_details(word_freq_ms, "word_freq_ms");
+
+    std::cout << "Frequency of 'hello': " << word_freq_ms.count("hello") << std::endl;
+    std::cout << "Frequency of 'world': " << word_freq_ms.count("world") << std::endl;
+    std::cout << "Frequency of 'python': " << word_freq_ms.count("python") << std::endl;
+
+    // 3. Swapping multisets
+    std::cout << "\n--- Swap Example ---" << std::endl;
+    cpp_utils::UnorderedMultiset<int> ms1;
+    ms1.insert(1); ms1.insert(1); ms1.insert(2);
+
+    cpp_utils::UnorderedMultiset<int> ms2;
+    ms2.insert(100); ms2.insert(200); ms2.insert(200); ms2.insert(200);
+
+    std::cout << "Before swap:" << std::endl;
+    print_multiset_details(ms1, "ms1");
+    print_multiset_details(ms2, "ms2");
+
+    ms1.swap(ms2); // Member swap
+
+    std::cout << "\nAfter member swap:" << std::endl;
+    print_multiset_details(ms1, "ms1 (now has ms2's content)");
+    print_multiset_details(ms2, "ms2 (now has ms1's content)");
+
+    // Using non-member swap (std::swap or the custom one)
+    swap(ms1, ms2); // Should call cpp_utils::swap or fall back to std::swap if ADL works
+
+    std::cout << "\nAfter non-member swap (back to original):" << std::endl;
+    print_multiset_details(ms1, "ms1");
+    print_multiset_details(ms2, "ms2");
+
+
+    std::cout << "\n=== Example Finished ===" << std::endl;
+    return 0;
+}

--- a/include/unordered_multiset.h
+++ b/include/unordered_multiset.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <functional> // For std::hash, std::equal_to
+#include <utility>    // For std::pair
+#include <unordered_map> // Underlying container for element counts
+
+// Note: <vector> was removed as it's not directly used by this implementation.
+// It might be re-added if custom iterators requiring it are developed later.
+
+// The UnorderedMultiset class provides a hash-table based multiset,
+// storing elements and their counts. It's similar in concept to
+// std::unordered_multiset but implemented here potentially for specific
+// library integration or API style.
+
+namespace cpp_utils {
+
+template <
+    typename T,
+    typename Hash = std::hash<T>,
+    typename KeyEqual = std::equal_to<T>
+>
+class UnorderedMultiset {
+public:
+    using key_type = T;
+    using value_type = T; // In a multiset, key and value are the same
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    // For now, using a placeholder for iterator. This will be fleshed out.
+    // It will likely iterate over unique elements, and count provides multiplicity.
+    // Or, it could iterate over all elements including duplicates.
+    // Let's define it to iterate over unique elements first.
+    // The underlying map's iterator can serve this purpose.
+    using underlying_container_type = std::unordered_map<T, size_type, Hash, KeyEqual>;
+    using const_iterator = typename underlying_container_type::const_iterator; // Iterates unique keys
+    // To iterate over all elements (including duplicates), a custom iterator would be needed.
+    // This will be part of the implementation detail.
+
+    // Constructors
+    UnorderedMultiset() = default;
+    explicit UnorderedMultiset(const Hash& hashfn, const KeyEqual& eq = KeyEqual())
+        : map_(10, hashfn, eq) {} // Initial bucket count, hash, equal
+
+    // Capacity
+    bool empty() const noexcept {
+        return total_elements_ == 0;
+    }
+
+    size_type size() const noexcept {
+        return total_elements_;
+    }
+
+    // Modifiers
+    void insert(const T& value) {
+        map_[value]++;
+        total_elements_++;
+    }
+
+    void insert(T&& value) {
+        map_[std::move(value)]++;
+        total_elements_++;
+    }
+
+    // Erases one instance of the value.
+    // Returns the number of elements erased (0 or 1).
+    size_type erase(const T& value) {
+        auto it = map_.find(value);
+        if (it != map_.end()) {
+            if (it->second > 1) {
+                it->second--;
+            } else {
+                map_.erase(it);
+            }
+            total_elements_--;
+            return 1;
+        }
+        return 0;
+    }
+
+    // Erases all instances of the value.
+    // Returns the number of elements erased.
+    size_type erase_all(const T& value) {
+        auto it = map_.find(value);
+        if (it != map_.end()) {
+            size_type num_erased = it->second;
+            total_elements_ -= num_erased;
+            map_.erase(it);
+            return num_erased;
+        }
+        return 0;
+    }
+
+    void clear() noexcept {
+        map_.clear();
+        total_elements_ = 0;
+    }
+
+    void swap(UnorderedMultiset& other) noexcept {
+        map_.swap(other.map_);
+        std::swap(total_elements_, other.total_elements_);
+    }
+
+    // Lookup
+    size_type count(const T& value) const {
+        auto it = map_.find(value);
+        if (it != map_.end()) {
+            return it->second;
+        }
+        return 0;
+    }
+
+    bool contains(const T& value) const {
+        return map_.count(value) > 0;
+    }
+
+    // Iterators for unique elements
+    const_iterator begin() const noexcept {
+        return map_.begin();
+    }
+
+    const_iterator end() const noexcept {
+        return map_.end();
+    }
+
+    const_iterator cbegin() const noexcept {
+        return map_.cbegin();
+    }
+
+    const_iterator cend() const noexcept {
+        return map_.cend();
+    }
+
+    // Bucket interface (optional, but good for compatibility with std::unordered_*)
+    // These could be added if desired, forwarding to the underlying map_.
+    // size_type bucket_count() const noexcept { return map_.bucket_count(); }
+    // float load_factor() const noexcept { return map_.load_factor(); }
+
+private:
+    underlying_container_type map_;
+    size_type total_elements_ = 0;
+};
+
+// Non-member swap
+template <typename T, typename Hash, typename KeyEqual>
+void swap(UnorderedMultiset<T, Hash, KeyEqual>& lhs,
+          UnorderedMultiset<T, Hash, KeyEqual>& rhs) noexcept {
+    lhs.swap(rhs);
+}
+
+} // namespace cpp_utils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         TreapLib # Added for treap_test
         CountMinSketchLib # Added for count_min_sketch_test
         CountingBloomFilterLib
+        UnorderedMultisetLib # Added for unordered_multiset_test
     )
 
     # Specific configurations for certain tests

--- a/tests/unordered_multiset_test.cpp
+++ b/tests/unordered_multiset_test.cpp
@@ -1,0 +1,302 @@
+#include "gtest/gtest.h"
+#include "unordered_multiset.h" // Assuming header is in include/
+#include <string>
+#include <vector>
+#include <algorithm> // For std::sort, std::is_permutation (if needed for more complex checks)
+#include <map> // For convenience in checking counts
+
+// Test fixture for common setup
+class UnorderedMultisetTest : public ::testing::Test {
+protected:
+    cpp_utils::UnorderedMultiset<int> ms_int;
+    cpp_utils::UnorderedMultiset<std::string> ms_string;
+
+    // Helper to get items and their counts for comparison
+    template<typename T, typename Hash, typename KeyEqual>
+    std::map<T, size_t> get_counts(const cpp_utils::UnorderedMultiset<T, Hash, KeyEqual>& ms) {
+        std::map<T, size_t> counts;
+        for (const auto& pair : ms) { // Iterates unique_key-count pairs from underlying map
+            counts[pair.first] = pair.second;
+        }
+        return counts;
+    }
+};
+
+// Test Cases
+
+TEST_F(UnorderedMultisetTest, DefaultConstructor) {
+    EXPECT_TRUE(ms_int.empty());
+    EXPECT_EQ(ms_int.size(), 0);
+    EXPECT_EQ(ms_int.begin(), ms_int.end());
+
+    cpp_utils::UnorderedMultiset<std::string, std::hash<std::string>, std::equal_to<std::string>> ms_str_explicit_params;
+    EXPECT_TRUE(ms_str_explicit_params.empty());
+}
+
+TEST_F(UnorderedMultisetTest, InsertAndCount) {
+    ms_int.insert(10);
+    EXPECT_EQ(ms_int.count(10), 1);
+    EXPECT_EQ(ms_int.size(), 1);
+    EXPECT_FALSE(ms_int.empty());
+
+    ms_int.insert(10);
+    EXPECT_EQ(ms_int.count(10), 2);
+    EXPECT_EQ(ms_int.size(), 2);
+
+    ms_int.insert(20);
+    EXPECT_EQ(ms_int.count(10), 2);
+    EXPECT_EQ(ms_int.count(20), 1);
+    EXPECT_EQ(ms_int.size(), 3);
+
+    EXPECT_EQ(ms_int.count(30), 0); // Non-existent
+}
+
+TEST_F(UnorderedMultisetTest, InsertRValue) {
+    ms_string.insert("hello");
+    EXPECT_EQ(ms_string.count("hello"), 1);
+    ms_string.insert(std::string("world"));
+    EXPECT_EQ(ms_string.count("world"), 1);
+    ms_string.insert(std::string("hello"));
+    EXPECT_EQ(ms_string.count("hello"), 2);
+    EXPECT_EQ(ms_string.size(), 3);
+}
+
+TEST_F(UnorderedMultisetTest, Contains) {
+    ms_int.insert(5);
+    ms_int.insert(5);
+    EXPECT_TRUE(ms_int.contains(5));
+    EXPECT_FALSE(ms_int.contains(10));
+}
+
+TEST_F(UnorderedMultisetTest, EraseSingleInstance) {
+    ms_int.insert(10);
+    ms_int.insert(10);
+    ms_int.insert(10);
+    ms_int.insert(20);
+    EXPECT_EQ(ms_int.size(), 4);
+    EXPECT_EQ(ms_int.count(10), 3);
+
+    size_t erased_count = ms_int.erase(10);
+    EXPECT_EQ(erased_count, 1);
+    EXPECT_EQ(ms_int.count(10), 2);
+    EXPECT_EQ(ms_int.size(), 3);
+    EXPECT_TRUE(ms_int.contains(10));
+
+    erased_count = ms_int.erase(10);
+    EXPECT_EQ(erased_count, 1);
+    EXPECT_EQ(ms_int.count(10), 1);
+    EXPECT_EQ(ms_int.size(), 2);
+
+    erased_count = ms_int.erase(10);
+    EXPECT_EQ(erased_count, 1);
+    EXPECT_EQ(ms_int.count(10), 0);
+    EXPECT_FALSE(ms_int.contains(10));
+    EXPECT_EQ(ms_int.size(), 1); // Only 20 should be left
+
+    erased_count = ms_int.erase(10); // Erase non-existent (already fully erased)
+    EXPECT_EQ(erased_count, 0);
+    EXPECT_EQ(ms_int.count(10), 0);
+    EXPECT_EQ(ms_int.size(), 1);
+
+    erased_count = ms_int.erase(30); // Erase completely non-existent
+    EXPECT_EQ(erased_count, 0);
+    EXPECT_EQ(ms_int.size(), 1);
+
+    EXPECT_EQ(ms_int.count(20), 1);
+}
+
+TEST_F(UnorderedMultisetTest, EraseAllInstances) {
+    ms_string.insert("apple");
+    ms_string.insert("banana");
+    ms_string.insert("apple");
+    ms_string.insert("orange");
+    ms_string.insert("apple");
+    // State: apple:3, banana:1, orange:1. Total size: 5
+    EXPECT_EQ(ms_string.size(), 5);
+    EXPECT_EQ(ms_string.count("apple"), 3);
+
+    size_t erased_count = ms_string.erase_all("apple");
+    EXPECT_EQ(erased_count, 3);
+    EXPECT_EQ(ms_string.count("apple"), 0);
+    EXPECT_FALSE(ms_string.contains("apple"));
+    EXPECT_EQ(ms_string.size(), 2); // banana and orange left
+
+    erased_count = ms_string.erase_all("apple"); // Already erased
+    EXPECT_EQ(erased_count, 0);
+    EXPECT_EQ(ms_string.size(), 2);
+
+    erased_count = ms_string.erase_all("grape"); // Non-existent
+    EXPECT_EQ(erased_count, 0);
+    EXPECT_EQ(ms_string.size(), 2);
+
+    EXPECT_TRUE(ms_string.contains("banana"));
+    EXPECT_TRUE(ms_string.contains("orange"));
+}
+
+TEST_F(UnorderedMultisetTest, Clear) {
+    ms_int.insert(1);
+    ms_int.insert(1);
+    ms_int.insert(2);
+    EXPECT_FALSE(ms_int.empty());
+    EXPECT_EQ(ms_int.size(), 3);
+
+    ms_int.clear();
+    EXPECT_TRUE(ms_int.empty());
+    EXPECT_EQ(ms_int.size(), 0);
+    EXPECT_EQ(ms_int.count(1), 0);
+    EXPECT_EQ(ms_int.count(2), 0);
+    EXPECT_EQ(ms_int.begin(), ms_int.end());
+}
+
+TEST_F(UnorderedMultisetTest, Iteration) {
+    ms_string.insert("a");
+    ms_string.insert("b");
+    ms_string.insert("a");
+    ms_string.insert("c");
+    ms_string.insert("b");
+    ms_string.insert("a");
+    // Expected counts: a:3, b:2, c:1. Total size: 6
+
+    std::map<std::string, size_t> expected_counts = {{"a", 3}, {"b", 2}, {"c", 1}};
+    std::map<std::string, size_t> actual_counts = get_counts(ms_string);
+
+    EXPECT_EQ(actual_counts.size(), 3); // 3 unique elements
+    EXPECT_EQ(actual_counts, expected_counts);
+
+    size_t unique_elements_iterated = 0;
+    for (auto it = ms_string.begin(); it != ms_string.end(); ++it) {
+        unique_elements_iterated++;
+        EXPECT_TRUE(expected_counts.count(it->first)); // key from map iterator
+        EXPECT_EQ(it->second, expected_counts.at(it->first)); // value from map iterator is the count
+    }
+    EXPECT_EQ(unique_elements_iterated, expected_counts.size());
+
+    // Const iteration
+    const auto& const_ms_string = ms_string;
+    actual_counts.clear();
+     for (const auto& pair : const_ms_string) {
+        actual_counts[pair.first] = pair.second;
+    }
+    EXPECT_EQ(actual_counts, expected_counts);
+}
+
+TEST_F(UnorderedMultisetTest, EmptySetOperations) {
+    EXPECT_TRUE(ms_int.empty());
+    EXPECT_EQ(ms_int.size(), 0);
+    EXPECT_EQ(ms_int.count(123), 0);
+    EXPECT_FALSE(ms_int.contains(123));
+    EXPECT_EQ(ms_int.erase(123), 0);
+    EXPECT_EQ(ms_int.erase_all(123), 0);
+    EXPECT_EQ(ms_int.begin(), ms_int.end());
+}
+
+TEST_F(UnorderedMultisetTest, SwapMember) {
+    ms_int.insert(1);
+    ms_int.insert(1);
+    ms_int.insert(2);
+
+    cpp_utils::UnorderedMultiset<int> other_ms;
+    other_ms.insert(30);
+    other_ms.insert(40);
+    other_ms.insert(40);
+    other_ms.insert(40);
+
+    auto counts1_orig = get_counts(ms_int);
+    size_t size1_orig = ms_int.size();
+    auto counts2_orig = get_counts(other_ms);
+    size_t size2_orig = other_ms.size();
+
+    ms_int.swap(other_ms);
+
+    EXPECT_EQ(get_counts(ms_int), counts2_orig);
+    EXPECT_EQ(ms_int.size(), size2_orig);
+    EXPECT_EQ(get_counts(other_ms), counts1_orig);
+    EXPECT_EQ(other_ms.size(), size1_orig);
+}
+
+TEST_F(UnorderedMultisetTest, SwapNonMember) {
+    ms_string.insert("x");
+    ms_string.insert("y");
+    ms_string.insert("x");
+
+    cpp_utils::UnorderedMultiset<std::string> other_ms_str;
+    other_ms_str.insert("a");
+    other_ms_str.insert("b");
+
+    auto counts1_orig = get_counts(ms_string);
+    size_t size1_orig = ms_string.size();
+    auto counts2_orig = get_counts(other_ms_str);
+    size_t size2_orig = other_ms_str.size();
+
+    swap(ms_string, other_ms_str); // Calls non-member swap
+
+    EXPECT_EQ(get_counts(ms_string), counts2_orig);
+    EXPECT_EQ(ms_string.size(), size2_orig);
+    EXPECT_EQ(get_counts(other_ms_str), counts1_orig);
+    EXPECT_EQ(other_ms_str.size(), size1_orig);
+}
+
+// Test with a custom struct and custom hash/equal
+struct MyData {
+    int id;
+    std::string name;
+
+    bool operator==(const MyData& other) const {
+        return id == other.id && name == other.name;
+    }
+};
+
+struct MyDataHash {
+    std::size_t operator()(const MyData& d) const {
+        return std::hash<int>()(d.id) ^ (std::hash<std::string>()(d.name) << 1);
+    }
+};
+
+TEST_F(UnorderedMultisetTest, CustomTypeAndHash) {
+    cpp_utils::UnorderedMultiset<MyData, MyDataHash> ms_custom;
+    MyData d1{1, "Alice"};
+    MyData d2{2, "Bob"};
+    MyData d1_again{1, "Alice"};
+
+    ms_custom.insert(d1);
+    ms_custom.insert(d2);
+    ms_custom.insert(d1_again); // Same as d1
+
+    EXPECT_EQ(ms_custom.size(), 3);
+    EXPECT_EQ(ms_custom.count(d1), 2);
+    EXPECT_EQ(ms_custom.count(d2), 1);
+    EXPECT_TRUE(ms_custom.contains(MyData{1, "Alice"}));
+
+    ms_custom.erase(MyData{1, "Alice"});
+    EXPECT_EQ(ms_custom.count(d1), 1);
+    EXPECT_EQ(ms_custom.size(), 2);
+
+    ms_custom.erase_all(d1);
+    EXPECT_EQ(ms_custom.count(d1), 0);
+    EXPECT_EQ(ms_custom.size(), 1); // Only d2 left
+    EXPECT_TRUE(ms_custom.contains(d2));
+}
+
+TEST_F(UnorderedMultisetTest, ConstructorWithHashAndEqual) {
+    MyDataHash hasher;
+    std::equal_to<MyData> equator; // Default is fine, but can be explicit
+    cpp_utils::UnorderedMultiset<MyData, MyDataHash, std::equal_to<MyData>> ms_custom_explicit(hasher, equator);
+
+    MyData d1{1, "Test"};
+    ms_custom_explicit.insert(d1);
+    EXPECT_EQ(ms_custom_explicit.count(d1), 1);
+    EXPECT_TRUE(ms_custom_explicit.contains(d1));
+}
+
+/*
+// Optional: Main function for running tests if not part of a larger test runner
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+*/
+
+// For GTest printing of MyData if needed in more complex EXPECT_EQ failures.
+// std::ostream& operator<<(std::ostream& os, const MyData& d) {
+//     return os << "MyData{id=" << d.id << ", name=\"" << d.name << "\"}";
+// }


### PR DESCRIPTION
This commit introduces a new data structure, `cpp_utils::UnorderedMultiset<T, Hash, KeyEqual>`.

The `UnorderedMultiset` (also known as a bag) is an unordered container that stores a collection of elements where multiple elements can have the same value. It is implemented using `std::unordered_map<T, size_t>` as its underlying storage, mapping each element to its count.

Key features:
- Average O(1) time complexity for insertion, deletion, and lookup.
- Methods: `insert`, `erase` (single instance), `erase_all` (all instances), `count`, `contains`, `size`, `empty`, `clear`, `swap`.
- Const iterators for unique elements (providing element and its count).

Includes:
- Header file: `include/unordered_multiset.h`
- Comprehensive tests: `tests/unordered_multiset_test.cpp`
- Example usage: `examples/unordered_multiset_example.cpp`
- Documentation: `docs/README_UnorderedMultiset.md`
- Updates to CMakeLists.txt files to integrate the new component.

All tests for UnorderedMultiset passed successfully.