### PR TITLE
Add DictWrapper class for easy dictionary extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,9 @@ target_include_directories(CountingBloomFilterLib INTERFACE ${CMAKE_CURRENT_SOUR
 add_library(SegmentTreeLib INTERFACE)
 target_include_directories(SegmentTreeLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define DictWrapperLib as an interface library (header-only)
+add_library(DictWrapperLib INTERFACE)
+target_include_directories(DictWrapperLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Define FrozenSetLib as an interface library (header-only)
 add_library(FrozenSetLib INTERFACE)
@@ -197,6 +200,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         SkipListLib          # Added for skip_list_example
         PairwiseLib          # Added for pairwise_example
         RedBlackTreeLib      # Added for red_black_tree_example
+        DictWrapperLib       # Added for dict_wrapper_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/examples/dict_wrapper_example.cpp
+++ b/examples/dict_wrapper_example.cpp
@@ -1,0 +1,167 @@
+#include "dict_wrapper.h" // Adjust path as necessary
+#include <iostream>
+#include <stdexcept> // For std::out_of_range
+#include <string>
+
+// Custom dictionary that logs insertions and deletions
+class LoggingDict : public DictWrapper<std::string, int> {
+public:
+  using Base = DictWrapper<std::string, int>; // Base class alias
+
+  // Inherit constructors from Base
+  using Base::Base;
+
+  // Override insert to log
+  std::pair<iterator, bool> insert(const value_type &value) override {
+    std::cout << "LOG: Inserting key='" << value.first
+              << "', value=" << value.second << std::endl;
+    auto result = Base::insert(value);
+    if (result.second) {
+      std::cout << "LOG: Successfully inserted key='" << value.first << "'"
+                << std::endl;
+    } else {
+      std::cout << "LOG: Key='" << value.first
+                << "' already exists. Insertion failed." << std::endl;
+    }
+    return result;
+  }
+
+  // Override erase (by key) to log
+  size_type erase(const key_type &key) override {
+    std::cout << "LOG: Attempting to erase key='" << key << "'" << std::endl;
+    bool was_present = this->contains(key); // Check before erasing
+    size_type result = Base::erase(key);
+    if (result > 0) {
+      std::cout << "LOG: Successfully erased key='" << key << "'" << std::endl;
+    } else {
+      if (was_present) { // Should not happen if erase returns 0 but was present
+        std::cout << "LOG: Erase for key='" << key
+                  << "' returned 0, but key was present. Inconsistent state?"
+                  << std::endl;
+      } else {
+        std::cout << "LOG: Key='" << key << "' not found for erasure."
+                  << std::endl;
+      }
+    }
+    return result;
+  }
+
+  // Override operator[] to add custom behavior (e.g., logging access)
+  mapped_type &operator[](const key_type &key) override {
+    std::cout << "LOG: Accessing key='" << key << "' via operator[]"
+              << std::endl;
+    if (!this->contains(key)) {
+      std::cout << "LOG: Key='" << key
+                << "' not found by operator[], will be default-inserted."
+                << std::endl;
+    }
+    return Base::operator[](key);
+  }
+
+  // Override at to log access (const version)
+  const mapped_type &at(const key_type &key) const override {
+    std::cout << "LOG: Accessing key='" << key << "' via at() const"
+              << std::endl;
+    try {
+      return Base::at(key);
+    } catch (const std::out_of_range &e) {
+      std::cout << "LOG: Key='" << key
+                << "' not found in at() const. Exception: " << e.what()
+                << std::endl;
+      throw; // Re-throw the exception
+    }
+  }
+  // Override at to log access (non-const version)
+  mapped_type &at(const key_type &key) override {
+    std::cout << "LOG: Accessing key='" << key << "' via at() non-const"
+              << std::endl;
+    try {
+      return Base::at(key);
+    } catch (const std::out_of_range &e) {
+      std::cout << "LOG: Key='" << key
+                << "' not found in at() non-const. Exception: " << e.what()
+                << std::endl;
+      throw; // Re-throw the exception
+    }
+  }
+};
+
+int main() {
+  std::cout << "--- Basic DictWrapper Usage ---" << std::endl;
+  DictWrapper<std::string, int> basic_dict;
+  basic_dict.insert({"one", 1});
+  basic_dict["two"] = 2;
+
+  std::cout << "basic_dict contains:" << std::endl;
+  for (const auto &pair : basic_dict) {
+    std::cout << pair.first << ": " << pair.second << std::endl;
+  }
+  std::cout << "Size of basic_dict: " << basic_dict.size() << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "--- LoggingDict Usage ---" << std::endl;
+  LoggingDict my_log_dict;
+
+  // Test overridden insert
+  my_log_dict.insert({"apple", 10});
+  my_log_dict.insert({"banana", 20});
+  my_log_dict.insert({"apple", 15}); // Attempt to insert duplicate
+
+  std::cout << std::endl;
+  // Test overridden operator[]
+  my_log_dict["cherry"] = 30; // New element
+  std::cout << "Value of cherry: " << my_log_dict["cherry"]
+            << std::endl; // Existing element
+
+  std::cout << std::endl;
+  // Test overridden at
+  try {
+    std::cout << "Value of banana: " << my_log_dict.at("banana") << std::endl;
+    std::cout << "Value of orange (const at): "
+              << static_cast<const LoggingDict &>(my_log_dict).at("orange")
+              << std::endl; // Test const at
+  } catch (const std::out_of_range &e) {
+    std::cout << "Exception caught: " << e.what() << std::endl;
+  }
+
+  std::cout << std::endl;
+  std::cout << "Current LoggingDict state:" << std::endl;
+  for (const auto &pair : my_log_dict) {
+    std::cout << pair.first << ": " << pair.second << std::endl;
+  }
+  std::cout << "Size of my_log_dict: " << my_log_dict.size() << std::endl;
+
+  std::cout << std::endl;
+  // Test overridden erase
+  my_log_dict.erase("banana");
+  my_log_dict.erase("grape"); // Attempt to erase non-existent key
+
+  std::cout << std::endl;
+  std::cout << "LoggingDict state after erasures:" << std::endl;
+  for (const auto &pair : my_log_dict) {
+    std::cout << pair.first << ": " << pair.second << std::endl;
+  }
+  std::cout << "Size of my_log_dict: " << my_log_dict.size() << std::endl;
+
+  std::cout << std::endl;
+  std::cout
+      << "--- Demonstrating other DictWrapper features with LoggingDict ---"
+      << std::endl;
+  LoggingDict dict2 = {{"uno", 1}, {"dos", 2}}; // Initializer list constructor
+  std::cout << "dict2 initialized. Size: " << dict2.size() << std::endl;
+
+  dict2.emplace("tres", 3); // Emplace (should use base emplace, no logging for
+                            // this one unless emplace is also overridden)
+  std::cout << "After emplace('tres', 3), dict2['tres']: " << dict2.at("tres")
+            << std::endl;
+
+  if (dict2.contains("dos")) {
+    std::cout << "dict2 contains 'dos'." << std::endl;
+  }
+
+  dict2.clear(); // Clear (should use base clear)
+  std::cout << "After clear(), dict2 is empty: " << std::boolalpha
+            << dict2.empty() << std::endl;
+
+  return 0;
+}

--- a/include/dict_wrapper.h
+++ b/include/dict_wrapper.h
@@ -1,0 +1,240 @@
+#ifndef DICT_WRAPPER_H
+#define DICT_WRAPPER_H
+
+#include <unordered_map>
+#include <utility> // For std::pair, std::move
+
+template <typename K, typename V, typename InnerMap = std::unordered_map<K, V>>
+class DictWrapper {
+public:
+  using key_type = K;
+  using mapped_type = V;
+  using value_type = typename InnerMap::value_type; // std::pair<const K, V>
+  using size_type = typename InnerMap::size_type;
+  using difference_type = typename InnerMap::difference_type;
+  using hasher = typename InnerMap::hasher;
+  using key_equal = typename InnerMap::key_equal;
+  using allocator_type = typename InnerMap::allocator_type;
+  using reference = typename InnerMap::reference;
+  using const_reference = typename InnerMap::const_reference;
+  using pointer = typename InnerMap::pointer;
+  using const_pointer = typename InnerMap::const_pointer;
+  using iterator = typename InnerMap::iterator;
+  using const_iterator = typename InnerMap::const_iterator;
+
+protected:
+  InnerMap data;
+
+public:
+  // Constructors
+  DictWrapper() = default;
+  explicit DictWrapper(const InnerMap &d) : data(d) {}
+  explicit DictWrapper(InnerMap &&d) : data(std::move(d)) {}
+
+  template <typename InputIt>
+  DictWrapper(InputIt first, InputIt last) : data(first, last) {}
+
+  DictWrapper(std::initializer_list<value_type> il) : data(il) {}
+
+  // Copy constructor
+  DictWrapper(const DictWrapper &other) : data(other.data) {}
+
+  // Move constructor
+  DictWrapper(DictWrapper &&other) noexcept : data(std::move(other.data)) {}
+
+  // Assignment operators
+  DictWrapper &operator=(const DictWrapper &other) {
+    if (this != &other) {
+      data = other.data;
+    }
+    return *this;
+  }
+
+  DictWrapper &operator=(DictWrapper &&other) noexcept {
+    if (this != &other) {
+      data = std::move(other.data);
+    }
+    return *this;
+  }
+
+  DictWrapper &operator=(std::initializer_list<value_type> il) {
+    data = il;
+    return *this;
+  }
+
+  // Element access
+  virtual mapped_type &operator[](const key_type &key) { return data[key]; }
+
+  virtual mapped_type &operator[](key_type &&key) {
+    return data[std::move(key)];
+  }
+
+  virtual mapped_type &at(const key_type &key) { return data.at(key); }
+
+  virtual const mapped_type &at(const key_type &key) const {
+    return data.at(key);
+  }
+
+  // Iterators
+  virtual iterator begin() noexcept { return data.begin(); }
+
+  virtual const_iterator begin() const noexcept { return data.begin(); }
+
+  virtual const_iterator cbegin() const noexcept { return data.cbegin(); }
+
+  virtual iterator end() noexcept { return data.end(); }
+
+  virtual const_iterator end() const noexcept { return data.end(); }
+
+  virtual const_iterator cend() const noexcept { return data.cend(); }
+
+  // Capacity
+  virtual bool empty() const noexcept { return data.empty(); }
+
+  virtual size_type size() const noexcept { return data.size(); }
+
+  virtual size_type max_size() const noexcept { return data.max_size(); }
+
+  // Modifiers
+  virtual void clear() noexcept { data.clear(); }
+
+  virtual std::pair<iterator, bool> insert(const value_type &value) {
+    return data.insert(value);
+  }
+
+  virtual std::pair<iterator, bool> insert(value_type &&value) {
+    return data.insert(std::move(value));
+  }
+
+  template <typename P> std::pair<iterator, bool> insert(P &&value) {
+    return data.insert(std::forward<P>(value));
+  }
+
+  iterator insert(const_iterator hint, const value_type &value) {
+    return data.insert(hint, value);
+  }
+
+  iterator insert(const_iterator hint, value_type &&value) {
+    return data.insert(hint, std::move(value));
+  }
+
+  template <typename P> iterator insert(const_iterator hint, P &&value) {
+    return data.insert(hint, std::forward<P>(value));
+  }
+
+  template <typename InputIt> void insert(InputIt first, InputIt last) {
+    data.insert(first, last);
+  }
+
+  void insert(std::initializer_list<value_type> il) { data.insert(il); }
+
+  template <typename... Args>
+  std::pair<iterator, bool> emplace(Args &&...args) {
+    return data.emplace(std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  iterator emplace_hint(const_iterator hint, Args &&...args) {
+    return data.emplace_hint(hint, std::forward<Args>(args)...);
+  }
+
+  virtual iterator erase(const_iterator pos) { return data.erase(pos); }
+
+  virtual iterator erase(const_iterator first, const_iterator last) {
+    return data.erase(first, last);
+  }
+
+  virtual size_type erase(const key_type &key) { return data.erase(key); }
+
+  virtual void swap(DictWrapper &other) noexcept { data.swap(other.data); }
+
+  // Lookup
+  virtual size_type count(const key_type &key) const { return data.count(key); }
+
+  virtual iterator find(const key_type &key) { return data.find(key); }
+
+  virtual const_iterator find(const key_type &key) const {
+    return data.find(key);
+  }
+
+  virtual bool contains(const key_type &key) const {
+    if constexpr (requires { data.contains(key); }) { // C++20 feature
+      return data.contains(key);
+    } else {
+      return data.find(key) != data.end();
+    }
+  }
+
+  virtual std::pair<iterator, iterator> equal_range(const key_type &key) {
+    return data.equal_range(key);
+  }
+
+  virtual std::pair<const_iterator, const_iterator>
+  equal_range(const key_type &key) const {
+    return data.equal_range(key);
+  }
+
+  // Bucket interface (forwarding as is)
+  // These are less commonly overridden but provided for completeness
+  virtual float load_factor() const { return data.load_factor(); }
+
+  virtual float max_load_factor() const { return data.max_load_factor(); }
+
+  virtual void max_load_factor(float ml) { data.max_load_factor(ml); }
+
+  virtual void rehash(size_type count) { data.rehash(count); }
+
+  virtual void reserve(size_type count) { data.reserve(count); }
+
+  // Hash policy
+  virtual hasher hash_function() const { return data.hash_function(); }
+
+  virtual key_equal key_eq() const { return data.key_eq(); }
+
+  // Allow access to underlying data for derived classes if needed, though
+  // direct access is discouraged in favor of overriding methods.
+protected:
+  InnerMap &get_data() { return data; }
+  const InnerMap &get_data() const { return data; }
+};
+
+// Non-member functions
+template <typename K, typename V, typename InnerMap>
+void swap(DictWrapper<K, V, InnerMap> &lhs,
+          DictWrapper<K, V, InnerMap> &rhs) noexcept {
+  lhs.swap(rhs);
+}
+
+template <typename K, typename V, typename InnerMap>
+bool operator==(const DictWrapper<K, V, InnerMap> &lhs,
+                const DictWrapper<K, V, InnerMap> &rhs) {
+  // Access protected data for comparison. This requires DictWrapper to be a
+  // friend or to expose data via a protected getter. Using a getter is cleaner.
+  // Alternatively, iterate and compare, but direct map comparison is more
+  // efficient. For now, let's assume we need a way to compare underlying maps.
+  // If InnerMap itself doesn't support operator==, this will fail.
+  // std::unordered_map supports operator==.
+  // This comparison should ideally be virtual if derived classes change
+  // equality definition. However, for a simple wrapper, comparing underlying
+  // data is standard. Let's stick to comparing the protected 'data' member.
+  // This would require friend declaration or making 'data' accessible.
+  // A simpler approach for now, not requiring friend:
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (const auto &p : lhs) {
+    auto it = rhs.find(p.first);
+    if (it == rhs.end() || !(it->second == p.second)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename K, typename V, typename InnerMap>
+bool operator!=(const DictWrapper<K, V, InnerMap> &lhs,
+                const DictWrapper<K, V, InnerMap> &rhs) {
+  return !(lhs == rhs);
+}
+
+#endif // DICT_WRAPPER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         SkipListLib          # Added for skip_list_test
         PairwiseLib          # Added for pairwise_test
         RedBlackTreeLib      # Added for red_black_tree_test
+        DictWrapperLib       # Added for dict_wrapper_test
     )
 
     # Specific configurations for certain tests

--- a/tests/dict_wrapper_test.cpp
+++ b/tests/dict_wrapper_test.cpp
@@ -1,0 +1,356 @@
+#include "dict_wrapper.h" // Adjust path as necessary
+#include <gtest/gtest.h>
+#include <stdexcept> // For std::out_of_range
+#include <string>
+#include <vector>
+
+// Test fixture for DictWrapper
+class DictWrapperTest : public ::testing::Test {
+protected:
+  DictWrapper<std::string, int> dict;
+  DictWrapper<int, std::string> dict_int_str;
+};
+
+// Test basic construction and emptiness
+TEST_F(DictWrapperTest, ConstructorAndEmpty) {
+  EXPECT_TRUE(dict.empty());
+  EXPECT_EQ(0, dict.size());
+
+  DictWrapper<std::string, int> dict_init_list = {{"one", 1}, {"two", 2}};
+  EXPECT_FALSE(dict_init_list.empty());
+  EXPECT_EQ(2, dict_init_list.size());
+}
+
+// Test insertion and operator[]
+TEST_F(DictWrapperTest, InsertAndBrackets) {
+  auto result = dict.insert({"one", 1});
+  EXPECT_TRUE(result.second); // Successful insertion
+  EXPECT_EQ("one", result.first->first);
+  EXPECT_EQ(1, result.first->second);
+  EXPECT_EQ(1, dict.size());
+
+  dict["two"] = 2;
+  EXPECT_EQ(2, dict.size());
+  EXPECT_EQ(1, dict["one"]);
+  EXPECT_EQ(2, dict["two"]);
+
+  // Test insert existing
+  auto result_exist = dict.insert({"one", 10});
+  EXPECT_FALSE(result_exist.second); // Failed insertion (already exists)
+  EXPECT_EQ(1,
+            result_exist.first->second); // Iterator points to existing element
+  EXPECT_EQ(2, dict.size());             // Size should not change
+  EXPECT_EQ(1, dict["one"]);             // Value should not change
+}
+
+// Test `at` and `contains`
+TEST_F(DictWrapperTest, AtAndContains) {
+  dict["one"] = 1;
+  EXPECT_EQ(1, dict.at("one"));
+  EXPECT_TRUE(dict.contains("one"));
+  EXPECT_FALSE(dict.contains("two"));
+
+  EXPECT_THROW(dict.at("two"), std::out_of_range);
+
+  const auto &const_dict = dict;
+  EXPECT_EQ(1, const_dict.at("one"));
+  EXPECT_TRUE(const_dict.contains("one"));
+  EXPECT_THROW(const_dict.at("two"), std::out_of_range);
+}
+
+// Test erase
+TEST_F(DictWrapperTest, Erase) {
+  dict["one"] = 1;
+  dict["two"] = 2;
+  dict["three"] = 3;
+  EXPECT_EQ(3, dict.size());
+
+  // Erase by key
+  EXPECT_EQ(1, dict.erase("two")); // Erase existing
+  EXPECT_EQ(2, dict.size());
+  EXPECT_FALSE(dict.contains("two"));
+  EXPECT_EQ(0, dict.erase("two")); // Erase non-existing
+
+  // Erase by iterator
+  auto it = dict.find("one");
+  ASSERT_NE(dict.end(), it);
+  it = dict.erase(it); // Erase 'one'
+  EXPECT_EQ(1, dict.size());
+  EXPECT_FALSE(dict.contains("one"));
+  if (it != dict.end()) { // 'it' might be end() or point to 'three' depending
+                          // on map impl.
+    // In this case, with "three" remaining, it should point to "three" or end()
+    // For std::unordered_map, erase invalidates iterators, so we can't rely on
+    // it directly. A better test for erase(iterator) would check size and
+    // remaining elements.
+  }
+
+  // Erase by range (if applicable, though simple erase is more common)
+  dict["four"] = 4;
+  dict["five"] = 5;
+  // To test erase(first, last), we need sorted iterators or specific known
+  // order. For unordered_map, this is tricky. Let's clear and re-add for a
+  // simple range.
+  dict.clear();
+  dict["a"] = 1;
+  dict["b"] = 2;
+  dict["c"] = 3;
+  dict["d"] = 4;
+  // Erase all elements
+  dict.erase(dict.begin(), dict.end());
+  EXPECT_TRUE(dict.empty());
+}
+
+// Test clear and iterators
+TEST_F(DictWrapperTest, ClearAndIterators) {
+  dict["one"] = 1;
+  dict["two"] = 2;
+  ASSERT_FALSE(dict.empty());
+
+  dict.clear();
+  EXPECT_TRUE(dict.empty());
+  EXPECT_EQ(0, dict.size());
+  EXPECT_EQ(dict.begin(), dict.end());
+  EXPECT_EQ(dict.cbegin(), dict.cend());
+
+  // Check iterators on an empty map
+  DictWrapper<int, int> empty_dict;
+  EXPECT_EQ(empty_dict.begin(), empty_dict.end());
+}
+
+// Test count
+TEST_F(DictWrapperTest, Count) {
+  dict["one"] = 1;
+  EXPECT_EQ(1, dict.count("one"));
+  EXPECT_EQ(0, dict.count("two"));
+  dict.insert({"one", 10});        // Should not insert
+  EXPECT_EQ(1, dict.count("one")); // Still 1 for unique maps
+}
+
+// Test emplace
+TEST_F(DictWrapperTest, Emplace) {
+  auto result = dict.emplace("one", 1);
+  EXPECT_TRUE(result.second);
+  EXPECT_EQ("one", result.first->first);
+  EXPECT_EQ(1, result.first->second);
+  EXPECT_EQ(1, dict.size());
+
+  result = dict.emplace("one", 10); // Attempt to emplace existing
+  EXPECT_FALSE(result.second);
+  EXPECT_EQ(1, result.first->second); // Value remains original
+  EXPECT_EQ(1, dict.size());
+}
+
+// Test swap
+TEST_F(DictWrapperTest, Swap) {
+  DictWrapper<std::string, int> dict1 = {{"a", 1}, {"b", 2}};
+  DictWrapper<std::string, int> dict2 = {{"x", 10}, {"y", 20}, {"z", 30}};
+
+  dict1.swap(dict2);
+
+  EXPECT_EQ(3, dict1.size());
+  EXPECT_TRUE(dict1.contains("x"));
+  EXPECT_FALSE(dict1.contains("a"));
+
+  EXPECT_EQ(2, dict2.size());
+  EXPECT_TRUE(dict2.contains("a"));
+  EXPECT_FALSE(dict2.contains("x"));
+
+  swap(dict1, dict2); // Test non-member swap
+
+  EXPECT_EQ(2, dict1.size());
+  EXPECT_TRUE(dict1.contains("a"));
+  EXPECT_FALSE(dict1.contains("x"));
+
+  EXPECT_EQ(3, dict2.size());
+  EXPECT_TRUE(dict2.contains("x"));
+  EXPECT_FALSE(dict2.contains("a"));
+}
+
+// Test equality operators
+TEST_F(DictWrapperTest, EqualityOperators) {
+  DictWrapper<std::string, int> dict1 = {{"a", 1}, {"b", 2}};
+  DictWrapper<std::string, int> dict2 = {
+      {"b", 2}, {"a", 1}}; // Same elements, different order
+  DictWrapper<std::string, int> dict3 = {{"a", 1}, {"b", 3}}; // Different value
+  DictWrapper<std::string, int> dict4 = {{"a", 1}};           // Different size
+  DictWrapper<std::string, int> dict1_copy = dict1;
+
+  EXPECT_TRUE(dict1 == dict1_copy);
+  EXPECT_TRUE(dict1 ==
+              dict2); // Order doesn't matter for unordered_map comparison
+  EXPECT_FALSE(dict1 == dict3);
+  EXPECT_FALSE(dict1 == dict4);
+
+  EXPECT_FALSE(dict1 != dict1_copy);
+  EXPECT_FALSE(dict1 != dict2);
+  EXPECT_TRUE(dict1 != dict3);
+  EXPECT_TRUE(dict1 != dict4);
+}
+
+// --- Tests for derived class overriding behavior ---
+
+// Custom dictionary for testing override
+class MyCustomDict : public DictWrapper<std::string, int> {
+public:
+  using Base = DictWrapper<std::string, int>;
+  int insert_override_called = 0;
+  int erase_override_called = 0;
+  int at_override_called = 0;
+  int bracket_override_called = 0;
+
+  using Base::Base; // Inherit constructors
+
+  std::pair<iterator, bool> insert(const value_type &value) override {
+    insert_override_called++;
+    return Base::insert(value);
+  }
+
+  size_type erase(const key_type &key) override {
+    erase_override_called++;
+    return Base::erase(key);
+  }
+
+  mapped_type &at(const key_type &key) override {
+    at_override_called++;
+    return Base::at(key);
+  }
+
+  // Note: const version of 'at' also needs to be overridden if used.
+  const mapped_type &at(const key_type &key) const override {
+    // To make this testable, we'd need a mutable counter or a way to track
+    // calls in const methods. For simplicity, we'll focus on non-const `at` or
+    // use a trick. const_cast<MyCustomDict*>(this)->at_override_called++; //
+    // Not ideal, but for testing... Let's just rely on the non-const version
+    // for this simple test.
+    return Base::at(key);
+  }
+
+  mapped_type &operator[](const key_type &key) override {
+    bracket_override_called++;
+    return Base::operator[](key);
+  }
+};
+
+TEST_F(DictWrapperTest, DerivedClassOverrideInsert) {
+  MyCustomDict custom_dict;
+  custom_dict.insert({"hello", 100});
+  EXPECT_EQ(1, custom_dict.insert_override_called);
+  EXPECT_EQ(
+      100,
+      custom_dict["hello"]); // operator[] might also call overridden version
+  EXPECT_EQ(
+      1, custom_dict.bracket_override_called); // Reset for next specific tests
+  custom_dict.bracket_override_called = 0;
+
+  custom_dict.insert({"hello", 200}); // Attempt duplicate
+  EXPECT_EQ(2, custom_dict.insert_override_called);
+  EXPECT_EQ(100, custom_dict["hello"]); // Value should remain 100
+  EXPECT_EQ(1, custom_dict.bracket_override_called);
+}
+
+TEST_F(DictWrapperTest, DerivedClassOverrideErase) {
+  MyCustomDict custom_dict;
+  custom_dict["world"] = 200;
+  custom_dict.bracket_override_called = 0; // Reset after setup
+
+  custom_dict.erase("world");
+  EXPECT_EQ(1, custom_dict.erase_override_called);
+  EXPECT_FALSE(custom_dict.contains("world"));
+
+  custom_dict.erase("nonexistent");
+  EXPECT_EQ(2, custom_dict.erase_override_called);
+}
+
+TEST_F(DictWrapperTest, DerivedClassOverrideAt) {
+  MyCustomDict custom_dict;
+  custom_dict["key1"] = 300;
+  custom_dict.bracket_override_called = 0; // Reset
+
+  EXPECT_EQ(300, custom_dict.at("key1"));
+  EXPECT_EQ(1, custom_dict.at_override_called);
+
+  EXPECT_THROW(custom_dict.at("nonexistent"), std::out_of_range);
+  EXPECT_EQ(2,
+            custom_dict.at_override_called); // `at` is called even if it throws
+}
+
+TEST_F(DictWrapperTest, DerivedClassOverrideBrackets) {
+  MyCustomDict custom_dict;
+  custom_dict["newkey"] = 400; // Insertion
+  EXPECT_EQ(1, custom_dict.bracket_override_called);
+  EXPECT_EQ(400, custom_dict.at("newkey")); // Check value using public accessor
+  EXPECT_EQ(1, custom_dict.at_override_called); // at() was called
+  custom_dict.at_override_called = 0;           // Reset for next check
+
+  custom_dict["newkey"] = 401; // Access and assignment
+  EXPECT_EQ(2, custom_dict.bracket_override_called);
+  EXPECT_EQ(401, custom_dict.at("newkey")); // Check value
+  EXPECT_EQ(1, custom_dict.at_override_called);
+  custom_dict.at_override_called = 0; // Reset
+
+  // Access for reading
+  [[maybe_unused]] int val = custom_dict["newkey"];
+  EXPECT_EQ(3, custom_dict.bracket_override_called);
+}
+
+// Test iterators with a derived class (should behave like base)
+TEST_F(DictWrapperTest, DerivedClassIterators) {
+  MyCustomDict custom_dict = {{"a", 1}, {"b", 2}};
+  custom_dict.insert_override_called = 0; // Reset counter
+
+  std::vector<std::pair<std::string, int>> contents;
+  for (const auto &p : custom_dict) {
+    contents.push_back(p);
+  }
+  EXPECT_EQ(2, contents.size());
+  // Check if elements exist, order doesn't matter for unordered_map
+  bool found_a = false, found_b = false;
+  for (const auto &p : contents) {
+    if (p.first == "a" && p.second == 1)
+      found_a = true;
+    if (p.first == "b" && p.second == 2)
+      found_b = true;
+  }
+  EXPECT_TRUE(found_a);
+  EXPECT_TRUE(found_b);
+
+  // Ensure base iterators are used (no override calls for begin/end)
+  EXPECT_EQ(
+      0,
+      custom_dict.insert_override_called); // No insert calls during iteration
+}
+
+// Test const correctness with derived class
+TEST_F(DictWrapperTest, DerivedClassConstMethods) {
+  MyCustomDict custom_dict_mut;
+  custom_dict_mut["const_test"] = 500;
+  custom_dict_mut.bracket_override_called = 0; // Reset for this test
+
+  const MyCustomDict &const_ref_dict = custom_dict_mut;
+
+  EXPECT_TRUE(const_ref_dict.contains("const_test"));
+  EXPECT_EQ(500, const_ref_dict.at("const_test"));
+  // If const `at` was overridden to increment a mutable counter, we could test
+  // it here. Since it's not, we just check it works.
+
+  EXPECT_EQ(1, const_ref_dict.size());
+  EXPECT_FALSE(const_ref_dict.empty());
+
+  // Test iteration on const derived object
+  int count = 0;
+  for (const auto &pair : const_ref_dict) {
+    if (pair.first == "const_test" && pair.second == 500) {
+      count++;
+    }
+  }
+  EXPECT_EQ(1, count);
+  EXPECT_EQ(
+      0,
+      custom_dict_mut.bracket_override_called); // No non-const operator[] calls
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This commit introduces the `DictWrapper` class template, similar to Python's `UserDict`.

- It is defined in `include/dict_wrapper.h`.
- It wraps an `std::unordered_map` (or a user-specified map type) and provides a virtual interface for most dictionary operations, allowing derived classes to customize behavior.
- An example usage is provided in `examples/dict_wrapper_example.cpp`, demonstrating a `LoggingDict` that overrides methods to log its operations.
- Unit tests are included in `tests/dict_wrapper_test.cpp` to verify the functionality of `DictWrapper` and the overriding mechanism.
- CMake files have been updated to include the new library, example, and test targets.