### PR TITLE
Add FrozenSet immutable container

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,10 @@ target_include_directories(CountingBloomFilterLib INTERFACE ${CMAKE_CURRENT_SOUR
 add_library(SegmentTreeLib INTERFACE)
 target_include_directories(SegmentTreeLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define FrozenSetLib as an interface library (header-only)
+add_library(FrozenSetLib INTERFACE)
+target_include_directories(FrozenSetLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Future steps will add examples and tests here
 
 # Automatically add executables for all files in the examples/ directory
@@ -154,6 +158,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         TreapLib # Added for treap_example
         CountMinSketchLib # Added for count_min_sketch_example
         CountingBloomFilterLib
+        FrozenSetLib # Added for frozen_set_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/docs/README_FrozenSet.md
+++ b/docs/README_FrozenSet.md
@@ -1,0 +1,170 @@
+# FrozenSet
+
+## Overview
+
+`FrozenSet<Key, Compare, Allocator>` is an immutable container that stores a collection of unique, sorted elements of type `Key`. Once a `FrozenSet` is created, its contents cannot be modified. This immutability provides several benefits, including inherent thread safety for read operations and the ability for `FrozenSet` instances themselves to be hashable and thus usable as keys in hash-based associative containers like `std::unordered_map`.
+
+The elements are sorted according to a comparator `Compare` (defaulting to `std::less<Key>`). Uniqueness is also determined based on this comparator: two elements `a` and `b` are considered equivalent if `!comp(a, b) && !comp(b, a)`.
+
+Internally, `FrozenSet` typically uses a sorted `std::vector` to store its elements, providing cache-friendly iteration and efficient lookups (O(log N)).
+
+## Template Parameters
+
+*   `Key`: The type of elements stored in the `FrozenSet`.
+*   `Compare`: A comparison function object type that defines the ordering of elements. Defaults to `std::less<Key>`. This comparator is used to sort elements and to determine uniqueness.
+*   `Allocator`: The allocator type used for memory management of the elements. Defaults to `std::allocator<Key>`.
+
+## Key Features
+
+*   **Immutability**: Contents are fixed upon construction. No methods modify the set after it's created (e.g., no `insert`, `erase`).
+*   **Uniqueness**: Stores only unique elements, as determined by the `Compare` functor.
+*   **Sorted Order**: Elements are always stored in a sorted order defined by `Compare`.
+*   **Hashable**: `std::hash<FrozenSet<...>>` is specialized, allowing `FrozenSet` instances to be used as keys in `std::unordered_map`, `std::unordered_set`, or the custom `cpp_collections::dict`.
+*   **Efficient Lookups**: `find()`, `contains()`, and `count()` operations are O(log N) due to the sorted internal storage.
+*   **Efficient Iteration**: Iteration is cache-friendly, similar to `std::vector`.
+
+## API Reference
+
+### Member Types
+
+| Type              | Definition                                         |
+|-------------------|----------------------------------------------------|
+| `key_type`        | `Key`                                              |
+| `value_type`      | `Key` (as sets store keys as values)               |
+| `size_type`       | `std::size_t`                                      |
+| `difference_type` | `std::ptrdiff_t`                                   |
+| `key_compare`     | `Compare`                                          |
+| `value_compare`   | `Compare`                                          |
+| `allocator_type`  | `Allocator`                                        |
+| `reference`       | `const Key&` (elements are always const)           |
+| `const_reference` | `const Key&`                                       |
+| `pointer`         | `std::allocator_traits<Allocator>::const_pointer`  |
+| `const_pointer`   | `std::allocator_traits<Allocator>::const_pointer`  |
+| `iterator`        | Constant iterator to `Key`                         |
+| `const_iterator`  | Constant iterator to `Key`                         |
+
+### Constructors
+
+*   `FrozenSet(const Allocator& alloc = Allocator())`
+    *   Default constructor. Creates an empty `FrozenSet`.
+*   `FrozenSet(const Compare& comp, const Allocator& alloc = Allocator())`
+    *   Creates an empty `FrozenSet` with a specific comparator.
+*   `template <typename InputIt> FrozenSet(InputIt first, InputIt last, const Compare& comp = Compare(), const Allocator& alloc = Allocator())`
+    *   Constructs a `FrozenSet` with elements from the range `[first, last)`. Elements are sorted and duplicates are removed.
+*   `FrozenSet(std::initializer_list<Key> ilist, const Compare& comp = Compare(), const Allocator& alloc = Allocator())`
+    *   Constructs a `FrozenSet` from an initializer list.
+*   `FrozenSet(const FrozenSet& other)`
+    *   Copy constructor.
+*   `FrozenSet(FrozenSet&& other) noexcept`
+    *   Move constructor.
+
+### Iterators
+
+*   `iterator begin() const noexcept`
+*   `const_iterator cbegin() const noexcept`
+    *   Returns an iterator to the beginning of the set.
+*   `iterator end() const noexcept`
+*   `const_iterator cend() const noexcept`
+    *   Returns an iterator to the end of the set.
+
+### Capacity
+
+*   `bool empty() const noexcept`
+    *   Returns `true` if the set is empty, `false` otherwise.
+*   `size_type size() const noexcept`
+    *   Returns the number of elements in the set.
+*   `size_type max_size() const noexcept`
+    *   Returns the maximum possible number of elements.
+
+### Lookup
+
+*   `size_type count(const Key& key) const`
+    *   Returns `1` if an element equivalent to `key` exists, `0` otherwise. (O(log N))
+*   `bool contains(const Key& key) const`
+    *   Returns `true` if an element equivalent to `key` exists, `false` otherwise. (O(log N))
+*   `iterator find(const Key& key) const`
+    *   Returns an iterator to the element equivalent to `key` if found, otherwise returns `end()`. (O(log N))
+
+### Observers
+
+*   `key_compare key_comp() const`
+    *   Returns the key comparison object.
+*   `value_compare value_comp() const`
+    *   Returns the value comparison object (same as `key_comp`).
+*   `allocator_type get_allocator() const noexcept`
+    *   Returns the allocator object.
+
+### Comparison Operators
+
+Standard comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) are provided for comparing two `FrozenSet` instances.
+*   `operator==`: Two `FrozenSet`s are equal if they have the same size and all elements are element-wise equal according to their internal sorted order. This means their internal `data_` vectors must be identical. If custom comparators result in different canonical representations (e.g., "Apple" vs "apple" with a case-insensitive comparator where `std::unique` keeps the first seen), the `FrozenSet`s will not be equal.
+*   `operator<`: Lexicographical comparison.
+
+### Non-Member Functions
+
+*   `template <typename K, typename C, typename A> void swap(FrozenSet<K,C,A>& lhs, FrozenSet<K,C,A>& rhs) noexcept(...)`
+    *   Swaps the contents of `lhs` and `rhs`. (Note: This technically mutates the `FrozenSet` objects involved in the swap, but not their conceptual "frozen" content which is transferred.)
+
+### Hashing
+
+A specialization `std::hash<cpp_collections::FrozenSet<Key, Compare, Allocator>>` is provided, allowing `FrozenSet` objects to be used as keys in standard C++ unordered associative containers (e.g., `std::unordered_map`). The hash value is computed based on the sequence of elements in their sorted order.
+
+## Time Complexity
+
+*   **Construction**: O(M log M) where M is the number of elements in the input range (due to sorting), or O(M) if input is already sorted and unique.
+*   **Lookup (`find`, `contains`, `count`)**: O(log N) where N is the size of the `FrozenSet`.
+*   **Iteration**: O(N) to iterate through all elements.
+*   **Comparison (`operator==`, `operator<`)**: O(N) in the worst case.
+
+## Space Complexity
+
+*   O(N) to store N elements.
+
+## Example Usage
+
+```cpp
+#include "FrozenSet.h"
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+int main() {
+    // Create a FrozenSet from an initializer list
+    cpp_collections::FrozenSet<int> fs1 = {3, 1, 4, 1, 5, 9, 2, 6};
+
+    std::cout << "fs1 size: " << fs1.size() << std::endl; // Output: 7
+    std::cout << "fs1 elements: ";
+    for (int x : fs1) {
+        std::cout << x << " "; // Output: 1 2 3 4 5 6 9
+    }
+    std::cout << std::endl;
+
+    if (fs1.contains(4)) {
+        std::cout << "fs1 contains 4." << std::endl;
+    }
+
+    // FrozenSet as a key in std::unordered_map
+    std::unordered_map<cpp_collections::FrozenSet<std::string>, int> word_set_ids;
+
+    cpp_collections::FrozenSet<std::string> words1 = {"hello", "world"};
+    cpp_collections::FrozenSet<std::string> words2 = {"world", "hello"}; // Equivalent to words1
+    cpp_collections::FrozenSet<std::string> words3 = {"frozen", "set"};
+
+    word_set_ids[words1] = 1;
+    word_set_ids[words3] = 2;
+
+    std::cout << "ID for {\"hello\", \"world\"}: " << word_set_ids[words1] << std::endl;
+    std::cout << "ID for {\"world\", \"hello\"} (should be same): " << word_set_ids[words2] << std::endl;
+    std::cout << "ID for {\"frozen\", \"set\"}: " << word_set_ids[words3] << std::endl;
+
+    return 0;
+}
+```
+
+## When to Use
+
+*   When you need a set-like data structure whose contents will not change after creation.
+*   When you need to use sets as keys in hash maps or elements in other sets.
+*   In multi-threaded environments where immutable data can simplify concurrency (read operations are inherently safe).
+*   To represent constant collections of unique items.
+```

--- a/examples/frozen_set_example.cpp
+++ b/examples/frozen_set_example.cpp
@@ -1,0 +1,166 @@
+#include "FrozenSet.h"
+#include <iostream>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+// Custom struct for demonstration
+struct Book {
+    std::string title;
+    std::string author;
+
+    Book(std::string t, std::string a) : title(std::move(t)), author(std::move(a)) {}
+
+    // Comparison for sorting within FrozenSet
+    bool operator<(const Book& other) const {
+        if (author < other.author) return true;
+        if (author > other.author) return false;
+        return title < other.title;
+    }
+
+    // Equality (mainly for demonstration/easy checking)
+    bool operator==(const Book& other) const {
+        return title == other.title && author == other.author;
+    }
+};
+
+// Hash specialization for Book to be used in FrozenSet (if Book itself was the Key)
+// and for FrozenSet<Book> to be used as a key in unordered_map.
+namespace std {
+    template<> struct hash<Book> {
+        size_t operator()(const Book& b) const {
+            return std::hash<std::string>()(b.author) ^
+                   (std::hash<std::string>()(b.title) << 1);
+        }
+    };
+} // namespace std
+
+// Custom comparator for strings (case-insensitive)
+struct CaseInsensitiveStringCompare {
+    bool operator()(const std::string& a, const std::string& b) const {
+        return std::lexicographical_compare(
+            a.begin(), a.end(),
+            b.begin(), b.end(),
+            [](char c1, char c2) {
+                return std::tolower(c1) < std::tolower(c2);
+            }
+        );
+    }
+};
+
+
+int main() {
+    std::cout << "--- Basic FrozenSet of Integers ---" << std::endl;
+    cpp_collections::FrozenSet<int> fs_ints = {5, 1, 8, 3, 5, 1, 9};
+
+    std::cout << "Size: " << fs_ints.size() << std::endl; // Expected: 5 (duplicates removed)
+    std::cout << "Elements: ";
+    for (int val : fs_ints) {
+        std::cout << val << " "; // Expected: 1 3 5 8 9 (sorted)
+    }
+    std::cout << std::endl;
+
+    std::cout << "Contains 5? " << (fs_ints.contains(5) ? "Yes" : "No") << std::endl;
+    std::cout << "Contains 10? " << (fs_ints.contains(10) ? "Yes" : "No") << std::endl;
+
+    auto it_find = fs_ints.find(8);
+    if (it_find != fs_ints.end()) {
+        std::cout << "Found 8: " << *it_find << std::endl;
+    }
+
+    std::cout << "\n--- FrozenSet of Strings ---" << std::endl;
+    std::vector<std::string> str_vector = {"banana", "apple", "cherry", "apple", "date"};
+    cpp_collections::FrozenSet<std::string> fs_strings(str_vector.begin(), str_vector.end());
+
+    std::cout << "Elements: ";
+    for (const auto& s : fs_strings) {
+        std::cout << s << " "; // Expected: apple banana cherry date
+    }
+    std::cout << std::endl;
+
+    std::cout << "\n--- FrozenSet with Custom Objects (Books) ---" << std::endl;
+    cpp_collections::FrozenSet<Book> fs_books = {
+        {"The Lord of the Rings", "J.R.R. Tolkien"},
+        {"Pride and Prejudice", "Jane Austen"},
+        {"The Hobbit", "J.R.R. Tolkien"},
+        {"Pride and Prejudice", "Jane Austen"} // Duplicate
+    };
+
+    std::cout << "Favorite Authors & Books (sorted by author, then title):" << std::endl;
+    for (const auto& book : fs_books) {
+        std::cout << " - " << book.author << ", \"" << book.title << "\"" << std::endl;
+    }
+    // Expected:
+    // - Jane Austen, "Pride and Prejudice"
+    // - J.R.R. Tolkien, "The Hobbit"
+    // - J.R.R. Tolkien, "The Lord of the Rings"
+
+    std::cout << "\n--- FrozenSet Comparison ---" << std::endl;
+    cpp_collections::FrozenSet<int> fs_a = {1, 2, 3};
+    cpp_collections::FrozenSet<int> fs_b = {3, 2, 1}; // Same elements, different init order
+    cpp_collections::FrozenSet<int> fs_c = {1, 2, 4};
+
+    std::cout << "fs_a == fs_b? " << (fs_a == fs_b ? "Yes" : "No") << std::endl; // Expected: Yes
+    std::cout << "fs_a == fs_c? " << (fs_a == fs_c ? "Yes" : "No") << std::endl; // Expected: No
+    std::cout << "fs_a < fs_c? " << (fs_a < fs_c ? "Yes" : "No") << std::endl;   // Expected: Yes
+
+    std::cout << "\n--- FrozenSet Hashing (Usage as Map Key) ---" << std::endl;
+    std::unordered_map<cpp_collections::FrozenSet<std::string>, std::string> anagram_groups;
+
+    cpp_collections::FrozenSet<std::string> group1 = {"eat", "tea", "ate"};
+    cpp_collections::FrozenSet<std::string> group2 = {"tan", "nat"};
+    cpp_collections::FrozenSet<std::string> group3 = {"bat"};
+    // Another way to define group1, should result in the same FrozenSet
+    cpp_collections::FrozenSet<std::string> group1_alt = {"ate", "eat", "tea"};
+
+
+    anagram_groups[group1] = "Group A (eat, tea, ate)";
+    anagram_groups[group2] = "Group B (tan, nat)";
+    anagram_groups[group3] = "Group C (bat)";
+
+    std::cout << "Lookup group1: " << anagram_groups[group1] << std::endl;
+    std::cout << "Lookup group1_alt (should be same as group1): " << anagram_groups[group1_alt] << std::endl;
+
+    if (anagram_groups.count(group2)) {
+        std::cout << "Found group2: " << anagram_groups.at(group2) << std::endl;
+    }
+
+    std::cout << "Number of unique groups in map: " << anagram_groups.size() << std::endl; // Expected: 3
+
+    std::cout << "\n--- FrozenSet with Custom Comparator (Case-Insensitive Strings) ---" << std::endl;
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveStringCompare> fs_ci_strings =
+        {"Apple", "banana", "CHERRY", "apple"};
+
+    std::cout << "Case-insensitive elements: ";
+    for (const auto& s : fs_ci_strings) {
+        std::cout << s << " "; // Order might be "Apple", "banana", "CHERRY" or "apple", "banana", "CHERRY"
+                               // depending on stability of sort/unique for equivalent items.
+                               // What's guaranteed is that only one "apple"/"Apple" variant is stored.
+    }
+    std::cout << std::endl;
+    std::cout << "Size: " << fs_ci_strings.size() << std::endl; // Expected: 3 ("Apple" and "apple" are equiv)
+    std::cout << "Contains 'apple'? " << (fs_ci_strings.contains("apple") ? "Yes" : "No") << std::endl;
+    std::cout << "Contains 'APPLE'? " << (fs_ci_strings.contains("APPLE") ? "Yes" : "No") << std::endl;
+    std::cout << "Contains 'Banana'? " << (fs_ci_strings.contains("Banana") ? "Yes" : "No") << std::endl;
+
+
+    // Demonstrating that FrozenSets with custom comparators, if their stored representations differ,
+    // are different keys in a hash map, even if their elements are "equivalent" by the custom comparator.
+    std::unordered_map<cpp_collections::FrozenSet<std::string, CaseInsensitiveStringCompare>, int> ci_map;
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveStringCompare> ci_key1 = {"Hello", "World"}; // stores "Hello", "World"
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveStringCompare> ci_key2 = {"hello", "world"}; // stores "hello", "world"
+
+    // ci_key1 and ci_key2 are NOT equal because their internal data_ vectors differ.
+    // The hash function for FrozenSet hashes the actual stored elements.
+    std::cout << "ci_key1 == ci_key2 ? " << (ci_key1 == ci_key2 ? "Yes" : "No") << std::endl; // Expected: No
+
+    ci_map[ci_key1] = 10;
+    ci_map[ci_key2] = 20; // This will be a separate entry
+
+    std::cout << "ci_map size: " << ci_map.size() << std::endl; // Expected: 2
+    std::cout << "Value for {\"Hello\", \"World\"}: " << ci_map.at(ci_key1) << std::endl;
+    std::cout << "Value for {\"hello\", \"world\"}: " << ci_map.at(ci_key2) << std::endl;
+
+
+    return 0;
+}

--- a/include/FrozenSet.h
+++ b/include/FrozenSet.h
@@ -1,0 +1,203 @@
+#pragma once
+
+#include <vector>
+#include <algorithm> // For std::sort, std::unique, std::lower_bound
+#include <functional>  // For std::less, std::hash
+#include <memory>      // For std::allocator
+#include <initializer_list> // For std::initializer_list
+#include <stdexcept>   // For std::out_of_range (though not strictly needed for FrozenSet's typical API)
+#include <iterator>    // For std::iterator_traits
+
+namespace cpp_collections {
+
+template <
+    typename Key,
+    typename Compare = std::less<Key>,
+    typename Allocator = std::allocator<Key>
+>
+class FrozenSet {
+public:
+    // Types
+    using key_type = Key;
+    using value_type = Key; // Set stores keys as values
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using key_compare = Compare;
+    using value_compare = Compare;
+    using allocator_type = Allocator;
+    using reference = const Key&; // Always const reference
+    using const_reference = const Key&;
+    using pointer = typename std::allocator_traits<Allocator>::const_pointer; // Always const pointer
+    using const_pointer = typename std::allocator_traits<Allocator>::const_pointer;
+
+    // Use std::vector's const_iterator as FrozenSet's iterator
+    using iterator = typename std::vector<Key, Allocator>::const_iterator;
+    using const_iterator = typename std::vector<Key, Allocator>::const_iterator;
+
+private:
+    std::vector<Key, Allocator> data_;
+    Compare comparator_;
+
+    // Helper to sort and unique a vector
+    template<typename InputIt>
+    void build_from_range(InputIt first, InputIt last) {
+        data_.assign(first, last);
+        std::sort(data_.begin(), data_.end(), comparator_);
+        data_.erase(std::unique(data_.begin(), data_.end(),
+                                [this](const Key& a, const Key& b){ return !comparator_(a,b) && !comparator_(b,a); }),
+                    data_.end());
+        data_.shrink_to_fit(); // Minimize capacity as it won't change
+    }
+
+public:
+    // Constructors
+    FrozenSet(const Allocator& alloc = Allocator())
+        : data_(alloc), comparator_(Compare()) {}
+
+    FrozenSet(const Compare& comp, const Allocator& alloc = Allocator())
+        : data_(alloc), comparator_(comp) {}
+
+    template <typename InputIt>
+    FrozenSet(InputIt first, InputIt last,
+              const Compare& comp = Compare(),
+              const Allocator& alloc = Allocator())
+        : data_(alloc), comparator_(comp) {
+        build_from_range(first, last);
+    }
+
+    FrozenSet(std::initializer_list<Key> ilist,
+              const Compare& comp = Compare(),
+              const Allocator& alloc = Allocator())
+        : data_(alloc), comparator_(comp) {
+        build_from_range(ilist.begin(), ilist.end());
+    }
+
+    // Copy constructor
+    FrozenSet(const FrozenSet& other) = default;
+    FrozenSet(const FrozenSet& other, const Allocator& alloc)
+        : data_(other.data_, alloc), comparator_(other.comparator_) {}
+
+    // Move constructor
+    FrozenSet(FrozenSet&& other) noexcept = default;
+    FrozenSet(FrozenSet&& other, const Allocator& alloc) noexcept
+        : data_(std::move(other.data_), alloc), comparator_(std::move(other.comparator_)) {}
+
+    // Destructor
+    ~FrozenSet() = default;
+
+    // Assignment operators (though less common for immutable types, can be useful for reassignment)
+    // However, true immutability would mean no assignment after construction.
+    // For now, let's stick to "frozen after construction" meaning the object itself can be reassigned.
+    FrozenSet& operator=(const FrozenSet& other) = default;
+    FrozenSet& operator=(FrozenSet&& other) noexcept = default;
+    FrozenSet& operator=(std::initializer_list<Key> ilist) {
+        build_from_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    // Iterators
+    iterator begin() const noexcept { return data_.begin(); }
+    const_iterator cbegin() const noexcept { return data_.cbegin(); }
+    iterator end() const noexcept { return data_.end(); }
+    const_iterator cend() const noexcept { return data_.cend(); }
+
+    // Capacity
+    bool empty() const noexcept { return data_.empty(); }
+    size_type size() const noexcept { return data_.size(); }
+    size_type max_size() const noexcept { return data_.max_size(); }
+
+    // Lookup
+    size_type count(const Key& key) const {
+        auto it = std::lower_bound(data_.begin(), data_.end(), key, comparator_);
+        if (it != data_.end() && !comparator_(*it, key) && !comparator_(key, *it)) { // Found and equivalent
+            return 1;
+        }
+        return 0;
+    }
+
+    bool contains(const Key& key) const {
+        return count(key) > 0;
+    }
+
+    iterator find(const Key& key) const {
+        auto it = std::lower_bound(data_.begin(), data_.end(), key, comparator_);
+        if (it != data_.end() && !comparator_(*it, key) && !comparator_(key, *it)) { // Found and equivalent
+            return it;
+        }
+        return data_.end();
+    }
+
+    // Comparators
+    key_compare key_comp() const { return comparator_; }
+    value_compare value_comp() const { return comparator_; } // Same as key_comp for sets
+
+    // Allocator
+    allocator_type get_allocator() const noexcept { return data_.get_allocator(); }
+
+    // Comparison operators for FrozenSet objects
+    friend bool operator==(const FrozenSet& lhs, const FrozenSet& rhs) {
+        if (lhs.size() != rhs.size()) return false;
+        // Relies on data_ being sorted and unique, and using the same comparator logic for equality.
+        // std::equal uses lhs.comparator_ for element comparison by default if available.
+        // However, we need to ensure both sets consider elements equal in the same way.
+        // The most robust way is to check if their internal vectors are equal.
+        return lhs.data_ == rhs.data_;
+    }
+
+    friend bool operator!=(const FrozenSet& lhs, const FrozenSet& rhs) {
+        return !(lhs == rhs);
+    }
+
+    friend bool operator<(const FrozenSet& lhs, const FrozenSet& rhs) {
+        // Lexicographical comparison
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            lhs.comparator_);
+    }
+
+    friend bool operator<=(const FrozenSet& lhs, const FrozenSet& rhs) {
+        return !(rhs < lhs);
+    }
+
+    friend bool operator>(const FrozenSet& lhs, const FrozenSet& rhs) {
+        return rhs < lhs;
+    }
+
+    friend bool operator>=(const FrozenSet& lhs, const FrozenSet& rhs) {
+        return !(lhs < rhs);
+    }
+
+    // Swap (member swap is often good practice, though less critical for immutable types if copy/move assign are deleted)
+    void swap(FrozenSet& other) noexcept(
+        std::allocator_traits<Allocator>::propagate_on_container_swap::value ||
+        std::allocator_traits<Allocator>::is_always_equal::value) {
+        std::swap(data_, other.data_);
+        std::swap(comparator_, other.comparator_);
+    }
+};
+
+// Non-member swap
+template <typename Key, typename Compare, typename Allocator>
+void swap(FrozenSet<Key, Compare, Allocator>& lhs,
+          FrozenSet<Key, Compare, Allocator>& rhs) noexcept(noexcept(lhs.swap(rhs))) {
+    lhs.swap(rhs);
+}
+
+} // namespace cpp_collections
+
+// Specialization of std::hash for FrozenSet
+namespace std {
+template <typename Key, typename Compare, typename Allocator>
+struct hash<cpp_collections::FrozenSet<Key, Compare, Allocator>> {
+    std::size_t operator()(const cpp_collections::FrozenSet<Key, Compare, Allocator>& fs) const {
+        std::size_t seed = 0;
+        // Combine hashes of elements. Order matters as the set is ordered.
+        // A common way to combine hashes:
+        std::hash<Key> hasher;
+        for (const auto& elem : fs) {
+            seed ^= hasher(elem) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        }
+        return seed;
+    }
+};
+} // namespace std

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         TreapLib # Added for treap_test
         CountMinSketchLib # Added for count_min_sketch_test
         CountingBloomFilterLib
+        FrozenSetLib # Added for frozen_set_test
     )
 
     # Specific configurations for certain tests

--- a/tests/frozen_set_test.cpp
+++ b/tests/frozen_set_test.cpp
@@ -1,0 +1,455 @@
+#include "FrozenSet.h"
+#include <gtest/gtest.h>
+#include <vector>
+#include <string>
+#include <unordered_map> // For testing hashing
+#include <set> // For comparison data
+
+// Test fixture for FrozenSet tests
+class FrozenSetTest : public ::testing::Test {
+protected:
+    // Per-test set-up and tear-down logic if needed
+};
+
+// Test default constructor and basic properties
+TEST_F(FrozenSetTest, DefaultConstructor) {
+    cpp_collections::FrozenSet<int> fs_int;
+    EXPECT_TRUE(fs_int.empty());
+    EXPECT_EQ(fs_int.size(), 0);
+    EXPECT_EQ(fs_int.begin(), fs_int.end());
+
+    cpp_collections::FrozenSet<std::string> fs_str;
+    EXPECT_TRUE(fs_str.empty());
+    EXPECT_EQ(fs_str.size(), 0);
+}
+
+// Test construction from initializer list
+TEST_F(FrozenSetTest, InitializerListConstructor) {
+    cpp_collections::FrozenSet<int> fs1 = {3, 1, 4, 1, 5, 9, 2, 6};
+    EXPECT_FALSE(fs1.empty());
+    EXPECT_EQ(fs1.size(), 7); // Duplicates (1) should be removed
+
+    std::vector<int> expected_elements = {1, 2, 3, 4, 5, 6, 9};
+    size_t i = 0;
+    for (int val : fs1) {
+        EXPECT_EQ(val, expected_elements[i++]);
+    }
+
+    EXPECT_TRUE(fs1.contains(1));
+    EXPECT_TRUE(fs1.contains(9));
+    EXPECT_FALSE(fs1.contains(0));
+    EXPECT_FALSE(fs1.contains(7));
+
+    cpp_collections::FrozenSet<int> fs_empty = {};
+    EXPECT_TRUE(fs_empty.empty());
+    EXPECT_EQ(fs_empty.size(), 0);
+}
+
+// Test construction from iterators
+TEST_F(FrozenSetTest, IteratorConstructor) {
+    std::vector<std::string> data = {"apple", "banana", "cherry", "apple", "date"};
+    cpp_collections::FrozenSet<std::string> fs(data.begin(), data.end());
+
+    EXPECT_EQ(fs.size(), 4); // "apple" duplicate removed
+    EXPECT_TRUE(fs.contains("apple"));
+    EXPECT_TRUE(fs.contains("banana"));
+    EXPECT_TRUE(fs.contains("cherry"));
+    EXPECT_TRUE(fs.contains("date"));
+    EXPECT_FALSE(fs.contains("fig"));
+
+    std::vector<std::string> expected_elements = {"apple", "banana", "cherry", "date"};
+    std::sort(expected_elements.begin(), expected_elements.end()); // Ensure sorted for comparison
+
+    size_t i = 0;
+    for (const auto& s : fs) {
+        EXPECT_EQ(s, expected_elements[i++]);
+    }
+
+    std::vector<int> empty_vec;
+    cpp_collections::FrozenSet<int> fs_empty(empty_vec.begin(), empty_vec.end());
+    EXPECT_TRUE(fs_empty.empty());
+}
+
+// Test lookup methods: count, contains, find
+TEST_F(FrozenSetTest, LookupMethods) {
+    cpp_collections::FrozenSet<int> fs = {10, 20, 30, 40, 50};
+
+    // contains
+    EXPECT_TRUE(fs.contains(10));
+    EXPECT_TRUE(fs.contains(30));
+    EXPECT_TRUE(fs.contains(50));
+    EXPECT_FALSE(fs.contains(0));
+    EXPECT_FALSE(fs.contains(25));
+    EXPECT_FALSE(fs.contains(60));
+
+    // count
+    EXPECT_EQ(fs.count(10), 1);
+    EXPECT_EQ(fs.count(30), 1);
+    EXPECT_EQ(fs.count(50), 1);
+    EXPECT_EQ(fs.count(0), 0);
+    EXPECT_EQ(fs.count(25), 0);
+    EXPECT_EQ(fs.count(60), 0);
+
+    // find
+    EXPECT_NE(fs.find(10), fs.end());
+    EXPECT_EQ(*fs.find(10), 10);
+    EXPECT_NE(fs.find(30), fs.end());
+    EXPECT_EQ(*fs.find(30), 30);
+    EXPECT_NE(fs.find(50), fs.end());
+    EXPECT_EQ(*fs.find(50), 50);
+
+    EXPECT_EQ(fs.find(0), fs.end());
+    EXPECT_EQ(fs.find(25), fs.end());
+    EXPECT_EQ(fs.find(60), fs.end());
+}
+
+// Test iteration
+TEST_F(FrozenSetTest, Iteration) {
+    cpp_collections::FrozenSet<int> fs = {5, 1, 3, 2, 4};
+    std::vector<int> expected = {1, 2, 3, 4, 5};
+    std::vector<int> actual;
+    for (int val : fs) {
+        actual.push_back(val);
+    }
+    EXPECT_EQ(actual, expected);
+
+    // const iteration
+    const auto& cfs = fs;
+    actual.clear();
+    for (int val : cfs) {
+        actual.push_back(val);
+    }
+    EXPECT_EQ(actual, expected);
+
+    // cbegin/cend
+    actual.clear();
+    for (auto it = fs.cbegin(); it != fs.cend(); ++it) {
+        actual.push_back(*it);
+    }
+    EXPECT_EQ(actual, expected);
+}
+
+// Test comparison operators
+TEST_F(FrozenSetTest, ComparisonOperators) {
+    cpp_collections::FrozenSet<int> fs1 = {1, 2, 3};
+    cpp_collections::FrozenSet<int> fs2 = {1, 2, 3};
+    cpp_collections::FrozenSet<int> fs3 = {1, 2, 4};
+    cpp_collections::FrozenSet<int> fs4 = {1, 2};
+    cpp_collections::FrozenSet<int> fs_empty1;
+    cpp_collections::FrozenSet<int> fs_empty2;
+
+    // == and !=
+    EXPECT_TRUE(fs1 == fs2);
+    EXPECT_FALSE(fs1 != fs2);
+    EXPECT_FALSE(fs1 == fs3);
+    EXPECT_TRUE(fs1 != fs3);
+    EXPECT_FALSE(fs1 == fs4);
+    EXPECT_TRUE(fs1 != fs4);
+    EXPECT_TRUE(fs_empty1 == fs_empty2);
+    EXPECT_FALSE(fs_empty1 != fs_empty2);
+    EXPECT_FALSE(fs1 == fs_empty1);
+
+    // <, <=, >, >=
+    EXPECT_FALSE(fs1 < fs2); // Equal
+    EXPECT_TRUE(fs1 <= fs2); // Equal
+    EXPECT_FALSE(fs1 > fs2); // Equal
+    EXPECT_TRUE(fs1 >= fs2); // Equal
+
+    EXPECT_TRUE(fs1 < fs3);  // {1,2,3} < {1,2,4}
+    EXPECT_TRUE(fs1 <= fs3);
+    EXPECT_FALSE(fs1 > fs3);
+    EXPECT_FALSE(fs1 >= fs3);
+
+    EXPECT_FALSE(fs3 < fs1);
+    EXPECT_FALSE(fs3 <= fs1);
+    EXPECT_TRUE(fs3 > fs1);
+    EXPECT_TRUE(fs3 >= fs1);
+
+    EXPECT_TRUE(fs4 < fs1); // {1,2} < {1,2,3} (shorter sequence)
+    EXPECT_TRUE(fs4 <= fs1);
+    EXPECT_FALSE(fs4 > fs1);
+    EXPECT_FALSE(fs4 >= fs1);
+
+    EXPECT_TRUE(fs_empty1 < fs1);
+    EXPECT_FALSE(fs1 < fs_empty1);
+}
+
+// Test hashing and usage in unordered_map
+TEST_F(FrozenSetTest, Hashing) {
+    cpp_collections::FrozenSet<std::string> fs1 = {"hello", "world"};
+    cpp_collections::FrozenSet<std::string> fs2 = {"world", "hello"}; // Same elements, different order in list
+    cpp_collections::FrozenSet<std::string> fs3 = {"hello", "c++"};
+    cpp_collections::FrozenSet<std::string> fs_empty;
+
+    std::hash<cpp_collections::FrozenSet<std::string>> hasher;
+
+    EXPECT_EQ(hasher(fs1), hasher(fs2)); // Should be equal as content is same and sorted
+    EXPECT_NE(hasher(fs1), hasher(fs3));
+    EXPECT_NE(hasher(fs1), hasher(fs_empty));
+
+    std::unordered_map<cpp_collections::FrozenSet<std::string>, int> map_fs_to_int;
+    map_fs_to_int[fs1] = 100;
+    map_fs_to_int[fs3] = 200;
+    map_fs_to_int[fs_empty] = 0;
+
+    EXPECT_EQ(map_fs_to_int.count(fs1), 1);
+    EXPECT_EQ(map_fs_to_int.at(fs1), 100);
+    EXPECT_EQ(map_fs_to_int.count(fs2), 1); // fs2 is equivalent to fs1
+    EXPECT_EQ(map_fs_to_int.at(fs2), 100);
+    EXPECT_EQ(map_fs_to_int.count(fs3), 1);
+    EXPECT_EQ(map_fs_to_int.at(fs3), 200);
+    EXPECT_EQ(map_fs_to_int.count(fs_empty), 1);
+    EXPECT_EQ(map_fs_to_int.at(fs_empty), 0);
+
+    cpp_collections::FrozenSet<std::string> fs_not_in_map = {"test"};
+    EXPECT_EQ(map_fs_to_int.count(fs_not_in_map), 0);
+}
+
+// Test with custom comparator
+struct CaseInsensitiveCompare {
+    bool operator()(const std::string& a, const std::string& b) const {
+        return std::lexicographical_compare(
+            a.begin(), a.end(),
+            b.begin(), b.end(),
+            [](char c1, char c2) {
+                return std::tolower(c1) < std::tolower(c2);
+            }
+        );
+    }
+};
+
+// Custom equality for testing with CaseInsensitiveCompare
+struct CaseInsensitiveEqual {
+     bool operator()(const std::string& a, const std::string& b) const {
+        if (a.length() != b.length()) return false;
+        return std::equal(a.begin(), a.end(), b.begin(),
+                          [](char c1, char c2){ return std::tolower(c1) == std::tolower(c2); });
+    }
+};
+
+
+TEST_F(FrozenSetTest, CustomComparator) {
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> fs = {"Apple", "banana", "APPLE", "Cherry"};
+    EXPECT_EQ(fs.size(), 3); // "Apple" and "APPLE" are duplicates with case-insensitive compare
+
+    // Order should be Apple (or APPLE), banana, Cherry (case might vary based on sort stability)
+    // Let's check contents
+    EXPECT_TRUE(fs.contains("apple"));
+    EXPECT_TRUE(fs.contains("APPLE")); // Both should work due to comparator
+    EXPECT_TRUE(fs.contains("Banana"));
+    EXPECT_TRUE(fs.contains("cherry"));
+    EXPECT_FALSE(fs.contains("Date"));
+
+    // Test find with custom comparator
+    auto it_apple = fs.find("apple");
+    ASSERT_NE(it_apple, fs.end());
+    EXPECT_TRUE(CaseInsensitiveEqual()(*it_apple, "Apple")); // Check if one of the "apple"s is found
+
+    auto it_APPLE = fs.find("APPLE");
+    ASSERT_NE(it_APPLE, fs.end());
+    EXPECT_TRUE(CaseInsensitiveEqual()(*it_APPLE, "Apple"));
+
+    // Ensure internal order is consistent with comparator
+    std::vector<std::string> actual_elements;
+    for(const auto& s : fs) actual_elements.push_back(s);
+
+    // Expected can be tricky due to sort stability. We know "apple" comes before "banana"
+    // and "banana" before "cherry" case-insensitively.
+    // The specific original casing ("Apple" vs "APPLE") kept depends on std::sort stability
+    // and std::unique behavior with equivalent elements.
+    // Let's just check the elements are present in a case-insensitive way and sorted.
+    ASSERT_EQ(actual_elements.size(), 3);
+    EXPECT_TRUE(CaseInsensitiveEqual()(actual_elements[0], "Apple")); // or "APPLE"
+    EXPECT_TRUE(CaseInsensitiveEqual()(actual_elements[1], "banana"));
+    EXPECT_TRUE(CaseInsensitiveEqual()(actual_elements[2], "Cherry"));
+
+    // Test hashing with custom comparator
+    // Note: std::hash<FrozenSet> uses std::hash<Key>. If Key is std::string,
+    // it uses case-sensitive hash. This means fs_ci1 and fs_ci2 below might have different hashes
+    // if their *stored representations* are different ("Apple" vs "apple"), even if they
+    // compare equal with CaseInsensitiveCompare. This is a known subtlety.
+    // For hash to be consistent with custom comparison, the std::hash<Key> would also need
+    // to be consistent with that comparison (e.g. hash(tolower(str))).
+    // The current std::hash<FrozenSet> will use the *actual stored values*.
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> fs_ci1 = {"Apple", "Banana"};
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> fs_ci2 = {"apple", "banana"};
+    // fs_ci1 and fs_ci2 should compare equal using operator== for FrozenSet,
+    // because operator== uses the FrozenSet's comparator implicitly through its sorted vector storage.
+    // Let's verify this first.
+    // The internal data_ vector for fs_ci1 might be {"Apple", "Banana"}
+    // The internal data_ vector for fs_ci2 might be {"apple", "banana"}
+    // If CaseInsensitiveCompare is used for std::sort, then "Apple" and "apple" are equivalent.
+    // std::unique will keep the first one. So fs_ci1 from {"Apple", "Banana"} will store {"Apple", "Banana"}
+    // fs_ci2 from {"apple", "banana"} will store {"apple", "banana"}
+    // These will NOT be equal with operator== if their internal vectors are different.
+    // This is a critical point: operator== for FrozenSet is defined as `lhs.data_ == rhs.data_`.
+    // This implies that for two FrozenSets to be equal, their comparators must have produced
+    // identical canonical representations in their `data_` vectors.
+    // If fs_ci1 stores "Apple" and fs_ci2 stores "apple", they are NOT equal by FrozenSet::operator==.
+    // This is actually the desired behavior for a generic FrozenSet. If you want case-insensitive
+    // equality to also mean they are the *same* FrozenSet, the elements themselves would need to be
+    // canonicalized (e.g., all lowercase) before insertion or the comparator for equality needs to be more complex.
+
+    // Let's test this understanding:
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> fs_test1 = {"KEY", "value"}; // stores "KEY", "value" (assuming this order by CICompare)
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> fs_test2 = {"key", "VALUE"}; // stores "key", "VALUE"
+
+    // They *contain* the same elements case-insensitively:
+    EXPECT_TRUE(fs_test1.contains("key"));
+    EXPECT_TRUE(fs_test1.contains("VALUE"));
+    EXPECT_TRUE(fs_test2.contains("KEY"));
+    EXPECT_TRUE(fs_test2.contains("value"));
+
+    // But are they equal? Depends on what `std::unique` kept.
+    // If CaseInsensitiveCompare sorts "KEY" before "value", and "key" before "VALUE"
+    // and "KEY" is equivalent to "key", "value" to "VALUE".
+    // {"KEY", "value"} -> sorts to {"KEY", "value"} (original order preserved for equivalent) -> unique keeps {"KEY", "value"}
+    // {"key", "VALUE"} -> sorts to {"key", "VALUE"} -> unique keeps {"key", "VALUE"}
+    // Then fs_test1.data_ is {"KEY", "value"} and fs_test2.data_ is {"key", "VALUE"}. These vectors are not equal.
+    EXPECT_FALSE(fs_test1 == fs_test2); // This is expected.
+
+    // If we construct them to have the same canonical representation:
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> fs_canon1 = {"apple", "banana"};
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> fs_canon2 = {"Apple", "Banana"};
+    // fs_canon1.data_ will be {"apple", "banana"}
+    // fs_canon2.data_ will be {"Apple", "Banana"} because unique keeps the first encountered.
+    // So they are still not equal by data_ comparison.
+
+    // The only way they'd be equal is if the input to the constructor, after sorting by CaseInsensitiveCompare,
+    // results in the *exact same sequence of elements being kept by std::unique*.
+    // Example:
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> fs_eq1 = {"apple", "Banana", "apple"}; // -> unique keeps "apple", "Banana"
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> fs_eq2 = {"Apple", "banana", "APPLE"}; // -> unique keeps "Apple", "banana"
+    // These are NOT equal. fs_eq1.data_ is {"apple", "Banana"}, fs_eq2.data_ is {"Apple", "banana"}
+    // (assuming "apple" comes before "Banana" with CICompare)
+
+    // This shows that std::hash<FrozenSet> will correctly produce different hashes for fs_eq1 and fs_eq2,
+    // which is consistent with their inequality.
+    // The definition of equality for FrozenSet is strict: same elements in same order with same comparator logic.
+    // The custom comparator influences sorting and uniqueness, but equality is on the final stored representation.
+
+    std::unordered_map<cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare>, int> map_fs_custom_comp;
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> key1 = {"Case", "Test"}; // Stored as e.g. {"Case", "Test"}
+    cpp_collections::FrozenSet<std::string, CaseInsensitiveCompare> key2 = {"case", "test"}; // Stored as e.g. {"case", "test"}
+
+    map_fs_custom_comp[key1] = 1;
+    map_fs_custom_comp[key2] = 2;
+
+    EXPECT_EQ(map_fs_custom_comp.at(key1), 1);
+    EXPECT_EQ(map_fs_custom_comp.at(key2), 2); // key1 and key2 are different keys
+    EXPECT_NE(std::hash<decltype(key1)>()(key1), std::hash<decltype(key2)>()(key2));
+}
+
+
+// Test copy and move semantics
+TEST_F(FrozenSetTest, CopyAndMove) {
+    cpp_collections::FrozenSet<int> fs1 = {1, 2, 3};
+
+    // Copy constructor
+    cpp_collections::FrozenSet<int> fs2 = fs1;
+    EXPECT_EQ(fs1, fs2);
+    EXPECT_EQ(fs2.size(), 3);
+    EXPECT_TRUE(fs2.contains(2));
+
+    // Copy assignment
+    cpp_collections::FrozenSet<int> fs3;
+    fs3 = fs1;
+    EXPECT_EQ(fs1, fs3);
+    EXPECT_EQ(fs3.size(), 3);
+    EXPECT_TRUE(fs3.contains(3));
+
+    // Move constructor
+    cpp_collections::FrozenSet<int> fs4 = std::move(fs2); // fs2 is now in a valid but unspecified state
+    EXPECT_EQ(fs1, fs4); // fs4 should have taken fs2's (which was fs1's) content
+    EXPECT_EQ(fs4.size(), 3);
+    EXPECT_TRUE(fs4.contains(1));
+    // EXPECT_TRUE(fs2.empty()); // Not guaranteed, but likely for vector move
+
+    // Move assignment
+    cpp_collections::FrozenSet<int> fs5;
+    fs5 = std::move(fs3); // fs3 is now in a valid but unspecified state
+    EXPECT_EQ(fs1, fs5);
+    EXPECT_EQ(fs5.size(), 3);
+    EXPECT_TRUE(fs5.contains(2));
+    // EXPECT_TRUE(fs3.empty()); // Not guaranteed
+}
+
+// Test FrozenSet with non-pod types
+struct MyNonPodType {
+    std::string s;
+    int id;
+
+    MyNonPodType(std::string s_val, int id_val) : s(std::move(s_val)), id(id_val) {}
+
+    // Need comparison for FrozenSet
+    bool operator<(const MyNonPodType& other) const {
+        if (s < other.s) return true;
+        if (s > other.s) return false;
+        return id < other.id;
+    }
+    // Need equality for some tests, though FrozenSet uses < for equivalence
+    bool operator==(const MyNonPodType& other) const {
+        return s == other.s && id == other.id;
+    }
+};
+
+// Hash specialization for MyNonPodType
+namespace std {
+    template<> struct hash<MyNonPodType> {
+        size_t operator()(const MyNonPodType& m) const {
+            return std::hash<std::string>()(m.s) ^ (std::hash<int>()(m.id) << 1);
+        }
+    };
+}
+
+
+TEST_F(FrozenSetTest, NonPodType) {
+    MyNonPodType mp1("obj1", 10);
+    MyNonPodType mp2("obj2", 20);
+    MyNonPodType mp3("obj1", 5); // Different id, same string as mp1 but smaller
+    MyNonPodType mp1_dup("obj1", 10);
+
+    cpp_collections::FrozenSet<MyNonPodType> fs = {mp1, mp2, mp3, mp1_dup};
+    EXPECT_EQ(fs.size(), 3); // mp1 and mp1_dup are duplicates
+
+    EXPECT_TRUE(fs.contains(mp1));
+    EXPECT_TRUE(fs.contains(MyNonPodType("obj2", 20)));
+    EXPECT_TRUE(fs.contains(MyNonPodType("obj1", 5)));
+    EXPECT_FALSE(fs.contains(MyNonPodType("obj3", 30)));
+
+    // Check order: mp3 ("obj1", 5), mp1 ("obj1", 10), mp2 ("obj2", 20)
+    auto it = fs.begin();
+    EXPECT_EQ(it->s, "obj1"); EXPECT_EQ(it->id, 5); // mp3
+    ++it;
+    EXPECT_EQ(it->s, "obj1"); EXPECT_EQ(it->id, 10); // mp1
+    ++it;
+    EXPECT_EQ(it->s, "obj2"); EXPECT_EQ(it->id, 20); // mp2
+    ++it;
+    EXPECT_EQ(it, fs.end());
+
+    // Test hashing with non-POD
+    std::unordered_map<cpp_collections::FrozenSet<MyNonPodType>, std::string> map_fs_non_pod;
+    map_fs_non_pod[fs] = "Set1";
+    EXPECT_EQ(map_fs_non_pod.at(fs), "Set1");
+
+    cpp_collections::FrozenSet<MyNonPodType> fs_other = {mp2, mp3}; // Different set
+    map_fs_non_pod[fs_other] = "Set2";
+    EXPECT_EQ(map_fs_non_pod.at(fs_other), "Set2");
+}
+
+// Test allocator support (basic check - not exhaustive)
+TEST_F(FrozenSetTest, AllocatorSupport) {
+    std::allocator<int> alloc;
+    cpp_collections::FrozenSet<int, std::less<int>, std::allocator<int>> fs(alloc);
+    EXPECT_TRUE(fs.empty());
+    EXPECT_EQ(fs.get_allocator(), alloc);
+
+    cpp_collections::FrozenSet<int> fs2({1,2,3}, std::less<int>(), alloc);
+    EXPECT_EQ(fs2.size(), 3);
+    EXPECT_EQ(fs2.get_allocator(), alloc);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This commit introduces FrozenSet, an immutable container that stores unique, sorted elements.

Key features:
- Immutable: Contents are fixed upon construction.
- Unique & Sorted: Elements are unique and sorted according to a comparator.
- Hashable: std::hash<FrozenSet> is specialized, allowing use in unordered maps.
- Efficient Lookups: O(log N) for find, contains, count.

Includes:
- FrozenSet.h: Class definition and implementation.
- frozen_set_test.cpp: Comprehensive unit tests.
- frozen_set_example.cpp: Example usage.
- README_FrozenSet.md: Documentation.
- Updates to CMakeLists.txt to integrate the new component.