### PR TITLE
feat: Add InterningPool data structure

### DIFF
--- a/docs/README_interning_pool.md
+++ b/docs/README_interning_pool.md
@@ -1,0 +1,119 @@
+# InterningPool
+
+## Overview
+
+An `InterningPool<T>` is a data structure that stores and manages unique instances of objects of type `T`. When an object is "interned," the pool checks if an identical object already exists within its collection.
+- If it exists, the pool returns a handle (a `const T*` pointer) to the pre-existing object.
+- If it does not exist, the pool stores the new object and then returns a handle to it.
+
+This mechanism ensures that for any given value, only one instance is stored by the pool, referenced by potentially many handles.
+
+## Purpose and Benefits
+
+The primary purposes and benefits of using an `InterningPool` are:
+
+1.  **Memory Savings:** By storing only one copy of each unique object, especially for frequently repeated objects like strings, significant memory can be saved.
+2.  **Faster Comparisons:** Handles (pointers) to interned objects can be compared directly for equality. If two handles are identical, the objects they point to are guaranteed to be the same. This pointer comparison is typically much faster than comparing the objects' actual values (e.g., string content comparison). This is particularly useful when objects are used as keys in maps or elements in sets, or when frequent equality checks are performed.
+3.  **Centralized Management:** Provides a single point of management for the lifetime of these unique objects.
+
+## Usage
+
+### Include Header
+```cpp
+#include "interning_pool.hpp" // Adjust path as per your project structure
+```
+
+### Basic Example
+
+```cpp
+#include "interning_pool.hpp"
+#include <iostream>
+#include <string>
+
+int main() {
+    // Create an interning pool for strings
+    cpp_collections::InterningPool<std::string> string_pool;
+
+    // Intern some strings
+    const std::string* handle1 = string_pool.intern("hello");
+    const std::string* handle2 = string_pool.intern("world");
+    const std::string* handle3 = string_pool.intern("hello"); // Duplicate
+
+    // Check pool size (number of unique items)
+    std::cout << "Pool size: " << string_pool.size() << std::endl; // Output: Pool size: 2
+
+    // Compare handles
+    if (handle1 == handle3) {
+        std::cout << "Handles for \"hello\" (handle1 and handle3) are the same." << std::endl;
+        // Output: Handles for "hello" (handle1 and handle3) are the same.
+    }
+
+    if (handle1 != handle2) {
+        std::cout << "Handles for \"hello\" (handle1) and \"world\" (handle2) are different." << std::endl;
+        // Output: Handles for "hello" (handle1) and "world" (handle2) are different.
+    }
+
+    // Access the interned value
+    std::cout << "Value for handle1: " << *handle1 << std::endl; // Output: Value for handle1: hello
+
+    // Intern using move semantics (for rvalues/temporaries)
+    const std::string* handle4 = string_pool.intern(std::string("ephemeral"));
+    const std::string* handle5 = string_pool.intern("ephemeral");
+    std::cout << "Pool size after interning \"ephemeral\": " << string_pool.size() << std::endl; // Output: Pool size: 3
+    if (handle4 == handle5) {
+        std::cout << "Handles for \"ephemeral\" (handle4 and handle5) are the same." << std::endl;
+    }
+     // Output: Handles for "ephemeral" (handle4 and handle5) are the same.
+
+    // Check if a value is contained
+    if (string_pool.contains("world")) {
+        std::cout << "\"world\" is in the pool." << std::endl; // Output: "world" is in the pool.
+    }
+
+    // Clear the pool (invalidates all existing handles)
+    string_pool.clear();
+    std::cout << "Pool size after clear: " << string_pool.size() << std::endl; // Output: Pool size after clear: 0
+    // Note: handle1, handle2, handle3, handle4, handle5 are now dangling pointers.
+}
+```
+
+## API
+
+The `InterningPool<T, Hash, KeyEqual, Allocator>` class template provides the following key methods:
+
+-   `InterningPool()`: Default constructor.
+-   `InterningPool(const Allocator& alloc)`: Constructor with allocator.
+-   `InterningPool(size_type bucket_count, const Hash& hash, const KeyEqual& equal, const Allocator& alloc)`: Constructor with hash parameters and allocator.
+-   `InterningPool(InterningPool&& other) noexcept`: Move constructor.
+-   `InterningPool& operator=(InterningPool&& other) noexcept`: Move assignment.
+-   `handle_type intern(const T& value)`: Interns a copy of `value`.
+-   `handle_type intern(T&& value)`: Interns `value` by moving it if it's new.
+-   `bool contains(const T& value) const`: Checks if `value` is already interned.
+-   `size_type size() const noexcept`: Returns the number of unique items.
+-   `bool empty() const noexcept`: Checks if the pool is empty.
+-   `void clear() noexcept`: Removes all items, invalidating all handles.
+-   `allocator_type get_allocator() const`: Gets the allocator.
+-   `hasher hash_function() const`: Gets the hash function.
+-   `key_equal key_eq() const`: Gets the key equality predicate.
+
+Copy constructor and copy assignment are deleted to prevent ambiguity with handle ownership and validity.
+
+## Template Parameters
+
+-   `T`: The type of objects to be interned.
+-   `Hash`: A hash function for `T`. Defaults to `std::hash<T>`.
+-   `KeyEqual`: An equality comparison function for `T`. Defaults to `std::equal_to<T>`.
+-   `Allocator`: An allocator for `T`. Defaults to `std::allocator<T>`.
+
+## Thread Safety
+
+The current implementation of `InterningPool` is **not** thread-safe. If concurrent access is required, external synchronization (e.g., a mutex) must be used to protect all accesses to the pool.
+
+## Design Choices and Limitations
+
+-   **Handle Type:** Uses `const T*` as the handle. The lifetime of the pointed-to object is managed by the pool.
+-   **Storage:** Internally uses `std::unordered_set<T, Hash, KeyEqual, Allocator>` to store the unique objects. Pointers to elements in `std::unordered_set` are stable as long as the element is not erased.
+-   **No Erasure of Individual Items:** The pool does not support removing individual interned items. This is a common design choice for interning pools, as managing the validity of outstanding handles upon selective erasure is complex. The entire pool can be cleared using `clear()`, which invalidates all handles.
+-   **Performance:** `intern()` operations have an average time complexity of O(1) due to the use of `std::unordered_set`, assuming a good hash function. In the worst case (many hash collisions), it can be O(N). Memory usage is O(M) where M is the sum of the sizes of the unique objects.
+
+This `InterningPool` provides a fundamental building block for scenarios where managing unique instances of objects is beneficial.

--- a/examples/interning_pool_example.cpp
+++ b/examples/interning_pool_example.cpp
@@ -1,0 +1,107 @@
+#include "interning_pool.hpp" // Adjust path as necessary
+#include <iostream>
+#include <string>
+#include <vector>
+
+void print_handles_comparison(const std::string& s1_val, const std::string* h1,
+                              const std::string& s2_val, const std::string* h2) {
+    std::cout << "String 1: \"" << s1_val << "\", Handle 1: " << static_cast<const void*>(h1) << " (Value: \"" << *h1 << "\")\n";
+    std::cout << "String 2: \"" << s2_val << "\", Handle 2: " << static_cast<const void*>(h2) << " (Value: \"" << *h2 << "\")\n";
+    if (h1 == h2) {
+        std::cout << "Handles are THE SAME. The strings are interned to the same object.\n";
+    } else {
+        std::cout << "Handles are DIFFERENT. The strings are interned to different objects.\n";
+    }
+    std::cout << "----------------------------------------\n";
+}
+
+int main() {
+    // Create an InterningPool for std::string
+    cpp_collections::InterningPool<std::string> string_pool;
+
+    std::cout << "Initial pool size: " << string_pool.size() << std::endl;
+    std::cout << "Pool is empty: " << (string_pool.empty() ? "true" : "false") << std::endl;
+    std::cout << "----------------------------------------\n";
+
+    // Intern some strings
+    const std::string* handle1 = string_pool.intern("hello");
+    const std::string* handle2 = string_pool.intern("world");
+    const std::string* handle3 = string_pool.intern("hello"); // Duplicate
+
+    std::cout << "Pool size after interning \"hello\", \"world\", \"hello\": " << string_pool.size() << std::endl;
+
+    // Demonstrate handle equality for identical strings
+    std::cout << "Comparing handles for \"hello\" and \"hello\":\n";
+    print_handles_comparison("hello", handle1, "hello", handle3);
+
+    // Demonstrate handle inequality for different strings
+    std::cout << "Comparing handles for \"hello\" and \"world\":\n";
+    print_handles_comparison("hello", handle1, "world", handle2);
+
+    // Intern an empty string
+    const std::string* handle_empty1 = string_pool.intern("");
+    const std::string* handle_empty2 = string_pool.intern("");
+    std::cout << "Pool size after interning two empty strings: " << string_pool.size() << std::endl;
+    std::cout << "Comparing handles for empty string and empty string:\n";
+    print_handles_comparison("", handle_empty1, "", handle_empty2);
+
+    // Demonstrate interning with rvalue (temporary string)
+    const std::string* handle_rvalue = string_pool.intern(std::string("temporary"));
+    const std::string* handle_rvalue_dup = string_pool.intern("temporary");
+    std::cout << "Pool size after interning rvalue \"temporary\" and lvalue \"temporary\": " << string_pool.size() << std::endl;
+    std::cout << "Comparing handles for rvalue \"temporary\" and lvalue \"temporary\":\n";
+    print_handles_comparison("temporary", handle_rvalue, "temporary", handle_rvalue_dup);
+
+
+    // Demonstrate `contains`
+    std::cout << "Pool contains \"world\": " << (string_pool.contains("world") ? "true" : "false") << std::endl;
+    std::cout << "Pool contains \"new_string\": " << (string_pool.contains("new_string") ? "true" : "false") << std::endl;
+    const std::string* handle_new = string_pool.intern("new_string");
+    std::cout << "Pool contains \"new_string\" after interning: " << (string_pool.contains("new_string") ? "true" : "false") << std::endl;
+    std::cout << "Pool size: " << string_pool.size() << std::endl;
+    std::cout << "----------------------------------------\n";
+
+    // Demonstrate `clear`
+    std::cout << "Clearing the pool...\n";
+    string_pool.clear();
+    std::cout << "Pool size after clear: " << string_pool.size() << std::endl;
+    std::cout << "Pool is empty after clear: " << (string_pool.empty() ? "true" : "false") << std::endl;
+
+    // Note: After `clear()`, old handles (handle1, handle2, etc.) are invalidated.
+    // Accessing them (e.g., *handle1) would be undefined behavior.
+    // Re-interning "hello" will likely give a new handle address.
+    const std::string* handle_hello_after_clear = string_pool.intern("hello");
+    std::cout << "Interning \"hello\" again after clear.\n";
+    std::cout << "Old handle1 for \"hello\" (invalid): " << static_cast<const void*>(handle1) << std::endl;
+    std::cout << "New handle for \"hello\" after clear: " << static_cast<const void*>(handle_hello_after_clear)
+              << " (Value: \"" << *handle_hello_after_clear << "\")\n";
+    std::cout << "----------------------------------------\n";
+
+
+    // Example with a different type (int)
+    // Note: Interning basic types like int might be less common but demonstrates template usability.
+    // For basic types, the overhead of the pool might outweigh benefits unless there's a
+    // very specific scenario (e.g., limited set of int values that are frequently compared by identity).
+    cpp_collections::InterningPool<int> int_pool;
+    const int* h_int1 = int_pool.intern(100);
+    const int* h_int2 = int_pool.intern(200);
+    const int* h_int3 = int_pool.intern(100);
+
+    std::cout << "Int pool size: " << int_pool.size() << std::endl; // Expected: 2
+    std::cout << "Comparing handles for int 100 and int 100:\n";
+    if (h_int1 == h_int3) {
+        std::cout << "Handles for 100 are THE SAME. Address: " << static_cast<const void*>(h_int1) << ", Value: " << *h_int1 << std::endl;
+    } else {
+        std::cout << "Handles for 100 are DIFFERENT.\n";
+    }
+    std::cout << "Comparing handles for int 100 and int 200:\n";
+    if (h_int1 == h_int2) {
+        std::cout << "Handles for 100 and 200 are THE SAME.\n";
+    } else {
+        std::cout << "Handles for 100 and 200 are DIFFERENT. Handle for 200: " << static_cast<const void*>(h_int2) << ", Value: " << *h_int2 << std::endl;
+    }
+    std::cout << "----------------------------------------\n";
+
+
+    return 0;
+}

--- a/include/interning_pool.hpp
+++ b/include/interning_pool.hpp
@@ -1,0 +1,146 @@
+#ifndef INTERNING_POOL_HPP
+#define INTERNING_POOL_HPP
+
+#include <unordered_set>
+#include <string> // Default type for T, and for std::hash/equal_to specializations
+#include <functional> // For std::hash, std::equal_to
+#include <memory>     // For std::allocator
+#include <utility>    // For std::move
+
+namespace cpp_collections {
+
+template <
+    typename T,
+    typename Hash = std::hash<T>,
+    typename KeyEqual = std::equal_to<T>,
+    typename Allocator = std::allocator<T>
+>
+class InterningPool {
+public:
+    using value_type = T;
+    using handle_type = const T*;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using allocator_type = Allocator;
+    using internal_set_type = std::unordered_set<T, Hash, KeyEqual, Allocator>;
+    using size_type = typename internal_set_type::size_type;
+
+private:
+    internal_set_type S_set_;
+
+public:
+    // Constructors
+    InterningPool() : S_set_() {}
+
+    explicit InterningPool(const Allocator& alloc) : S_set_(alloc) {}
+
+    InterningPool(size_type bucket_count,
+                  const Hash& hash = Hash(),
+                  const KeyEqual& equal = KeyEqual(),
+                  const Allocator& alloc = Allocator())
+        : S_set_(bucket_count, hash, equal, alloc) {}
+
+    // No copy constructor/assignment, as copying an interning pool is tricky
+    // regarding handle validity from the original. Typically, interning pools
+    // are unique instances. If copying is needed, it implies a new set of handles.
+    // For simplicity, make it non-copyable. Users can create a new pool and re-intern.
+    InterningPool(const InterningPool&) = delete;
+    InterningPool& operator=(const InterningPool&) = delete;
+
+    // Move constructor/assignment
+    InterningPool(InterningPool&& other) noexcept = default;
+    InterningPool& operator=(InterningPool&& other) noexcept = default;
+
+    /**
+     * @brief Interns a value.
+     * If the value is already in the pool, returns a handle to the existing object.
+     * Otherwise, inserts a copy of the value into the pool and returns a handle to it.
+     * @param value The value to intern.
+     * @return A handle (const T*) to the interned object.
+     */
+    handle_type intern(const T& value) {
+        auto it = S_set_.find(value);
+        if (it != S_set_.end()) {
+            return &(*it);
+        }
+        // Value not found, insert it. std::unordered_set::insert returns std::pair<iterator, bool>.
+        auto insert_result = S_set_.insert(value);
+        return &(*(insert_result.first)); // Pointer to the newly inserted element
+    }
+
+    /**
+     * @brief Interns a value using move semantics.
+     * If an equivalent value is already in the pool, returns a handle to the existing object.
+     * The passed rvalue `value` might be discarded if an existing entry is found.
+     * Otherwise, moves the value into the pool and returns a handle to it.
+     * @param value The value to intern (rvalue reference).
+     * @return A handle (const T*) to the interned object.
+     */
+    handle_type intern(T&& value) {
+        // Need to check if the value (or an equivalent one) already exists.
+        // `find` requires a const T& or equivalent.
+        auto it = S_set_.find(value);
+        if (it != S_set_.end()) {
+            return &(*it);
+        }
+        // Value not found, insert it by moving.
+        auto insert_result = S_set_.insert(std::move(value));
+        return &(*(insert_result.first)); // Pointer to the newly inserted element
+    }
+
+    /**
+     * @brief Checks if a value has already been interned.
+     * @param value The value to check.
+     * @return True if the value is in the pool, false otherwise.
+     */
+    bool contains(const T& value) const {
+        return S_set_.count(value) > 0;
+    }
+
+    /**
+     * @brief Returns the number of unique items stored in the pool.
+     * @return The number of unique items.
+     */
+    size_type size() const noexcept {
+        return S_set_.size();
+    }
+
+    /**
+     * @brief Checks if the pool is empty.
+     * @return True if the pool contains no items, false otherwise.
+     */
+    bool empty() const noexcept {
+        return S_set_.empty();
+    }
+
+    /**
+     * @brief Removes all items from the pool.
+     * This invalidates all previously returned handles.
+     */
+    void clear() noexcept {
+        S_set_.clear();
+    }
+
+    // Expose allocator
+    allocator_type get_allocator() const {
+        return S_set_.get_allocator();
+    }
+
+    // Expose hash function and key equal
+    hasher hash_function() const {
+        return S_set_.hash_function();
+    }
+
+    key_equal key_eq() const {
+        return S_set_.key_eq();
+    }
+};
+
+// Deduction guide for common case (e.g. from initializer list of strings)
+// This is tricky for InterningPool as its constructors don't directly take ranges of values to intern.
+// Users typically construct an empty pool and then call intern().
+// So, standard deduction guides for containers might not apply directly or be as useful.
+
+} // namespace cpp_collections
+
+#endif // INTERNING_POOL_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,3 +27,8 @@ target_link_libraries(multiset_counter_test PRIVATE GTest::gtest GTest::gtest_ma
 # target_link_libraries(multiset_counter_test PRIVATE MultisetCounterLib GTest::gtest GTest::gtest_main)
 # But since it's header-only and included via include_directories, direct GTest linking is primary.
 gtest_discover_tests(multiset_counter_test)
+
+# Add the test executable for interning_pool
+add_executable(interning_pool_test test_interning_pool.cpp)
+target_link_libraries(interning_pool_test PRIVATE GTest::gtest GTest::gtest_main)
+gtest_discover_tests(interning_pool_test)

--- a/tests/test_interning_pool.cpp
+++ b/tests/test_interning_pool.cpp
@@ -1,0 +1,248 @@
+#include "interning_pool.hpp" // Adjust path as necessary
+#include "gtest/gtest.h"
+#include <string>
+#include <vector>
+#include <set> // For testing uniqueness of handles
+
+// Test fixture for InterningPool tests
+class InterningPoolTest : public ::testing::Test {
+protected:
+    // You can put setup code here if needed, e.g., creating a pool instance
+    // For most tests, a local pool instance within the TEST_F block is fine.
+};
+
+TEST_F(InterningPoolTest, EmptyPool) {
+    cpp_collections::InterningPool<std::string> pool;
+    ASSERT_TRUE(pool.empty());
+    ASSERT_EQ(pool.size(), 0);
+}
+
+TEST_F(InterningPoolTest, InternNewStrings) {
+    cpp_collections::InterningPool<std::string> pool;
+    const std::string s1 = "hello";
+    const std::string s2 = "world";
+
+    const std::string* h1 = pool.intern(s1);
+    ASSERT_EQ(pool.size(), 1);
+    ASSERT_TRUE(pool.contains(s1));
+    ASSERT_NE(h1, nullptr);
+    ASSERT_EQ(*h1, s1);
+
+    const std::string* h2 = pool.intern(s2);
+    ASSERT_EQ(pool.size(), 2);
+    ASSERT_TRUE(pool.contains(s2));
+    ASSERT_NE(h2, nullptr);
+    ASSERT_EQ(*h2, s2);
+    ASSERT_NE(h1, h2); // Handles to different strings should be different
+}
+
+TEST_F(InterningPoolTest, InternDuplicateStrings) {
+    cpp_collections::InterningPool<std::string> pool;
+    const std::string s1 = "duplicate";
+    const std::string s_other = "another";
+
+    const std::string* h1 = pool.intern(s1);
+    ASSERT_EQ(pool.size(), 1);
+    ASSERT_NE(h1, nullptr);
+    ASSERT_EQ(*h1, s1);
+
+    const std::string* h2 = pool.intern("duplicate"); // Intern string literal
+    ASSERT_EQ(pool.size(), 1); // Size should not change
+    ASSERT_EQ(h1, h2);         // Handles should be the same
+    ASSERT_NE(h2, nullptr);
+    ASSERT_EQ(*h2, s1);
+
+    const std::string* h3 = pool.intern(s_other);
+    ASSERT_EQ(pool.size(), 2);
+    ASSERT_NE(h1, h3);
+
+    const std::string* h4 = pool.intern(std::string("duplicate")); // Intern rvalue
+    ASSERT_EQ(pool.size(), 2);
+    ASSERT_EQ(h1, h4);
+    ASSERT_NE(h4, nullptr);
+    ASSERT_EQ(*h4, s1);
+}
+
+TEST_F(InterningPoolTest, InternEmptyString) {
+    cpp_collections::InterningPool<std::string> pool;
+    const std::string empty_str = "";
+
+    const std::string* h1 = pool.intern(empty_str);
+    ASSERT_EQ(pool.size(), 1);
+    ASSERT_TRUE(pool.contains(""));
+    ASSERT_NE(h1, nullptr);
+    ASSERT_TRUE(h1->empty());
+
+    const std::string* h2 = pool.intern("");
+    ASSERT_EQ(pool.size(), 1);
+    ASSERT_EQ(h1, h2);
+}
+
+TEST_F(InterningPoolTest, InternRvalueStrings) {
+    cpp_collections::InterningPool<std::string> pool;
+
+    const std::string* h1 = pool.intern(std::string("temporary1"));
+    ASSERT_EQ(pool.size(), 1);
+    ASSERT_TRUE(pool.contains("temporary1"));
+    ASSERT_NE(h1, nullptr);
+    ASSERT_EQ(*h1, "temporary1");
+
+    const std::string* h2 = pool.intern(std::string("temporary2"));
+    ASSERT_EQ(pool.size(), 2);
+    ASSERT_TRUE(pool.contains("temporary2"));
+    ASSERT_NE(h2, nullptr);
+    ASSERT_EQ(*h2, "temporary2");
+    ASSERT_NE(h1, h2);
+
+    const std::string* h3 = pool.intern(std::string("temporary1")); // Duplicate rvalue
+    ASSERT_EQ(pool.size(), 2); // Size should not change
+    ASSERT_EQ(h1, h3);         // Handles should be the same
+}
+
+TEST_F(InterningPoolTest, ContainsMethod) {
+    cpp_collections::InterningPool<std::string> pool;
+    ASSERT_FALSE(pool.contains("test"));
+
+    pool.intern("test");
+    ASSERT_TRUE(pool.contains("test"));
+    ASSERT_TRUE(pool.contains(std::string("test")));
+    ASSERT_FALSE(pool.contains("non_existent"));
+}
+
+TEST_F(InterningPoolTest, ClearPool) {
+    cpp_collections::InterningPool<std::string> pool;
+    pool.intern("one");
+    pool.intern("two");
+    ASSERT_EQ(pool.size(), 2);
+    ASSERT_FALSE(pool.empty());
+
+    // const std::string* h_one_before_clear = pool.intern("one"); // Already interned
+
+    pool.clear();
+    ASSERT_TRUE(pool.empty());
+    ASSERT_EQ(pool.size(), 0);
+    ASSERT_FALSE(pool.contains("one"));
+    ASSERT_FALSE(pool.contains("two"));
+
+    // Test interning after clear
+    const std::string* h_one_after_clear = pool.intern("one");
+    ASSERT_EQ(pool.size(), 1);
+    ASSERT_TRUE(pool.contains("one"));
+    ASSERT_NE(h_one_after_clear, nullptr);
+    ASSERT_EQ(*h_one_after_clear, "one");
+}
+
+// Custom struct for testing
+struct MyStruct {
+    int id;
+    std::string name;
+
+    bool operator==(const MyStruct& other) const {
+        return id == other.id && name == other.name;
+    }
+};
+
+// Hash specialization for MyStruct in std namespace (or provide as template arg)
+namespace std {
+    template <> struct hash<MyStruct> {
+        std::size_t operator()(const MyStruct& s) const {
+            std::size_t h1 = std::hash<int>{}(s.id);
+            std::size_t h2 = std::hash<std::string>{}(s.name);
+            return h1 ^ (h2 << 1); // Combine hashes
+        }
+    };
+}
+
+
+TEST_F(InterningPoolTest, InternDifferentTypes) {
+    cpp_collections::InterningPool<int> int_pool;
+    const int val1 = 123;
+    const int val2 = 456;
+
+    const int* h_i1 = int_pool.intern(val1);
+    ASSERT_EQ(int_pool.size(), 1);
+    ASSERT_TRUE(int_pool.contains(val1));
+    ASSERT_NE(h_i1, nullptr);
+    ASSERT_EQ(*h_i1, val1);
+
+    const int* h_i2 = int_pool.intern(val2);
+    ASSERT_EQ(int_pool.size(), 2);
+    ASSERT_TRUE(int_pool.contains(val2));
+    ASSERT_NE(h_i2, nullptr);
+    ASSERT_EQ(*h_i2, val2);
+    ASSERT_NE(h_i1, h_i2);
+
+    const int* h_i3 = int_pool.intern(123); // Rvalue int
+    ASSERT_EQ(int_pool.size(), 2);
+    ASSERT_EQ(h_i1, h_i3);
+
+    // Test with MyStruct
+    // Using default std::hash<MyStruct> because we specialized it.
+    cpp_collections::InterningPool<MyStruct> struct_pool;
+    MyStruct struct1 = {1, "Alice"};
+    MyStruct struct2 = {2, "Bob"};
+    MyStruct struct1_dup = {1, "Alice"};
+
+    const MyStruct* h_s1 = struct_pool.intern(struct1);
+    ASSERT_EQ(struct_pool.size(), 1);
+    ASSERT_TRUE(struct_pool.contains(struct1));
+    ASSERT_NE(h_s1, nullptr);
+    ASSERT_EQ(h_s1->id, 1);
+    ASSERT_EQ(h_s1->name, "Alice");
+
+    const MyStruct* h_s2 = struct_pool.intern(struct2);
+    ASSERT_EQ(struct_pool.size(), 2);
+    ASSERT_NE(h_s1, h_s2);
+
+    const MyStruct* h_s3 = struct_pool.intern(struct1_dup);
+    ASSERT_EQ(struct_pool.size(), 2);
+    ASSERT_EQ(h_s1, h_s3);
+
+    const MyStruct* h_s4 = struct_pool.intern({1, "Alice"}); // Rvalue MyStruct
+    ASSERT_EQ(struct_pool.size(), 2);
+    ASSERT_EQ(h_s1, h_s4);
+}
+
+TEST_F(InterningPoolTest, HandleStabilityAndValues) {
+    cpp_collections::InterningPool<std::string> pool;
+    std::vector<const std::string*> handles;
+    std::vector<std::string> original_values;
+    const int num_items = 100;
+
+    for (int i = 0; i < num_items; ++i) {
+        std::string val = "string_" + std::to_string(i);
+        original_values.push_back(val);
+        handles.push_back(pool.intern(val));
+    }
+    ASSERT_EQ(pool.size(), num_items);
+
+    // Intern some duplicates
+    handles.push_back(pool.intern("string_0"));
+    original_values.push_back("string_0"); // For comparison
+    handles.push_back(pool.intern("string_" + std::to_string(num_items / 2)));
+    original_values.push_back("string_" + std::to_string(num_items / 2));
+
+    ASSERT_EQ(pool.size(), num_items); // Size should remain the same due to duplicates
+
+    // Verify all handles point to the correct values and are unique for unique strings
+    std::set<const std::string*> unique_handles_set;
+    for (size_t i = 0; i < handles.size(); ++i) {
+        ASSERT_NE(handles[i], nullptr);
+        ASSERT_EQ(*handles[i], original_values[i]); // Check value
+        if (i < num_items) { // Only original unique strings for this set
+             unique_handles_set.insert(handles[i]);
+        }
+    }
+    ASSERT_EQ(unique_handles_set.size(), num_items); // Ensure unique strings got unique handles
+
+    // Check specific duplicate handles
+    ASSERT_EQ(handles[0], handles[num_items]); // "string_0"
+    ASSERT_EQ(handles[num_items/2], handles[num_items+1]); // "string_num_items/2"
+}
+
+// main function for GTest can be omitted if linking with GTest::gtest_main
+// Or included if preferred:
+// int main(int argc, char **argv) {
+//     ::testing::InitGoogleTest(&argc, argv);
+//     return RUN_ALL_TESTS();
+// }


### PR DESCRIPTION
Implements a new data structure `InterningPool<T>` for interning objects, primarily designed for strings but usable with any hashable type `T`.

The InterningPool stores unique instances of objects and returns lightweight, comparable handles (`const T*`) to them. This helps in reducing memory by storing only one copy of each unique object and allows for faster equality comparisons using handle pointers.

Key features:
- Templated class `InterningPool<T, Hash, KeyEqual, Allocator>`.
- `intern(const T&)` and `intern(T&&)` methods.
- `contains(const T&)`, `size()`, `empty()`, `clear()` methods.
- Move semantics supported; copy operations deleted.
- Header-only implementation in `include/interning_pool.hpp`.

Includes:
- Example usage in `examples/interning_pool_example.cpp`.
- Unit tests in `tests/test_interning_pool.cpp` using GTest.
- Documentation in `docs/README_interning_pool.md`.
- Updated CMakeLists.txt for the new tests.