### PR TITLE
feat: Add PriorityQueueMap (Indexed Priority Queue)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,10 @@ target_include_directories(SkipListLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/inc
 add_library(PairwiseLib INTERFACE)
 target_include_directories(PairwiseLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define PriorityQueueMapLib as an interface library (header-only)
+add_library(PriorityQueueMapLib INTERFACE)
+target_include_directories(PriorityQueueMapLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Define RedBlackTreeLib as an interface library (header-only)
 add_library(RedBlackTreeLib INTERFACE)
 target_include_directories(RedBlackTreeLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -201,6 +205,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         PairwiseLib          # Added for pairwise_example
         RedBlackTreeLib      # Added for red_black_tree_example
         DictWrapperLib       # Added for dict_wrapper_example
+        PriorityQueueMapLib  # Added for priority_queue_map_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It features:
 *   **Associative Containers:** `bimap.h` (bi-directional map), `dict.h` (Python-style dictionary), `const_dict.h` (compile-time constant dictionary), `flatMap.h` (sorted vector-based map), `chain_map.h` (view over multiple maps), `delta_map.h` (tracks changes to a map).
 *   **Set-like Structures:** `ordered_set.h` (preserves insertion order), `bounded_set.h` (fixed-capacity with FIFO eviction), `disjoint_set_union.h` (DSU, for tracking disjoint sets).
 *   **Specialized Arrays and Storage:** `persist_array.h` (memory-mapped array), `SlotMap.h` (stable keyed storage with O(1) operations).
-*   **Queues:** `heap_queue.h` (priority queue), `round_robin_queue.h`, `unique_queue.h` (elements are unique), `spsc.h` (single-producer, single-consumer), `deque.h` ([Deque](docs/README_Deque.md) - double-ended queue).
+*   **Queues:** `heap_queue.h` (priority queue), `PriorityQueueMap.h` ([PriorityQueueMap / Indexed Priority Queue](docs/README_PriorityQueueMap.md) - priority queue with key-based updates and removals), `round_robin_queue.h`, `unique_queue.h` (elements are unique), `spsc.h` (single-producer, single-consumer), `deque.h` ([Deque](docs/README_Deque.md) - double-ended queue).
 *   **Specialized Maps:** `interval_map.h` (maps values to intervals, distinct from `interval_tree.h`), `enum_map.h` (map keyed by enum values).
 *   **Sorted Lists:** `sorted_list.h` (elements kept sorted).
 *   **Probabilistic Data Structures:** `bloom_filter.h` (space-efficient probabilistic set membership).

--- a/docs/README_PriorityQueueMap.md
+++ b/docs/README_PriorityQueueMap.md
@@ -1,0 +1,113 @@
+# PriorityQueueMap (Indexed Priority Queue)
+
+## Overview
+
+The `PriorityQueueMap` is a C++ data structure that combines the features of a priority queue with a map. It allows for efficient retrieval of the element with the highest (or lowest) priority, like a standard priority queue, but also provides efficient mechanisms to update the priority of any element or remove any element by its key. This is often referred to as an Indexed Priority Queue or Updatable Priority Queue.
+
+This implementation is templated, allowing users to specify the types for keys, values, priorities, and a custom comparison function for priorities. By default, it behaves as a min-priority queue (smallest priority value is considered highest priority).
+
+## Template Parameters
+
+```cpp
+template <
+    typename KeyType,     // Type of the keys used to identify elements
+    typename ValueType,   // Type of the values associated with keys
+    typename PriorityType, // Type of the priorities
+    typename Compare = std::greater<PriorityType> // Comparator for priorities.
+                                                // std::greater for min-heap (default)
+                                                // std::less for max-heap
+>
+class PriorityQueueMap;
+```
+
+-   `KeyType`: The type of the unique keys that identify items in the queue. Must be hashable for use with `std::unordered_map`.
+-   `ValueType`: The type of the values stored alongside the keys.
+-   `PriorityType`: The type used for priorities. Must be comparable by the `Compare` functor.
+-   `Compare`: A comparison functor that determines the order of priorities.
+    -   Defaults to `std::greater<PriorityType>`, which results in a **min-priority queue** (the element with the *smallest* priority value is at the top).
+    -   To create a **max-priority queue** (element with the *largest* priority value at the top), use `std::less<PriorityType>`.
+
+## Core Features
+
+-   **Efficient Priority Updates:** Change the priority of an existing element in O(log N) time.
+-   **Efficient Key-Based Removal:** Remove any element by its key in O(log N) time.
+-   **Efficient Top Element Access:** Get the element with the highest (or lowest) priority in O(1) time.
+-   **Efficient Pop:** Remove the element with the highest (or lowest) priority in O(log N) time.
+-   **Key Existence Check:** Check if a key is present in the queue in O(1) average time.
+-   **Value Access:** Retrieve the value associated with a key in O(1) average time.
+
+## Time Complexity
+
+-   `push(key, value, priority)`: O(log N) if key is new. If key exists, it's an update, also O(log N).
+-   `pop()`: O(log N)
+-   `top_key()`, `top_priority()`: O(1)
+-   `update_priority(key, new_priority)`: O(log N)
+-   `remove(key)`: O(log N)
+-   `contains(key)`: O(1) on average (due to `std::unordered_map` lookup)
+-   `get_value(key)`: O(1) on average
+-   `empty()`, `size()`: O(1)
+
+N is the number of elements in the `PriorityQueueMap`.
+
+## Usage Example
+
+```cpp
+#include "PriorityQueueMap.h"
+#include <iostream>
+#include <string>
+
+int main() {
+    // Min-priority queue (default: smallest priority value is top)
+    cpp_utils::PriorityQueueMap<int, std::string, int> tasks;
+
+    tasks.push(1, "Write report", 20);
+    tasks.push(2, "Fix bug #101", 10); // Higher priority (lower value)
+    tasks.push(3, "Attend meeting", 15);
+
+    std::cout << "Top task: Key=" << tasks.top_key() << ", Prio=" << tasks.top_priority()
+              << ", Val=" << tasks.get_value(tasks.top_key()) << std::endl; // Expected: Key=2, Prio=10
+
+    tasks.update_priority(1, 5); // Update report priority to be highest
+    std::cout << "After update, top task: Key=" << tasks.top_key()
+              << ", Prio=" << tasks.top_priority() << std::endl; // Expected: Key=1, Prio=5
+
+    tasks.remove(3); // Remove meeting task
+
+    std::cout << "Tasks remaining: " << tasks.size() << std::endl;
+
+    while (!tasks.empty()) {
+        int key = tasks.top_key();
+        std::string val = tasks.get_value(key);
+        int prio = tasks.pop(); // pop() returns priority
+        std::cout << "Processing: Key=" << key << ", Val=" << val << ", Prio=" << prio << std::endl;
+    }
+
+    // Max-priority queue (largest priority value is top)
+    cpp_utils::PriorityQueueMap<std::string, std::string, double, std::less<double>> alerts;
+    alerts.push("CPU_Usage", "Server A CPU high", 0.95); // Priority 0.95
+    alerts.push("Mem_Usage", "Server B Mem high", 0.80); // Priority 0.80
+    alerts.push("Disk_Space", "Server A Disk low", 0.98); // Priority 0.98 (highest)
+
+    std::cout << "\nTop alert: " << alerts.top_key()
+              << " with priority " << alerts.top_priority() << std::endl; // Expected: Disk_Space, 0.98
+
+    return 0;
+}
+```
+
+## When to Use
+
+-   Algorithms where priorities of elements change dynamically (e.g., Dijkstra's algorithm with edge relaxations, A* search).
+-   Event-driven simulations where event times (priorities) can be rescheduled.
+-   Task schedulers where task priorities need to be adjusted or tasks can be cancelled.
+-   Any scenario requiring a priority queue with efficient random access, update, and removal capabilities.
+
+## Internal Implementation
+
+The `PriorityQueueMap` is typically implemented using:
+1.  A `std::vector` managed as a binary heap to store pairs of `(PriorityType, KeyType)`. This allows for efficient O(log N) heap operations.
+2.  An `std::unordered_map<KeyType, ValueType>` to store the actual values associated with the keys. This gives O(1) average time access to values.
+3.  An `std::unordered_map<KeyType, size_t>` to map keys to their current index within the heap vector. This is crucial for enabling O(log N) updates and removals by key, as it allows direct access to the element's position in the heap.
+
+When an element's priority is updated or an element is removed, its position in the heap is found using the `key_to_heap_index_` map, the operation is performed, and the heap property is restored by sifting the affected element(s) up or down.
+```

--- a/examples/priority_queue_map_example.cpp
+++ b/examples/priority_queue_map_example.cpp
@@ -1,0 +1,103 @@
+#include "PriorityQueueMap.h"
+#include <iostream>
+#include <string>
+#include <vector>
+
+void print_divider() {
+    std::cout << "\n----------------------------------------\n" << std::endl;
+}
+
+int main() {
+    std::cout << "PriorityQueueMap Example" << std::endl;
+    print_divider();
+
+    // --- Min-Priority Queue Example (default behavior) ---
+    std::cout << "--- Min-Priority Queue (int keys, string values, int priorities) ---" << std::endl;
+    cpp_utils::PriorityQueueMap<int, std::string, int> min_pq;
+
+    std::cout << "Is empty initially? " << (min_pq.empty() ? "Yes" : "No") << ", Size: " << min_pq.size() << std::endl;
+
+    min_pq.push(1, "Task A (Report)", 20);
+    min_pq.push(2, "Task B (Bugfix)", 10); // Lower priority value = higher actual priority for min-heap
+    min_pq.push(3, "Task C (Meeting)", 15);
+    min_pq.push(4, "Task D (Research)", 10); // Same priority as Task B
+
+    std::cout << "After pushes: Is empty? " << (min_pq.empty() ? "Yes" : "No") << ", Size: " << min_pq.size() << std::endl;
+
+    if (!min_pq.empty()) {
+        std::cout << "Top element: Key=" << min_pq.top_key()
+                  << ", Priority=" << min_pq.top_priority()
+                  << ", Value=\"" << min_pq.get_value(min_pq.top_key()) << "\"" << std::endl;
+    }
+
+    std::cout << "\nPushing existing key 1 with new value and priority (5):" << std::endl;
+    min_pq.push(1, "Task A v2 (Urgent Report)", 5); // Updates key 1
+    std::cout << "Top element after update: Key=" << min_pq.top_key()
+              << ", Priority=" << min_pq.top_priority()
+              << ", Value=\"" << min_pq.get_value(min_pq.top_key()) << "\"" << std::endl;
+
+    std::cout << "\nUpdating priority of key 3 (Task C) to 2:" << std::endl;
+    min_pq.update_priority(3, 2);
+    std::cout << "Top element after update: Key=" << min_pq.top_key()
+              << ", Priority=" << min_pq.top_priority()
+              << ", Value=\"" << min_pq.get_value(min_pq.top_key()) << "\"" << std::endl;
+
+
+    std::cout << "\nContains key 2? " << (min_pq.contains(2) ? "Yes" : "No") << std::endl;
+    std::cout << "Contains key 99? " << (min_pq.contains(99) ? "Yes" : "No") << std::endl;
+
+    std::cout << "\nRemoving key 2 (Task B):" << std::endl;
+    min_pq.remove(2);
+    std::cout << "Size after removing key 2: " << min_pq.size() << std::endl;
+    std::cout << "Contains key 2 after removal? " << (min_pq.contains(2) ? "Yes" : "No") << std::endl;
+    if (!min_pq.empty()) {
+        std::cout << "Top element after removing key 2: Key=" << min_pq.top_key()
+                  << ", Priority=" << min_pq.top_priority() << std::endl;
+    }
+
+    std::cout << "\nProcessing elements in priority order (min-heap):" << std::endl;
+    while (!min_pq.empty()) {
+        int key = min_pq.top_key();
+        std::string value = min_pq.get_value(key);
+        // Pop returns the priority of the popped element
+        int priority = min_pq.pop();
+        std::cout << "  Popped: Key=" << key << ", Value=\"" << value << "\", Priority=" << priority << std::endl;
+    }
+    std::cout << "Is empty finally? " << (min_pq.empty() ? "Yes" : "No") << ", Size: " << min_pq.size() << std::endl;
+
+    print_divider();
+
+    // --- Max-Priority Queue Example ---
+    std::cout << "--- Max-Priority Queue (string keys, string values, double priorities) ---" << std::endl;
+    cpp_utils::PriorityQueueMap<std::string, std::string, double, std::less<double>> max_pq;
+
+    max_pq.push("ALPHA", "System Alpha", 0.75);
+    max_pq.push("BETA", "System Beta", 0.90); // Higher priority value = higher actual priority for max-heap
+    max_pq.push("GAMMA", "System Gamma", 0.80);
+
+    if (!max_pq.empty()) {
+        std::cout << "Top element: Key=" << max_pq.top_key()
+                  << ", Priority=" << max_pq.top_priority()
+                  << ", Value=\"" << max_pq.get_value(max_pq.top_key()) << "\"" << std::endl;
+    }
+
+    std::cout << "\nUpdating priority of ALPHA to 0.95:" << std::endl;
+    max_pq.update_priority("ALPHA", 0.95);
+    if (!max_pq.empty()) {
+        std::cout << "Top element after update: Key=" << max_pq.top_key()
+                  << ", Priority=" << max_pq.top_priority() << std::endl;
+    }
+
+    std::cout << "\nProcessing elements in priority order (max-heap):" << std::endl;
+    while (!max_pq.empty()) {
+        std::string key = max_pq.top_key();
+        std::string value = max_pq.get_value(key);
+        double priority = max_pq.pop();
+        std::cout << "  Popped: Key=" << key << ", Value=\"" << value << "\", Priority=" << priority << std::endl;
+    }
+
+    print_divider();
+    std::cout << "Example finished." << std::endl;
+
+    return 0;
+}

--- a/include/PriorityQueueMap.h
+++ b/include/PriorityQueueMap.h
@@ -1,0 +1,276 @@
+#pragma once
+
+#include <vector>
+#include <unordered_map>
+#include <functional> // For std::less, std::greater
+#include <stdexcept>  // For std::out_of_range
+#include <utility>    // For std::pair, std::move
+
+namespace cpp_utils {
+
+// Forward declaration for friend class in potential future extensions or specific tests
+// template <typename KeyType, typename ValueType, typename PriorityType, typename Compare>
+// class PriorityQueueMapTester;
+
+template <
+    typename KeyType,
+    typename ValueType,
+    typename PriorityType,
+    typename Compare = std::greater<PriorityType> // Min-heap: smallest priority value is "top"
+>
+class PriorityQueueMap {
+public:
+    using KeyPriorityPair = std::pair<PriorityType, KeyType>;
+
+    PriorityQueueMap() = default;
+
+    // Modifiers
+    void push(const KeyType& key, const ValueType& value, const PriorityType& priority);
+    void push(KeyType&& key, ValueType&& value, PriorityType&& priority);
+
+    PriorityType pop(); // Returns priority of the popped element. User can get value via key if needed.
+                        // Consider returning std::pair<KeyType, ValueType> or just KeyType
+
+    void update_priority(const KeyType& key, const PriorityType& new_priority);
+    void remove(const KeyType& key);
+
+    // Accessors
+    bool empty() const {
+        return heap_.empty();
+    }
+
+    size_t size() const {
+        return heap_.size();
+    }
+
+    bool contains(const KeyType& key) const {
+        return key_to_heap_index_.count(key);
+    }
+
+    // Returns the key of the top element
+    const KeyType& top_key() const {
+        if (empty()) {
+            throw std::out_of_range("PriorityQueueMap is empty");
+        }
+        return heap_[0].second;
+    }
+
+    // Returns the priority of the top element
+    const PriorityType& top_priority() const {
+        if (empty()) {
+            throw std::out_of_range("PriorityQueueMap is empty");
+        }
+        return heap_[0].first;
+    }
+
+    // Returns the value associated with a key
+    const ValueType& get_value(const KeyType& key) const {
+        auto it = value_map_.find(key);
+        if (it == value_map_.end()) {
+            throw std::out_of_range("Key not found in PriorityQueueMap");
+        }
+        return it->second;
+    }
+
+    ValueType& get_value(const KeyType& key) {
+        auto it = value_map_.find(key);
+        if (it == value_map_.end()) {
+            throw std::out_of_range("Key not found in PriorityQueueMap");
+        }
+        return it->second;
+    }
+
+
+private:
+    std::vector<KeyPriorityPair> heap_; // Stores {priority, key}
+    std::unordered_map<KeyType, ValueType> value_map_;
+    std::unordered_map<KeyType, size_t> key_to_heap_index_;
+    Compare compare_priority_{}; // Defaults to std::greater for min-heap behavior with sift_up/down
+
+    // Internal helper methods
+    void sift_up(size_t index);
+    void sift_down(size_t index);
+    void swap_elements(size_t index1, size_t index2);
+
+    size_t parent(size_t index) const { return (index - 1) / 2; }
+    size_t left_child(size_t index) const { return 2 * index + 1; }
+    size_t right_child(size_t index) const { return 2 * index + 2; }
+
+    // Friend class for testing private members, if needed for complex scenarios
+    // friend class PriorityQueueMapTester<KeyType, ValueType, PriorityType, Compare>;
+};
+
+// --- Implementation of Member Functions ---
+
+template <typename K, typename V, typename P, typename C>
+void PriorityQueueMap<K, V, P, C>::swap_elements(size_t index1, size_t index2) {
+    if (index1 == index2) return;
+    std::swap(heap_[index1], heap_[index2]);
+    key_to_heap_index_[heap_[index1].second] = index1;
+    key_to_heap_index_[heap_[index2].second] = index2;
+}
+
+template <typename K, typename V, typename P, typename C>
+void PriorityQueueMap<K, V, P, C>::sift_up(size_t index) {
+    if (index == 0) return;
+    size_t p_idx = parent(index);
+    // For min-heap (compare_priority_ is std::greater):
+    // if heap_[index].first < heap_[p_idx].first, then compare_priority_(heap_[p_idx].first, heap_[index].first) is true
+    while (index > 0 && compare_priority_(heap_[p_idx].first, heap_[index].first)) {
+        swap_elements(index, p_idx);
+        index = p_idx;
+        if (index == 0) break;
+        p_idx = parent(index);
+    }
+}
+
+template <typename K, typename V, typename P, typename C>
+void PriorityQueueMap<K, V, P, C>::sift_down(size_t index) {
+    size_t min_index = index;
+    size_t l_idx = left_child(index);
+    size_t r_idx = right_child(index);
+
+    if (l_idx < heap_.size() && compare_priority_(heap_[min_index].first, heap_[l_idx].first)) {
+        min_index = l_idx;
+    }
+    if (r_idx < heap_.size() && compare_priority_(heap_[min_index].first, heap_[r_idx].first)) {
+        min_index = r_idx;
+    }
+
+    if (index != min_index) {
+        swap_elements(index, min_index);
+        sift_down(min_index);
+    }
+}
+
+template <typename K, typename V, typename P, typename C>
+void PriorityQueueMap<K, V, P, C>::push(const K& key, const V& value, const P& priority) {
+    if (contains(key)) {
+        // If key exists, update its priority and value
+        value_map_[key] = value; // Update value
+        update_priority(key, priority);
+    } else {
+        // New key
+        heap_.emplace_back(priority, key);
+        key_to_heap_index_[key] = heap_.size() - 1;
+        value_map_[key] = value;
+        sift_up(heap_.size() - 1);
+    }
+}
+
+template <typename K, typename V, typename P, typename C>
+void PriorityQueueMap<K, V, P, C>::push(K&& key, V&& value, P&& priority) {
+    // Use a temporary to check contains, as key might be moved.
+    // Create a copy for contains check if key is rvalue that will be moved.
+    K key_copy_for_lookup = key;
+    if (contains(key_copy_for_lookup)) {
+        // If key exists, update its priority and value
+        value_map_[key_copy_for_lookup] = std::move(value); // Update value
+        update_priority(key_copy_for_lookup, std::move(priority));
+    } else {
+        // New key
+        // Move key and priority into the pair, then move the pair into the vector
+        heap_.emplace_back(std::move(priority), std::move(key));
+        // After key is moved from, its state is valid but unspecified if it was an rvalue.
+        // We need to use the key from heap_.back().second for map insertion,
+        // as the original 'key' parameter might have been moved from.
+        key_to_heap_index_[heap_.back().second] = heap_.size() - 1;
+        value_map_[heap_.back().second] = std::move(value);
+        sift_up(heap_.size() - 1);
+    }
+}
+
+
+template <typename K, typename V, typename P, typename C>
+P PriorityQueueMap<K, V, P, C>::pop() {
+    if (empty()) {
+        throw std::out_of_range("PriorityQueueMap is empty (pop)");
+    }
+    auto top_element = heap_[0]; // Type is std::pair<P, K>
+
+    // Remove from value_map and key_to_heap_index_
+    value_map_.erase(top_element.second);
+    key_to_heap_index_.erase(top_element.second);
+
+    if (heap_.size() == 1) {
+        heap_.pop_back();
+    } else {
+        heap_[0] = heap_.back(); // Move last element to root
+        heap_.pop_back();
+        key_to_heap_index_[heap_[0].second] = 0; // Update index of moved element
+        sift_down(0);
+    }
+    return top_element.first; // Return priority
+}
+
+template <typename K, typename V, typename P, typename C>
+void PriorityQueueMap<K, V, P, C>::update_priority(const K& key, const P& new_priority) {
+    auto it = key_to_heap_index_.find(key);
+    if (it == key_to_heap_index_.end()) {
+        throw std::out_of_range("Key not found for priority update");
+    }
+    size_t index = it->second;
+    P old_priority = heap_[index].first; // P is PriorityType here
+    heap_[index].first = new_priority;
+
+    // If new priority is "better" (e.g. smaller for min-heap) than old, try sifting up.
+    // compare_priority_(old_priority, new_priority) will be true if new_priority < old_priority for min-heap.
+    if (compare_priority_(old_priority, new_priority)) {
+        sift_up(index);
+    } else {
+        // Otherwise (new priority is "worse" or same), try sifting down.
+        // Sifting down is safe even if priority is same, just won't move.
+        sift_down(index);
+    }
+}
+
+template <typename K, typename V, typename P, typename C>
+void PriorityQueueMap<K, V, P, C>::remove(const K& key) {
+    auto it = key_to_heap_index_.find(key);
+    if (it == key_to_heap_index_.end()) {
+        throw std::out_of_range("Key not found for removal");
+    }
+    size_t index_to_remove = it->second;
+    P priority_of_removed_element = heap_[index_to_remove].first; // Priority of the element being removed
+
+    if (heap_.empty()) { // Should be caught by key_to_heap_index_.find already
+        return;
+    }
+
+    // If the element to remove is the last element in the heap
+    if (index_to_remove == heap_.size() - 1) {
+        heap_.pop_back();
+    } else {
+        // Not the last element. Swap it with the last element.
+        // The key of the element being moved from the end is heap_.back().second.
+        // This element will replace the one at index_to_remove.
+        // Our swap_elements helper correctly updates key_to_heap_index_ for both swapped parties.
+        swap_elements(index_to_remove, heap_.size() - 1);
+
+        // Now pop the (original) element (which is now at the end)
+        heap_.pop_back();
+
+        // The element that was moved from the end is now at index_to_remove.
+        // We need to restore heap property for this moved element.
+        // Its current priority is heap_[index_to_remove].first.
+        // We compare this with the priority of the element it replaced (priority_of_removed_element)
+        // to decide whether to sift up or down. This is similar to update_priority's logic.
+        if (index_to_remove < heap_.size()) { // Ensure index is still valid (heap didn't become empty or too small)
+            P current_priority_at_index = heap_[index_to_remove].first;
+            if (compare_priority_(priority_of_removed_element, current_priority_at_index)) {
+                // If the moved element's priority is "better" (e.g., smaller for min-heap)
+                // than the priority of the element it replaced, it might need to go up.
+                sift_up(index_to_remove);
+            } else {
+                // Otherwise (priority is "worse" or same), it might need to go down.
+                sift_down(index_to_remove);
+            }
+        }
+    }
+
+    // Remove the key from tracking maps after heap operations are complete
+    key_to_heap_index_.erase(key);
+    value_map_.erase(key);
+}
+
+} // namespace cpp_utils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         PairwiseLib          # Added for pairwise_test
         RedBlackTreeLib      # Added for red_black_tree_test
         DictWrapperLib       # Added for dict_wrapper_test
+        PriorityQueueMapLib  # Added for priority_queue_map_test
     )
 
     # Specific configurations for certain tests

--- a/tests/priority_queue_map_test.cpp
+++ b/tests/priority_queue_map_test.cpp
@@ -1,0 +1,318 @@
+#include "gtest/gtest.h"
+#include "PriorityQueueMap.h" // Assuming it's in the include path
+
+#include <string>
+#include <vector>
+
+// Basic test fixture
+class PriorityQueueMapTest : public ::testing::Test {
+protected:
+    cpp_utils::PriorityQueueMap<int, std::string, int> pq_int_string_int; // Min-heap by default
+    cpp_utils::PriorityQueueMap<std::string, double, double, std::less<double>> pq_string_double_double_max; // Max-heap
+};
+
+TEST_F(PriorityQueueMapTest, IsEmptyInitially) {
+    EXPECT_TRUE(pq_int_string_int.empty());
+    EXPECT_EQ(0, pq_int_string_int.size());
+}
+
+TEST_F(PriorityQueueMapTest, PushAndTop) {
+    pq_int_string_int.push(1, "one", 10);
+    EXPECT_FALSE(pq_int_string_int.empty());
+    EXPECT_EQ(1, pq_int_string_int.size());
+    EXPECT_EQ(1, pq_int_string_int.top_key());
+    EXPECT_EQ(10, pq_int_string_int.top_priority());
+    EXPECT_EQ("one", pq_int_string_int.get_value(1));
+
+    pq_int_string_int.push(2, "two", 5); // Lower priority, should be new top
+    EXPECT_EQ(2, pq_int_string_int.size());
+    EXPECT_EQ(2, pq_int_string_int.top_key());
+    EXPECT_EQ(5, pq_int_string_int.top_priority());
+    EXPECT_EQ("two", pq_int_string_int.get_value(2));
+
+    pq_int_string_int.push(3, "three", 12); // Higher priority
+    EXPECT_EQ(3, pq_int_string_int.size());
+    EXPECT_EQ(2, pq_int_string_int.top_key()); // Top should still be 2
+    EXPECT_EQ(5, pq_int_string_int.top_priority());
+    EXPECT_EQ("three", pq_int_string_int.get_value(3));
+}
+
+TEST_F(PriorityQueueMapTest, Pop) {
+    pq_int_string_int.push(1, "one", 10);
+    pq_int_string_int.push(2, "two", 5);
+    pq_int_string_int.push(3, "three", 12);
+
+    EXPECT_EQ(5, pq_int_string_int.pop()); // Pops key 2
+    EXPECT_EQ(1, pq_int_string_int.top_key());
+    EXPECT_EQ(10, pq_int_string_int.top_priority());
+    EXPECT_EQ(2, pq_int_string_int.size());
+    EXPECT_FALSE(pq_int_string_int.contains(2));
+
+    EXPECT_EQ(10, pq_int_string_int.pop()); // Pops key 1
+    EXPECT_EQ(3, pq_int_string_int.top_key());
+    EXPECT_EQ(12, pq_int_string_int.top_priority());
+    EXPECT_EQ(1, pq_int_string_int.size());
+    EXPECT_FALSE(pq_int_string_int.contains(1));
+
+    EXPECT_EQ(12, pq_int_string_int.pop()); // Pops key 3
+    EXPECT_TRUE(pq_int_string_int.empty());
+    EXPECT_EQ(0, pq_int_string_int.size());
+    EXPECT_FALSE(pq_int_string_int.contains(3));
+
+    EXPECT_THROW(pq_int_string_int.pop(), std::out_of_range);
+    EXPECT_THROW(pq_int_string_int.top_key(), std::out_of_range);
+}
+
+TEST_F(PriorityQueueMapTest, PushExistingKeyUpdates) {
+    pq_int_string_int.push(1, "one_v1", 10);
+    EXPECT_EQ("one_v1", pq_int_string_int.get_value(1));
+    EXPECT_EQ(10, pq_int_string_int.top_priority());
+
+    pq_int_string_int.push(1, "one_v2", 5); // Update value and priority
+    EXPECT_EQ(1, pq_int_string_int.size());
+    EXPECT_EQ("one_v2", pq_int_string_int.get_value(1));
+    EXPECT_EQ(5, pq_int_string_int.top_priority()); // Priority updated, should be top
+
+    pq_int_string_int.push(2, "two", 20);
+    pq_int_string_int.push(1, "one_v3", 30); // Update again, no longer top
+    EXPECT_EQ(2, pq_int_string_int.size());
+    EXPECT_EQ("one_v3", pq_int_string_int.get_value(1));
+    EXPECT_EQ(2, pq_int_string_int.top_key());
+    EXPECT_EQ(20, pq_int_string_int.top_priority());
+}
+
+TEST_F(PriorityQueueMapTest, UpdatePriority) {
+    pq_int_string_int.push(1, "one", 10);
+    pq_int_string_int.push(2, "two", 20);
+    pq_int_string_int.push(3, "three", 5); // Top: 3 (5)
+
+    EXPECT_EQ(3, pq_int_string_int.top_key());
+
+    // Decrease priority of 1 (make it better for min-heap)
+    pq_int_string_int.update_priority(1, 2); // 1 (2), 3 (5), 2 (20)
+    EXPECT_EQ(1, pq_int_string_int.top_key());
+    EXPECT_EQ(2, pq_int_string_int.top_priority());
+
+    // Increase priority of 1 (make it worse for min-heap)
+    pq_int_string_int.update_priority(1, 25); // 3 (5), 2 (20), 1 (25)
+    EXPECT_EQ(3, pq_int_string_int.top_key());
+    EXPECT_EQ(5, pq_int_string_int.top_priority());
+
+    // Update priority of current top
+    pq_int_string_int.update_priority(3, 30); // 2 (20), 1 (25), 3 (30)
+    EXPECT_EQ(2, pq_int_string_int.top_key());
+    EXPECT_EQ(20, pq_int_string_int.top_priority());
+
+    // Update to same priority
+    pq_int_string_int.update_priority(2, 20);
+    EXPECT_EQ(2, pq_int_string_int.top_key());
+    EXPECT_EQ(20, pq_int_string_int.top_priority());
+
+
+    EXPECT_THROW(pq_int_string_int.update_priority(100, 1), std::out_of_range); // Key not found
+}
+
+TEST_F(PriorityQueueMapTest, Remove) {
+    pq_int_string_int.push(1, "one", 10);
+    pq_int_string_int.push(2, "two", 5);   // Top
+    pq_int_string_int.push(3, "three", 12);
+    pq_int_string_int.push(4, "four", 3);  // New Top
+    pq_int_string_int.push(5, "five", 8);
+    // Heap state (key:priority): 4:3, 2:5, 3:12, 1:10, 5:8 (approx, depends on insertion details)
+    // Actual heap: (4,3), (5,8), (3,12), (1,10), (2,5) -> after sifting from (2,5) at (1)
+    // (4,3)
+    // (2,5) (3,12)
+    // (1,10) (5,8)
+    // After 4:3 -> (4,3), (2,5), (3,12), (1,10), (5,8)
+    // After 5:8 -> (4,3), (5,8), (3,12), (1,10), (2,5) -> key_to_idx: 4:0, 5:1, 3:2, 1:3, 2:4
+    // Pushed 1(10), 2(5), 3(12), 4(3), 5(8)
+    // Initial:
+    // (1,10)
+    // Push 2(5): (2,5), (1,10)
+    // Push 3(12): (2,5), (1,10), (3,12)
+    // Push 4(3): (4,3), (1,10), (3,12), (2,5)  -- 2(5) was root's child, 1(10) was other child
+    // Push 5(8): (4,3), (5,8), (3,12), (2,5), (1,10)
+    // Order of keys if popped: 4, 2, 5, 1, 3
+    // Priorities:             3, 5, 8, 10,12
+
+    EXPECT_EQ(5, pq_int_string_int.size());
+    EXPECT_EQ(4, pq_int_string_int.top_key());
+
+    // Remove top (4, priority 3)
+    pq_int_string_int.remove(4); // (2,5), (5,8), (3,12), (1,10)
+    EXPECT_EQ(4, pq_int_string_int.size());
+    EXPECT_FALSE(pq_int_string_int.contains(4));
+    EXPECT_EQ(2, pq_int_string_int.top_key()); // New top should be 2 (priority 5)
+    EXPECT_EQ(5, pq_int_string_int.top_priority());
+
+    // Remove a leaf (e.g. 1, priority 10 - assuming its a leaf or easily becomes one)
+    // Current: (2,5), (5,8), (3,12), (1,10)
+    pq_int_string_int.remove(1); // (2,5), (5,8), (3,12)
+    EXPECT_EQ(3, pq_int_string_int.size());
+    EXPECT_FALSE(pq_int_string_int.contains(1));
+    EXPECT_EQ(2, pq_int_string_int.top_key()); // Top still 2
+
+    // Remove a middle element (e.g. 5, priority 8)
+    // Current: (2,5), (5,8), (3,12)
+    pq_int_string_int.remove(5); // (2,5), (3,12)
+    EXPECT_EQ(2, pq_int_string_int.size());
+    EXPECT_FALSE(pq_int_string_int.contains(5));
+    EXPECT_EQ(2, pq_int_string_int.top_key());
+
+    pq_int_string_int.remove(2); // (3,12)
+    EXPECT_EQ(1, pq_int_string_int.size());
+    EXPECT_FALSE(pq_int_string_int.contains(2));
+    EXPECT_EQ(3, pq_int_string_int.top_key());
+
+    pq_int_string_int.remove(3);
+    EXPECT_TRUE(pq_int_string_int.empty());
+    EXPECT_FALSE(pq_int_string_int.contains(3));
+
+    EXPECT_THROW(pq_int_string_int.remove(100), std::out_of_range); // Key not found
+}
+
+TEST_F(PriorityQueueMapTest, Contains) {
+    EXPECT_FALSE(pq_int_string_int.contains(1));
+    pq_int_string_int.push(1, "one", 10);
+    EXPECT_TRUE(pq_int_string_int.contains(1));
+    pq_int_string_int.push(2, "two", 5);
+    EXPECT_TRUE(pq_int_string_int.contains(2));
+    pq_int_string_int.pop(); // Removes 2
+    EXPECT_TRUE(pq_int_string_int.contains(1));
+    EXPECT_FALSE(pq_int_string_int.contains(2));
+}
+
+TEST_F(PriorityQueueMapTest, GetValue) {
+    pq_int_string_int.push(1, "apple", 10);
+    pq_int_string_int.push(2, "banana", 5);
+    EXPECT_EQ("apple", pq_int_string_int.get_value(1));
+    EXPECT_EQ("banana", pq_int_string_int.get_value(2));
+
+    pq_int_string_int.push(1, "apricot", 12); // Update value
+    EXPECT_EQ("apricot", pq_int_string_int.get_value(1));
+
+    const auto& const_pq = pq_int_string_int;
+    EXPECT_EQ("apricot", const_pq.get_value(1));
+
+    EXPECT_THROW(pq_int_string_int.get_value(3), std::out_of_range);
+    EXPECT_THROW(const_pq.get_value(3), std::out_of_range);
+}
+
+TEST_F(PriorityQueueMapTest, MaxHeapOperations) {
+    pq_string_double_double_max.push("taskA", 10.0, 10.0); // Key, Value, Priority
+    pq_string_double_double_max.push("taskB", 20.0, 20.0);
+    pq_string_double_double_max.push("taskC", 5.0, 5.0);
+
+    EXPECT_EQ("taskB", pq_string_double_double_max.top_key());
+    EXPECT_EQ(20.0, pq_string_double_double_max.top_priority());
+
+    EXPECT_EQ(20.0, pq_string_double_double_max.pop()); // Pops taskB
+
+    EXPECT_EQ("taskA", pq_string_double_double_max.top_key());
+    EXPECT_EQ(10.0, pq_string_double_double_max.top_priority());
+
+    pq_string_double_double_max.update_priority("taskC", 25.0); // Increase priority of C
+    EXPECT_EQ("taskC", pq_string_double_double_max.top_key());
+    EXPECT_EQ(25.0, pq_string_double_double_max.top_priority());
+}
+
+TEST_F(PriorityQueueMapTest, StressTestLike) {
+    const int num_elements = 1000;
+    for (int i = 0; i < num_elements; ++i) {
+        pq_int_string_int.push(i, "val_" + std::to_string(i), num_elements - i); // Higher i = lower priority val
+    }
+    EXPECT_EQ(num_elements, pq_int_string_int.size());
+    EXPECT_EQ(num_elements - 1, pq_int_string_int.top_key()); // Key n-1 has priority 1 (highest)
+    EXPECT_EQ(1, pq_int_string_int.top_priority());
+
+    for (int i = 0; i < num_elements / 2; ++i) {
+        int key_to_update = i * 2; // Update even keys
+        // Make their priority worse (larger value for min-heap)
+        pq_int_string_int.update_priority(key_to_update, (num_elements - key_to_update) + num_elements);
+    }
+
+    // Check order after updates and pops
+    int last_priority = -1;
+    int count = 0;
+    while(!pq_int_string_int.empty()) {
+        int current_priority = pq_int_string_int.top_priority();
+        if (last_priority != -1) {
+            EXPECT_LE(last_priority, current_priority);
+        }
+        last_priority = pq_int_string_int.pop();
+        count++;
+    }
+    EXPECT_EQ(num_elements, count);
+}
+
+TEST_F(PriorityQueueMapTest, RValuePush) {
+    pq_int_string_int.push(100, std::string("hundred"), 100);
+    EXPECT_EQ("hundred", pq_int_string_int.get_value(100));
+    EXPECT_EQ(100, pq_int_string_int.top_key());
+
+    pq_int_string_int.push(100, std::string("hundred_v2"), 50); // Update with rvalues
+    EXPECT_EQ("hundred_v2", pq_int_string_int.get_value(100));
+    EXPECT_EQ(50, pq_int_string_int.top_priority());
+
+    pq_int_string_int.push(200, std::string("two_hundred"), 200);
+    EXPECT_EQ(100, pq_int_string_int.top_key()); // 100 (50) should still be top
+}
+
+TEST_F(PriorityQueueMapTest, RemoveComplexScenario) {
+    // Build a specific heap structure
+    // (0,0) (1,1) (2,2) (3,3) (4,4) (5,5) (6,6)
+    //             0(0)
+    //       /             \
+    //     1(1)            2(2)
+    //    /   \           /   \
+    //  3(3)  4(4)      5(5)  6(6)
+    for(int i=0; i<=6; ++i) {
+        pq_int_string_int.push(i, "v"+std::to_string(i), i);
+    }
+    EXPECT_EQ(0, pq_int_string_int.top_key());
+
+    // Remove root: 0
+    // Last element is 6(6). It moves to root.
+    // Sift down 6(6): should swap with 1(1).
+    // Heap becomes: 1(1) at root. 6(6) becomes child of 1(1).
+    //             1(1)
+    //       /             \
+    //     3(3)            2(2)   <-- Error in manual trace, 6(6) swaps with 1(1), then 6(6) sifts down again
+    //    /   \           /   \
+    //  6(6)  4(4)      5(5)
+    // Expected after removing 0: top is 1.
+    pq_int_string_int.remove(0);
+    EXPECT_EQ(6, pq_int_string_int.size());
+    EXPECT_FALSE(pq_int_string_int.contains(0));
+    EXPECT_EQ(1, pq_int_string_int.top_key());
+    EXPECT_EQ(1, pq_int_string_int.top_priority());
+
+    // Current top is 1. Remove 3 (a leaf child of 1)
+    //             1(1)
+    //       /             \
+    //     3(3)            2(2)
+    //    /   \           /
+    //  6(6)  4(4)      5(5)
+    // Remove 3(3). Last is 5(5). 5(5) moves to 3's spot.
+    // Sift up/down 5(5) at 3's old spot. Parent 1(1) is smaller. Children none. Stays.
+    // Top is 1.
+    pq_int_string_int.remove(3);
+    EXPECT_EQ(5, pq_int_string_int.size());
+    EXPECT_FALSE(pq_int_string_int.contains(3));
+    EXPECT_EQ(1, pq_int_string_int.top_key());
+    EXPECT_EQ(1, pq_int_string_int.top_priority());
+
+    // Pop all elements and check order
+    std::vector<int> expected_keys_after_removals = {1, 2, 4, 5, 6};
+    std::vector<int> popped_keys;
+    while(!pq_int_string_int.empty()){
+        popped_keys.push_back(pq_int_string_int.top_key());
+        pq_int_string_int.pop();
+    }
+    EXPECT_EQ(expected_keys_after_removals, popped_keys);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This commit introduces a new data structure: `PriorityQueueMap`.

The `PriorityQueueMap` (also known as an Indexed Priority Queue) combines features of a priority queue and a map. It allows for:
- Efficient O(log N) updates to the priority of existing items.
- Efficient O(log N) removal of items by key.
- O(1) access to the top priority item.
- O(1) average time for checking key existence and value retrieval.

The implementation is templated for KeyType, ValueType, PriorityType, and a custom Compare functor (defaulting to a min-heap).

Includes:
- `include/PriorityQueueMap.h`: Header file with implementation.
- `tests/priority_queue_map_test.cpp`: Unit tests.
- `examples/priority_queue_map_example.cpp`: Example usage.
- `docs/README_PriorityQueueMap.md`: Documentation for the new component.
- Updates to main `README.md` and CMakeLists to integrate the new component.