### PR TITLE
feat: Add DynamicBitset data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,10 @@ target_include_directories(CordLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include
 add_library(RibbonFilterLib INTERFACE)
 target_include_directories(RibbonFilterLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define DynamicBitsetLib as an interface library (header-only)
+add_library(DynamicBitsetLib INTERFACE)
+target_include_directories(DynamicBitsetLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -246,6 +250,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         BTreeLib             # Added for btree_example
         CordLib              # Added for cord_example
         RibbonFilterLib      # Added for ribbon_filter_example
+        DynamicBitsetLib     # Added for dynamic_bitset_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/docs/README_DynamicBitset.md
+++ b/docs/README_DynamicBitset.md
@@ -1,0 +1,123 @@
+# DynamicBitset
+
+## Overview
+
+`DynamicBitset` is a C++ class that implements a bitset (also known as a bitarray or bitvector) whose size is determined at runtime. It provides efficient storage and manipulation of a sequence of bits. This is in contrast to `std::bitset` where the size must be a compile-time constant. `DynamicBitset` aims to offer a similar interface to `std::bitset` where applicable, along with the flexibility of dynamic sizing.
+
+It is useful for representing a compact set of boolean flags, tracking states, or performing bitwise operations on data whose size isn't known until runtime.
+
+## Features
+
+*   **Dynamic Sizing**: The number of bits can be specified during construction.
+*   **Efficient Storage**: Bits are packed into an array of unsigned integer blocks (typically `uint64_t`).
+*   **Bit Manipulation**:
+    *   Set, reset, and flip individual bits.
+    *   Set, reset, and flip all bits in the set.
+    *   Access individual bits using `operator[]` (returns a proxy object for assignment and direct read).
+    *   Test individual bits using `test()`.
+*   **Query Operations**:
+    *   `size()`: Get the number of bits.
+    *   `count()`: Get the number of bits that are set to true.
+    *   `all()`: Check if all bits are set.
+    *   `any()`: Check if any bit is set.
+    *   `none()`: Check if no bits are set (i.e., all are false).
+    *   `empty()`: Check if the bitset has a size of 0.
+*   **Bitwise Operations**:
+    *   `operator&=`, `operator|=`, `operator^=` for bitwise AND, OR, XOR with another `DynamicBitset` of the same size.
+*   **Bounds Checking**: Accessing bits out of range will throw `std::out_of_range`. Operations on bitsets of mismatched sizes (for bitwise ops) will throw `std::invalid_argument`.
+
+## Internal Representation
+
+Bits are stored in a `std::vector<BlockType>`, where `BlockType` is `uint64_t`. The least significant bit of the first block corresponds to bit 0, and so on. Padding bits in the last block (if `num_bits_` is not a multiple of `kBitsPerBlock`) are always maintained as 0 to ensure correctness of operations like `count()`, `any()`, `none()`, and bitwise operations.
+
+## Usage
+
+### Include Header
+
+```cpp
+#include "DynamicBitset.h"
+```
+
+### Construction
+
+```cpp
+// Creates an empty bitset (size 0)
+DynamicBitset bs1;
+
+// Creates a bitset with 100 bits, all initialized to false (default)
+DynamicBitset bs2(100);
+
+// Creates a bitset with 64 bits, all initialized to true
+DynamicBitset bs3(64, true);
+```
+
+### Accessing and Modifying Bits
+
+```cpp
+DynamicBitset bs(10); // 10 bits, all false
+
+bs.set(0);        // Set bit 0 to true:  1000000000
+bs.set(3, true);  // Set bit 3 to true:  1001000000
+bs.set(5, false); // Set bit 5 to false (no change if already false)
+
+bs[1] = true;     // Set bit 1 using proxy: 1101000000
+bs[0].flip();     // Flip bit 0 using proxy: 0101000000
+
+if (bs.test(1)) { // Check bit 1
+    // ... bit 1 is true
+}
+
+bool val_at_2 = bs[2]; // Read bit 2 using proxy
+
+bs.reset(1);      // Reset bit 1 to false: 0001000000
+bs.flip(3);       // Flip bit 3: 0000000000
+```
+
+### Whole-Set Operations
+
+```cpp
+DynamicBitset bs(5); // 00000
+bs.set();            // Set all bits: 11111
+bs.reset();          // Reset all bits: 00000
+bs.flip();           // Flip all bits: 11111
+```
+
+### Querying
+
+```cpp
+DynamicBitset bs(8);
+bs.set(1); bs.set(3); bs.set(5); // 01010100
+
+std::cout << "Size: " << bs.size();     // Output: Size: 8
+std::cout << "Count: " << bs.count();   // Output: Count: 3
+std::cout << "Any set? " << bs.any();   // Output: Any set? true
+std::cout << "None set? " << bs.none(); // Output: None set? false
+std::cout << "All set? " << bs.all();   // Output: All set? false
+```
+
+### Bitwise Operations
+
+```cpp
+DynamicBitset a(4, false); // 0000
+a.set(0); a.set(2);        // a is 1010
+
+DynamicBitset b(4, false); // 0000
+b.set(1); b.set(2);        // b is 0110
+
+a &= b; // a becomes 0010 (a is modified)
+// a |= b;
+// a ^= b;
+
+// These require bitsets of the same size.
+// DynamicBitset c(5);
+// a &= c; // throws std::invalid_argument
+```
+
+## Future Considerations (Not Implemented)
+
+*   `resize()`: Method to change the size of the bitset after construction.
+*   `operator~()`: Bitwise NOT operator (returning a new bitset).
+*   Conversion to/from string or integer types.
+*   `find_first()`, `find_next()` for finding set bits.
+
+This `DynamicBitset` provides a flexible and efficient way to work with sequences of bits when the size is not known at compile time.

--- a/examples/dynamic_bitset_example.cpp
+++ b/examples/dynamic_bitset_example.cpp
@@ -1,0 +1,114 @@
+#include "DynamicBitset.h"
+#include <iostream>
+#include <vector>
+
+void print_bitset_details(const DynamicBitset& bs, const std::string& name) {
+    std::cout << "Bitset '" << name << "':\n";
+    std::cout << "  Size: " << bs.size() << "\n";
+    std::cout << "  Bits: ";
+    if (bs.empty()) {
+        std::cout << "(empty)";
+    } else {
+        for (size_t i = 0; i < bs.size(); ++i) {
+            std::cout << (bs[i] ? '1' : '0');
+        }
+    }
+    std::cout << "\n";
+    std::cout << "  Count of set bits: " << bs.count() << "\n";
+    std::cout << "  All bits set? " << (bs.all() ? "Yes" : "No") << "\n";
+    std::cout << "  Any bit set? " << (bs.any() ? "Yes" : "No") << "\n";
+    std::cout << "  No bits set? " << (bs.none() ? "Yes" : "No") << "\n";
+    std::cout << "----------------------------------------\n";
+}
+
+int main() {
+    std::cout << "DynamicBitset Examples\n";
+    std::cout << "========================\n\n";
+
+    // Example 1: Default constructor and basic operations
+    DynamicBitset bs1(10); // 10 bits, initialized to false
+    print_bitset_details(bs1, "bs1 (10 bits, default false)");
+
+    bs1.set(1);
+    bs1.set(3);
+    bs1.set(5, true);
+    bs1.set(7);
+    print_bitset_details(bs1, "bs1 after setting bits 1, 3, 5, 7");
+
+    std::cout << "bs1[3] is " << (bs1[3] ? "true" : "false") << std::endl;
+    bs1[3] = false;
+    std::cout << "bs1[3] after bs1[3] = false is " << (bs1[3] ? "true" : "false") << std::endl;
+    print_bitset_details(bs1, "bs1 after bs1[3] = false");
+
+    bs1.flip(0);
+    bs1[9].flip(); // Using proxy flip
+    print_bitset_details(bs1, "bs1 after flipping bits 0 and 9");
+
+    bs1.reset(5);
+    print_bitset_details(bs1, "bs1 after resetting bit 5");
+
+    // Example 2: Constructor with initial value
+    DynamicBitset bs2(17, true); // 17 bits, initialized to true
+    print_bitset_details(bs2, "bs2 (17 bits, default true)");
+    bs2.reset(); // Reset all to false
+    print_bitset_details(bs2, "bs2 after global reset()");
+
+    bs2.set(); // Set all to true
+    print_bitset_details(bs2, "bs2 after global set()");
+
+    bs2.flip(); // Flip all bits
+    print_bitset_details(bs2, "bs2 after global flip()");
+
+
+    // Example 3: Larger bitset (more than one block)
+    // Assuming BlockType is uint64_t (64 bits)
+    DynamicBitset bs3(70);
+    bs3.set(0);
+    bs3.set(63);
+    bs3.set(64);
+    bs3.set(69);
+    print_bitset_details(bs3, "bs3 (70 bits) with a few bits set");
+
+    // Example 4: Empty bitset
+    DynamicBitset bs_empty;
+    print_bitset_details(bs_empty, "bs_empty (default constructed)");
+    DynamicBitset bs_empty2(0);
+    print_bitset_details(bs_empty2, "bs_empty2 (constructed with 0 bits)");
+
+    // Example 5: Bitwise operations
+    DynamicBitset bsa(8, false);
+    bsa.set(1); bsa.set(2); bsa.set(5); // 01100100
+    // Bits:                                 01234567
+    // bsa: 01100100
+
+    DynamicBitset bsb(8, false);
+    bsb.set(2); bsb.set(3); bsb.set(5); bsb.set(7); // 00110101
+    // bsb: 00110101
+
+    print_bitset_details(bsa, "bsa for bitwise ops");
+    print_bitset_details(bsb, "bsb for bitwise ops");
+
+    DynamicBitset bsa_and = bsa;
+    bsa_and &= bsb; // Expected: 00100100
+    print_bitset_details(bsa_and, "bsa_and (bsa &= bsb)");
+
+    DynamicBitset bsa_or = bsa;
+    bsa_or |= bsb;  // Expected: 01110101
+    print_bitset_details(bsa_or, "bsa_or (bsa |= bsb)");
+
+    DynamicBitset bsa_xor = bsa;
+    bsa_xor ^= bsb; // Expected: 01010001
+    print_bitset_details(bsa_xor, "bsa_xor (bsa ^= bsb)");
+
+    std::cout << "\nTrying bitwise op with different sizes (should throw):\n";
+    try {
+        DynamicBitset bsc(7);
+        bsa_and &= bsc;
+    } catch (const std::exception& e) {
+        std::cout << "  Caught exception: " << e.what() << std::endl;
+    }
+    std::cout << "----------------------------------------\n";
+
+    std::cout << "\nEnd of DynamicBitset Examples\n";
+    return 0;
+}

--- a/include/DynamicBitset.h
+++ b/include/DynamicBitset.h
@@ -1,0 +1,310 @@
+#pragma once
+
+#include <vector>
+#include <cstdint> // For uint64_t
+#include <stdexcept> // For std::out_of_range
+#include <numeric>   // For std::accumulate, std::popcount (C++20)
+#include <algorithm> // For std::fill, std::all_of, std::any_of, std::none_of
+#include <limits>    // For std::numeric_limits
+
+// Forward declarations
+class DynamicBitset;
+
+namespace detail {
+// Definition of BitProxy needs to come before DynamicBitset if DynamicBitset returns it by value
+// However, BitProxy methods use DynamicBitset methods.
+// So, we declare BitProxy methods, define DynamicBitset, then define BitProxy methods.
+
+class BitProxy {
+public:
+    // Constructor can be here
+    BitProxy(DynamicBitset& bitset, size_t pos) : bitset_(bitset), pos_(pos) {}
+
+    // Declare methods that depend on DynamicBitset's full definition
+    BitProxy& operator=(bool value);
+    BitProxy& operator=(const BitProxy& other);
+    operator bool() const;
+    BitProxy& flip();
+
+private:
+    DynamicBitset& bitset_; // Reference is fine with forward declaration
+    size_t pos_;
+};
+} // namespace detail
+
+
+class DynamicBitset {
+public:
+    using BlockType = uint64_t;
+    static constexpr size_t kBitsPerBlock = std::numeric_limits<BlockType>::digits;
+
+    // Constructors
+    explicit DynamicBitset(size_t num_bits = 0, bool initial_value = false)
+        : num_bits_(num_bits) {
+        blocks_.assign(num_blocks_for_bits(num_bits_), 0); // All bits (including padding) are initially 0.
+
+        if (initial_value && num_bits_ > 0) {
+            size_t num_total_blocks_needed = num_blocks_for_bits(num_bits_);
+            if (num_total_blocks_needed == 0) return; // Should not happen if num_bits_ > 0
+
+            // Determine how many full blocks of 1s we need
+            size_t count_full_blocks_of_ones = num_bits_ / kBitsPerBlock;
+            for (size_t i = 0; i < count_full_blocks_of_ones; ++i) {
+                blocks_[i] = ~BlockType(0);
+            }
+
+            // Handle the last block, which might be partially filled with 1s
+            size_t remaining_bits = num_bits_ % kBitsPerBlock;
+            if (remaining_bits > 0) {
+                // The block index for these remaining bits is count_full_blocks_of_ones
+                BlockType mask = (BlockType(1) << remaining_bits) - 1;
+                blocks_[count_full_blocks_of_ones] = mask;
+            } else if (num_bits_ > 0 && count_full_blocks_of_ones > 0 && num_total_blocks_needed == count_full_blocks_of_ones) {
+                // This case means num_bits_ is a perfect multiple of kBitsPerBlock.
+                // The loop above already set blocks_[count_full_blocks_of_ones - 1] to all 1s.
+                // No further action needed for the last block if it was fully covered and set.
+            }
+        }
+        // Any padding bits in the last block remain 0 due to the initial blocks_.assign.
+    }
+
+    // Capacity
+    size_t size() const noexcept { return num_bits_; }
+    bool empty() const noexcept { return num_bits_ == 0; }
+
+    // Element access
+    bool test(size_t pos) const {
+        check_bounds(pos);
+        return (blocks_[get_block_index(pos)] >> get_bit_offset(pos)) & 1;
+    }
+
+    detail::BitProxy operator[](size_t pos) {
+        check_bounds(pos); // Check bounds before creating proxy
+        return detail::BitProxy(*this, pos);
+    }
+
+    bool operator[](size_t pos) const { // For const access
+        return test(pos);
+    }
+
+    // Modifiers
+    void set(size_t pos, bool value = true) {
+        check_bounds(pos);
+        BlockType& block = blocks_[get_block_index(pos)];
+        BlockType bit_mask = BlockType(1) << get_bit_offset(pos);
+        if (value) {
+            block |= bit_mask;
+        } else {
+            block &= ~bit_mask;
+        }
+    }
+
+    void set() { // Sets all bits to true
+        if (num_bits_ == 0) return;
+        size_t num_total_blocks = num_blocks_for_bits(num_bits_);
+        for (size_t i = 0; i < num_total_blocks; ++i) {
+            blocks_[i] = ~BlockType(0);
+        }
+        // Ensure padding bits in the last block are 0
+        if (num_bits_ % kBitsPerBlock != 0) {
+            BlockType mask = (BlockType(1) << (num_bits_ % kBitsPerBlock)) - 1;
+            blocks_.back() &= mask;
+        }
+    }
+
+    void reset(size_t pos) {
+        set(pos, false);
+    }
+
+    void reset() { // Clears all bits
+        std::fill(blocks_.begin(), blocks_.end(), 0);
+    }
+
+    void flip(size_t pos) {
+        check_bounds(pos);
+        blocks_[get_block_index(pos)] ^= (BlockType(1) << get_bit_offset(pos));
+    }
+
+    void flip() { // Flips all bits
+        if (num_bits_ == 0) return;
+        size_t num_total_blocks = num_blocks_for_bits(num_bits_);
+        for (size_t i = 0; i < num_total_blocks; ++i) {
+            blocks_[i] = ~blocks_[i];
+        }
+        // Ensure padding bits in the last block are 0 after flipping the whole block
+        if (num_bits_ % kBitsPerBlock != 0) {
+            BlockType mask = (BlockType(1) << (num_bits_ % kBitsPerBlock)) - 1;
+            blocks_.back() &= mask;
+        }
+    }
+
+    // Queries
+    // Definitions are now the declarations
+    // size_t count() const noexcept;
+    // bool all() const noexcept;
+    // bool any() const noexcept;
+    // bool none() const noexcept;
+
+    // TODO: Resize
+    // Bitwise operations
+    // Definitions are now the declarations
+    // DynamicBitset& operator&=(const DynamicBitset& other);
+    // DynamicBitset& operator|=(const DynamicBitset& other);
+    // DynamicBitset& operator^=(const DynamicBitset& other);
+    // operator~() could also be added, returning a new bitset. For now, flip() modifies in-place.
+
+    size_t count() const noexcept {
+        if (num_bits_ == 0) return 0;
+        size_t bit_count = 0;
+        size_t num_full_blocks = num_bits_ / kBitsPerBlock;
+
+        for (size_t i = 0; i < num_full_blocks; ++i) {
+            bit_count += software_popcount(blocks_[i]);
+        }
+
+        size_t remaining_bits = num_bits_ % kBitsPerBlock;
+        if (remaining_bits > 0) {
+            BlockType last_block = blocks_[num_full_blocks];
+            // Mask should not be needed here as padding bits are guaranteed to be 0
+            // BlockType mask = (BlockType(1) << remaining_bits) - 1;
+            // bit_count += software_popcount(last_block & mask);
+            bit_count += software_popcount(last_block); // Padding bits are 0, won't affect popcount
+        }
+        return bit_count;
+    }
+
+    bool all() const noexcept {
+        if (num_bits_ == 0) return true; // Or false, depending on convention. Typically true for empty sets.
+                                       // std::bitset::all() is true if size is 0.
+
+        size_t num_full_blocks = num_bits_ / kBitsPerBlock;
+        for (size_t i = 0; i < num_full_blocks; ++i) {
+            if (blocks_[i] != ~BlockType(0)) {
+                return false;
+            }
+        }
+
+        size_t remaining_bits = num_bits_ % kBitsPerBlock;
+        if (remaining_bits > 0) {
+            BlockType last_block_mask = (BlockType(1) << remaining_bits) - 1;
+            if ((blocks_[num_full_blocks] & last_block_mask) != last_block_mask) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool any() const noexcept {
+        if (num_bits_ == 0) return false;
+        // Relies on padding bits being 0.
+        for (BlockType block_val : blocks_) {
+            if (block_val != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool none() const noexcept {
+        if (num_bits_ == 0) return true;
+        // Relies on padding bits being 0.
+        for (BlockType block_val : blocks_) {
+            if (block_val != 0) {
+                return false;
+            }
+        }
+        return true; // Equivalent to !any()
+    }
+
+    DynamicBitset& operator&=(const DynamicBitset& other) {
+        if (num_bits_ != other.num_bits_) {
+            throw std::invalid_argument("DynamicBitset::operator&=: operands have different sizes");
+        }
+        for (size_t i = 0; i < blocks_.size(); ++i) {
+            blocks_[i] &= other.blocks_[i];
+        }
+        // Padding bits remain 0 as other.blocks_[i] also has its padding bits as 0.
+        return *this;
+    }
+
+    DynamicBitset& operator|=(const DynamicBitset& other) {
+        if (num_bits_ != other.num_bits_) {
+            throw std::invalid_argument("DynamicBitset::operator|=: operands have different sizes");
+        }
+        for (size_t i = 0; i < blocks_.size(); ++i) {
+            blocks_[i] |= other.blocks_[i];
+        }
+        // Padding bits remain 0 as other.blocks_[i] also has its padding bits as 0.
+        return *this;
+    }
+
+    DynamicBitset& operator^=(const DynamicBitset& other) {
+        if (num_bits_ != other.num_bits_) {
+            throw std::invalid_argument("DynamicBitset::operator^=: operands have different sizes");
+        }
+        for (size_t i = 0; i < blocks_.size(); ++i) {
+            blocks_[i] ^= other.blocks_[i];
+        }
+        // Padding bits remain 0 as other.blocks_[i] also has its padding bits as 0.
+        return *this;
+    }
+
+private:
+    friend class detail::BitProxy;
+
+    // Helper for popcount (can be replaced by std::popcount in C++20 or compiler intrinsics)
+    static int software_popcount(BlockType n) {
+        int count = 0;
+        while (n > 0) {
+            n &= (n - 1); // Brian Kernighan's algorithm
+            count++;
+        }
+        return count;
+    }
+
+    size_t get_block_index(size_t pos) const {
+        return pos / kBitsPerBlock;
+    }
+
+    size_t get_bit_offset(size_t pos) const {
+        return pos % kBitsPerBlock;
+    }
+
+    void check_bounds(size_t pos) const {
+        if (pos >= num_bits_) {
+            throw std::out_of_range("DynamicBitset: position out of range");
+        }
+    }
+
+    size_t num_blocks_for_bits(size_t num_bits) const {
+        if (num_bits == 0) return 0;
+        return (num_bits + kBitsPerBlock - 1) / kBitsPerBlock;
+    }
+
+    std::vector<BlockType> blocks_;
+    size_t num_bits_;
+};
+
+// Definitions for detail::BitProxy methods that require DynamicBitset to be complete.
+namespace detail {
+
+inline BitProxy& BitProxy::operator=(bool value) {
+    bitset_.set(pos_, value);
+    return *this;
+}
+
+inline BitProxy& BitProxy::operator=(const BitProxy& other) {
+    bitset_.set(pos_, static_cast<bool>(other)); // other.operator bool() will call bitset_.test(other.pos_)
+    return *this;
+}
+
+inline BitProxy::operator bool() const {
+    return bitset_.test(pos_);
+}
+
+inline BitProxy& BitProxy::flip() {
+    bitset_.flip(pos_);
+    return *this;
+}
+
+} // namespace detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,17 +1,15 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(RibbonFilterTests)
-
-# Add the include directory of the main project for ribbon_filter.h
+# Add the include directory of the main project for headers
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
-# Add the test executable
+# Add the test executable for ribbon_filter
 add_executable(ribbon_filter_test ribbon_filter_test.cpp)
-
-# Link GoogleTest
-# The main CMakeLists.txt should handle fetching GoogleTest
 target_link_libraries(ribbon_filter_test PRIVATE GTest::gtest GTest::gtest_main)
+include(GoogleTest) # Modern way to add tests
+gtest_discover_tests(ribbon_filter_test)
 
-# Add test to CTest
-include(CTest)
-add_test(NAME ribbon_filter_test COMMAND ribbon_filter_test)
+# Add the test executable for dynamic_bitset
+add_executable(dynamic_bitset_test dynamic_bitset_test.cpp)
+target_link_libraries(dynamic_bitset_test PRIVATE GTest::gtest GTest::gtest_main)
+gtest_discover_tests(dynamic_bitset_test)

--- a/tests/dynamic_bitset_test.cpp
+++ b/tests/dynamic_bitset_test.cpp
@@ -1,0 +1,312 @@
+#include "DynamicBitset.h"
+#include "gtest/gtest.h"
+#include <string>
+#include <vector>
+#include <stdexcept> // For std::out_of_range, std::invalid_argument
+
+// Helper to convert DynamicBitset to string for easy comparison
+std::string to_string(const DynamicBitset& bs) {
+    if (bs.empty()) {
+        return "";
+    }
+    std::string s;
+    s.reserve(bs.size());
+    for (size_t i = 0; i < bs.size(); ++i) {
+        s += (bs[i] ? '1' : '0');
+    }
+    return s;
+}
+
+TEST(DynamicBitsetTest, ConstructorDefault) {
+    DynamicBitset bs;
+    EXPECT_EQ(bs.size(), 0);
+    EXPECT_TRUE(bs.empty());
+    EXPECT_EQ(bs.count(), 0);
+    EXPECT_TRUE(bs.all()); // Consistent with std::bitset
+    EXPECT_FALSE(bs.any());
+    EXPECT_TRUE(bs.none());
+}
+
+TEST(DynamicBitsetTest, ConstructorSizedDefaultValue) {
+    DynamicBitset bs(10); // Default false
+    EXPECT_EQ(bs.size(), 10);
+    EXPECT_FALSE(bs.empty());
+    EXPECT_EQ(bs.count(), 0);
+    EXPECT_EQ(to_string(bs), "0000000000");
+    EXPECT_FALSE(bs.all());
+    EXPECT_FALSE(bs.any());
+    EXPECT_TRUE(bs.none());
+
+    DynamicBitset bs_large(100); // Default false
+    EXPECT_EQ(bs_large.size(), 100);
+    EXPECT_EQ(bs_large.count(), 0);
+    EXPECT_FALSE(bs_large.all());
+    EXPECT_TRUE(bs_large.none());
+}
+
+TEST(DynamicBitsetTest, ConstructorSizedSpecificValue) {
+    DynamicBitset bs_false(10, false);
+    EXPECT_EQ(bs_false.size(), 10);
+    EXPECT_EQ(bs_false.count(), 0);
+    EXPECT_EQ(to_string(bs_false), "0000000000");
+
+    DynamicBitset bs_true(10, true);
+    EXPECT_EQ(bs_true.size(), 10);
+    EXPECT_EQ(bs_true.count(), 10);
+    EXPECT_EQ(to_string(bs_true), "1111111111");
+    EXPECT_TRUE(bs_true.all());
+    EXPECT_TRUE(bs_true.any());
+    EXPECT_FALSE(bs_true.none());
+
+    DynamicBitset bs_large_true(130, true); // > 2 blocks
+    EXPECT_EQ(bs_large_true.size(), 130);
+    EXPECT_EQ(bs_large_true.count(), 130);
+    EXPECT_TRUE(bs_large_true.all());
+    for(size_t i=0; i < 130; ++i) EXPECT_TRUE(bs_large_true.test(i));
+}
+
+
+TEST(DynamicBitsetTest, SetAndTestIndividualBits) {
+    DynamicBitset bs(20);
+    bs.set(0);
+    bs.set(5, true);
+    bs.set(10, false); // should clear if already set, or remain clear
+    bs.set(19);
+
+    EXPECT_TRUE(bs.test(0));
+    EXPECT_TRUE(bs[0]); // Test const operator[]
+    EXPECT_TRUE(bs.test(5));
+    EXPECT_FALSE(bs.test(10));
+    EXPECT_TRUE(bs.test(19));
+
+    EXPECT_FALSE(bs.test(1));
+    EXPECT_FALSE(bs.test(18));
+
+    EXPECT_EQ(bs.count(), 3);
+    std::cout << "bs in SetAndTestIndividualBits: " << to_string(bs) << std::endl;
+    EXPECT_EQ(to_string(bs), "10000100000000000001");
+}
+
+TEST(DynamicBitsetTest, OperatorBracketAssignment) {
+    DynamicBitset bs(10);
+    bs[0] = true;
+    bs[3] = true;
+    bs[5] = false;
+    bs[3] = false;
+    bs[7] = bs[0]; // Assign from another proxy
+
+    EXPECT_TRUE(bs.test(0));
+    EXPECT_FALSE(bs.test(3));
+    EXPECT_FALSE(bs.test(5));
+    EXPECT_TRUE(bs.test(7));
+    EXPECT_EQ(to_string(bs), "1000000100");
+}
+
+
+TEST(DynamicBitsetTest, ResetIndividualBits) {
+    DynamicBitset bs(10, true);
+    bs.reset(0);
+    bs.reset(5);
+    bs.reset(9);
+
+    EXPECT_FALSE(bs.test(0));
+    EXPECT_TRUE(bs.test(1));
+    EXPECT_FALSE(bs.test(5));
+    EXPECT_TRUE(bs.test(8));
+    EXPECT_FALSE(bs.test(9));
+    EXPECT_EQ(bs.count(), 7);
+    EXPECT_EQ(to_string(bs), "0111101110");
+}
+
+TEST(DynamicBitsetTest, FlipIndividualBits) {
+    DynamicBitset bs(5); // 00000
+    bs.flip(0); // 10000
+    bs.flip(2); // 10100
+    bs.flip(4); // 10101
+    bs.flip(0); // 00101
+
+    EXPECT_EQ(to_string(bs), "00101");
+    EXPECT_EQ(bs.count(), 2);
+
+    bs[1].flip(); // 01101
+    EXPECT_EQ(to_string(bs), "01101");
+}
+
+TEST(DynamicBitsetTest, SetAllResetAllFlipAll) {
+    DynamicBitset bs(70); // Test across block boundaries
+    bs.set();
+    EXPECT_EQ(bs.count(), 70);
+    EXPECT_TRUE(bs.all());
+    for(size_t i=0; i < 70; ++i) EXPECT_TRUE(bs.test(i));
+
+
+    bs.reset();
+    EXPECT_EQ(bs.count(), 0);
+    EXPECT_TRUE(bs.none());
+    for(size_t i=0; i < 70; ++i) EXPECT_FALSE(bs.test(i));
+
+    bs.set(10);
+    bs.set(20);
+    bs.set(65); // 3 bits set
+
+    bs.flip(); // All other 67 bits should be set
+    EXPECT_EQ(bs.count(), 67);
+    EXPECT_FALSE(bs.test(10));
+    EXPECT_FALSE(bs.test(20));
+    EXPECT_FALSE(bs.test(65));
+    EXPECT_TRUE(bs.test(0));
+    EXPECT_TRUE(bs.test(69));
+}
+
+
+TEST(DynamicBitsetTest, AllAnyNoneQueries) {
+    DynamicBitset bs(5);
+    EXPECT_TRUE(bs.none());
+    EXPECT_FALSE(bs.any());
+    EXPECT_FALSE(bs.all());
+
+    bs.set(2); // 00100
+    EXPECT_FALSE(bs.none());
+    EXPECT_TRUE(bs.any());
+    EXPECT_FALSE(bs.all());
+
+    bs.set(); // 11111
+    EXPECT_FALSE(bs.none());
+    EXPECT_TRUE(bs.any());
+    EXPECT_TRUE(bs.all());
+
+    DynamicBitset bs_empty(0);
+    EXPECT_TRUE(bs_empty.none()); // True for empty
+    EXPECT_FALSE(bs_empty.any()); // False for empty
+    EXPECT_TRUE(bs_empty.all());  // True for empty
+}
+
+TEST(DynamicBitsetTest, BoundsChecking) {
+    DynamicBitset bs(10);
+    EXPECT_THROW(bs.test(10), std::out_of_range);
+    EXPECT_THROW(bs.set(10), std::out_of_range);
+    EXPECT_THROW(bs.reset(10), std::out_of_range);
+    EXPECT_THROW(bs.flip(10), std::out_of_range);
+    EXPECT_THROW(bs[10], std::out_of_range); // const operator[]
+
+    // Non-const operator[] check (access that would create proxy)
+    EXPECT_THROW(bs[10] = true, std::out_of_range);
+
+
+    // Valid accesses
+    EXPECT_NO_THROW(bs.test(9));
+    EXPECT_NO_THROW(bs.set(9));
+    EXPECT_NO_THROW(bs[9]);
+    EXPECT_NO_THROW(bs[9] = false);
+}
+
+TEST(DynamicBitsetTest, BitwiseOperations) {
+    DynamicBitset bs1(68); // Across block boundary
+    DynamicBitset bs2(68);
+
+    bs1.set(1); bs1.set(30); bs1.set(65); // 0...1...0...1...010
+    bs2.set(2); bs2.set(30); bs2.set(66); // 0..1..0...1...001
+
+    DynamicBitset bs_and = bs1;
+    bs_and &= bs2;
+    EXPECT_TRUE(bs_and.test(30));
+    EXPECT_FALSE(bs_and.test(1));
+    EXPECT_FALSE(bs_and.test(2));
+    EXPECT_FALSE(bs_and.test(65));
+    EXPECT_FALSE(bs_and.test(66));
+    EXPECT_EQ(bs_and.count(), 1);
+
+    DynamicBitset bs_or = bs1;
+    bs_or |= bs2;
+    EXPECT_TRUE(bs_or.test(1));
+    EXPECT_TRUE(bs_or.test(2));
+    EXPECT_TRUE(bs_or.test(30));
+    EXPECT_TRUE(bs_or.test(65));
+    EXPECT_TRUE(bs_or.test(66));
+    EXPECT_EQ(bs_or.count(), 5);
+
+    DynamicBitset bs_xor = bs1;
+    bs_xor ^= bs2;
+    EXPECT_TRUE(bs_xor.test(1));
+    EXPECT_TRUE(bs_xor.test(2));
+    EXPECT_FALSE(bs_xor.test(30)); // 1^1 = 0
+    EXPECT_TRUE(bs_xor.test(65));
+    EXPECT_TRUE(bs_xor.test(66));
+    EXPECT_EQ(bs_xor.count(), 4);
+}
+
+TEST(DynamicBitsetTest, BitwiseOperationsSizeMismatch) {
+    DynamicBitset bs1(10);
+    DynamicBitset bs2(12);
+    EXPECT_THROW(bs1 &= bs2, std::invalid_argument);
+    EXPECT_THROW(bs1 |= bs2, std::invalid_argument);
+    EXPECT_THROW(bs1 ^= bs2, std::invalid_argument);
+}
+
+TEST(DynamicBitsetTest, StressTestCount) {
+    DynamicBitset bs(256); // Exactly 4 blocks of 64 bits
+    for (size_t i = 0; i < bs.size(); i += 2) {
+        bs.set(i);
+    }
+    EXPECT_EQ(bs.count(), 128);
+
+    bs.flip();
+    EXPECT_EQ(bs.count(), 128);
+
+    bs.reset();
+    EXPECT_EQ(bs.count(), 0);
+
+    bs.set();
+    EXPECT_EQ(bs.count(), 256);
+}
+
+TEST(DynamicBitsetTest, ConstructorLargeValues) {
+    const size_t size1 = 1000;
+    DynamicBitset bs1_false(size1, false);
+    EXPECT_EQ(bs1_false.size(), size1);
+    EXPECT_EQ(bs1_false.count(), 0);
+    EXPECT_TRUE(bs1_false.none());
+    for(size_t i=0; i<size1; ++i) EXPECT_FALSE(bs1_false.test(i));
+
+    DynamicBitset bs1_true(size1, true);
+    EXPECT_EQ(bs1_true.size(), size1);
+    EXPECT_EQ(bs1_true.count(), size1);
+    EXPECT_TRUE(bs1_true.all());
+    for(size_t i=0; i<size1; ++i) EXPECT_TRUE(bs1_true.test(i));
+}
+
+TEST(DynamicBitsetTest, PaddingBitsCorrectness) {
+    // Test that padding bits in the last block are always zero
+    // and do not affect operations like count, any, none, all.
+    // Size 65 means 1 bit in the second block.
+    DynamicBitset bs(65, false); // blocks_[0] = 0, blocks_[1] = 0
+    bs.set(64); // blocks_[0] = 0, blocks_[1] = 1 (0...01)
+
+    EXPECT_EQ(bs.count(), 1);
+    EXPECT_TRUE(bs.any());
+    EXPECT_FALSE(bs.none());
+    EXPECT_FALSE(bs.all());
+    EXPECT_EQ(to_string(bs).length(), 65);
+    EXPECT_EQ(to_string(bs)[64], '1');
+
+
+    // Flip all. blocks_[0] becomes all 1s. blocks_[1] becomes 1...1110
+    // The relevant bit at pos 64 (offset 0 in block 1) flips to 0.
+    // Padding bits in block 1 must remain 0.
+    bs.flip();
+    EXPECT_EQ(bs.count(), 64); // 64 bits are now 1, bit 64 is 0.
+    EXPECT_FALSE(bs.test(64));
+    EXPECT_TRUE(bs.test(0));
+    EXPECT_TRUE(bs.test(63));
+
+    // Set all. blocks_[0] = all 1s. blocks_[1] = 0...01 (bit 64 set, padding 0)
+    bs.set();
+    EXPECT_EQ(bs.count(), 65);
+    EXPECT_TRUE(bs.all());
+    EXPECT_TRUE(bs.test(64));
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Implements a DynamicBitset class that provides a bitset whose size is determined at runtime.

Features include:
- Dynamic sizing specified at construction.
- Efficient storage using packed unsigned integer blocks.
- Bit manipulation: set, reset, flip individual bits and all bits.
- Proxy object for operator[] for assignment and read.
- Query operations: size, count, all, any, none, empty.
- Bitwise operations: &=, |=, ^= for same-sized bitsets.
- Bounds checking for out-of-range access.

Includes:
- Header file: include/DynamicBitset.h
- Example usage: examples/dynamic_bitset_example.cpp
- Unit tests: tests/dynamic_bitset_test.cpp (using Google Test)
- Documentation: docs/README_DynamicBitset.md

CMakeLists.txt files have been updated to integrate the new component, example, and tests. All new tests for DynamicBitset pass.