### PR TITLE
feat: Add WeightedRandomList data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,10 @@ target_include_directories(DynamicBitsetLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR
 add_library(MultisetCounterLib INTERFACE)
 target_include_directories(MultisetCounterLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define WeightedRandomListLib as an interface library (header-only)
+add_library(WeightedRandomListLib INTERFACE)
+target_include_directories(WeightedRandomListLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -256,6 +260,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         RibbonFilterLib      # Added for ribbon_filter_example
         DynamicBitsetLib     # Added for dynamic_bitset_example
         MultisetCounterLib   # Added for multiset_counter_example
+        WeightedRandomListLib # Added for weighted_random_list_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/examples/weighted_random_list_example.cpp
+++ b/examples/weighted_random_list_example.cpp
@@ -1,0 +1,143 @@
+#include "WeightedRandomList.h" // Assuming this path will be set up by CMake
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+
+// A simple helper to print the list contents
+template<typename T, typename WeightType>
+void print_list_details(const cpp_utils::WeightedRandomList<T, WeightType>& list) {
+    if (list.empty()) {
+        std::cout << "List is empty." << std::endl;
+        return;
+    }
+    std::cout << "List contents (size: " << list.size() << ", total weight: " << list.total_weight() << "):" << std::endl;
+    for (typename cpp_utils::WeightedRandomList<T, WeightType>::size_type i = 0; i < list.size(); ++i) {
+        auto entry = list.get_entry(i);
+        std::cout << "  Index " << i << ": Value = \"" << entry.first
+                  << "\", Weight = " << entry.second << std::endl;
+    }
+}
+
+int main() {
+    std::cout << "--- WeightedRandomList Example ---" << std::endl;
+
+    // 1. Create a WeightedRandomList
+    cpp_utils::WeightedRandomList<std::string> wr_list;
+    // Or: cpp_utils::WeightedRandomList<std::string, long long> wr_list_explicit;
+
+
+    // 2. Add elements with weights
+    std::cout << "\n--- Adding elements ---" << std::endl;
+    wr_list.push_back("apple", 10);
+    wr_list.push_back("banana", 20);
+    wr_list.push_back("cherry", 70);
+    wr_list.push_back("date", 0); // Zero weight, should not be selected
+
+    print_list_details(wr_list);
+
+    // 3. Fetch elements randomly
+    std::cout << "\n--- Random selections (10000 draws) ---" << std::endl;
+    if (wr_list.empty() || wr_list.total_weight() == 0) {
+        std::cout << "Cannot draw randomly, list is empty or has no total weight." << std::endl;
+    } else {
+        std::map<std::string, int> counts;
+        const int num_draws = 10000;
+        for (int i = 0; i < num_draws; ++i) {
+            auto random_item_opt = wr_list.get_random();
+            if (random_item_opt) {
+                counts[random_item_opt.value().get()]++;
+            }
+        }
+
+        for (const auto& pair : counts) {
+            double percentage = static_cast<double>(pair.second) / num_draws * 100.0;
+            std::cout << "\"" << pair.first << "\": " << pair.second << " times (" << percentage << "%)" << std::endl;
+        }
+        std::cout << "(Note: 'date' should have 0 draws or not appear if its weight is 0)." << std::endl;
+    }
+
+    // 4. Update weights
+    std::cout << "\n--- Updating weights ---" << std::endl;
+    std::cout << "Updating weight of 'apple' (index 0) from 10 to 50." << std::endl;
+    wr_list.update_weight(0, 50); // apple's index is 0
+
+    std::cout << "Updating weight of 'cherry' (index 2) from 70 to 10." << std::endl;
+    wr_list.update_weight(2, 10); // cherry's index is 2
+
+    print_list_details(wr_list);
+
+    std::cout << "\n--- Random selections after weight update (10000 draws) ---" << std::endl;
+    if (wr_list.empty() || wr_list.total_weight() == 0) {
+        std::cout << "Cannot draw randomly, list is empty or has no total weight." << std::endl;
+    } else {
+        std::map<std::string, int> counts_updated;
+        const int num_draws_updated = 10000;
+        for (int i = 0; i < num_draws_updated; ++i) {
+            auto random_item_opt = wr_list.get_random();
+            if (random_item_opt) {
+                counts_updated[random_item_opt.value().get()]++;
+            }
+        }
+        for (const auto& pair : counts_updated) {
+            double percentage = static_cast<double>(pair.second) / num_draws_updated * 100.0;
+            std::cout << "\"" << pair.first << "\": " << pair.second << " times (" << percentage << "%)" << std::endl;
+        }
+    }
+
+    // 5. Using operator[] and at()
+    std::cout << "\n--- Direct access using at() and operator[] ---" << std::endl;
+    try {
+        std::cout << "Element at index 1 (using at()): " << wr_list.at(1) << std::endl;
+        std::cout << "Element at index 0 (using operator[]): " << wr_list[0] << std::endl;
+        // Accessing out of bounds
+        // std::cout << "Element at index 10 (will throw): " << wr_list.at(10) << std::endl;
+    } catch (const std::out_of_range& e) {
+        std::cout << "Caught expected exception: " << e.what() << std::endl;
+    }
+
+    // 6. Modifying an element through mutable random access
+    std::cout << "\n--- Modifying element via get_random_mut() ---" << std::endl;
+    auto item_to_modify_opt = wr_list.get_random_mut();
+    if (item_to_modify_opt) {
+        std::string& item_ref = item_to_modify_opt.value().get();
+        std::cout << "Randomly selected item to modify: " << item_ref << std::endl;
+        item_ref = "MODIFIED_" + item_ref;
+        std::cout << "Item after modification: " << item_ref << std::endl;
+    }
+    print_list_details(wr_list);
+
+
+    // 7. Clearing the list
+    std::cout << "\n--- Clearing the list ---" << std::endl;
+    wr_list.clear();
+    print_list_details(wr_list);
+    std::cout << "Is list empty? " << (wr_list.empty() ? "Yes" : "No") << std::endl;
+
+    // 8. Example with zero total weight initially then adding positive weight
+    std::cout << "\n--- Example with initial zero total weight ---" << std::endl;
+    cpp_utils::WeightedRandomList<int> int_list;
+    int_list.push_back(100, 0);
+    int_list.push_back(200, 0);
+    print_list_details(int_list);
+    std::cout << "Attempting random draw (should be nullopt or handled gracefully):" << std::endl;
+    auto random_int_opt = int_list.get_random();
+    if (!random_int_opt) {
+        std::cout << "  Correctly received no item (nullopt)." << std::endl;
+    } else {
+        std::cout << "  Unexpectedly received item: " << random_int_opt.value().get() << std::endl;
+    }
+
+    std::cout << "Adding an item with positive weight:" << std::endl;
+    int_list.push_back(300, 5);
+    print_list_details(int_list);
+    random_int_opt = int_list.get_random();
+    if (random_int_opt) {
+        std::cout << "  Randomly selected item: " << random_int_opt.value().get() << " (should be 300)" << std::endl;
+    }
+
+
+    std::cout << "\n--- Example End ---" << std::endl;
+
+    return 0;
+}

--- a/include/WeightedRandomList.h
+++ b/include/WeightedRandomList.h
@@ -1,0 +1,228 @@
+#pragma once
+
+#include <vector>
+#include <random>
+#include <numeric> // for std::iota (potentially)
+#include <optional>
+#include <functional> // for std::reference_wrapper
+#include <stdexcept> // for std::out_of_range
+#include <type_traits> // for std::is_same_v, std::is_integral_v
+#include <algorithm> // for std::lower_bound in binary search logic
+
+#include "fenwick_tree.h" // Assuming it's in the same include directory
+
+namespace cpp_utils {
+
+template<typename T, typename WeightType = long long>
+class WeightedRandomList {
+public:
+    static_assert(std::is_same_v<WeightType, long long>,
+                  "WeightType must be long long for compatibility with the current FenwickTree implementation.");
+    static_assert(std::is_integral_v<WeightType> && std::is_signed_v<WeightType>,
+                  "WeightType must be a signed integral type."); // Weights can be 0, should not be negative.
+
+    using value_type = T;
+    using weight_type = WeightType;
+    using size_type = std::size_t;
+
+    // Constructors
+    WeightedRandomList() : ft_(0), total_weight_(0), gen_(rd_()) {}
+
+    explicit WeightedRandomList(size_type initial_capacity) : ft_(0), total_weight_(0), gen_(rd_()) {
+        elements_.reserve(initial_capacity);
+        weights_.reserve(initial_capacity);
+        // Fenwick tree will be built when elements are added.
+    }
+
+    // TODO: Consider constructors from iterators or initializer_list
+    // WeightedRandomList(std::initializer_list<std::pair<T, WeightType>> il);
+
+    // Modifiers
+    void push_back(const T& value, WeightType weight) {
+        if (weight < 0) {
+            throw std::invalid_argument("Weight cannot be negative.");
+        }
+        elements_.push_back(value);
+        weights_.push_back(weight);
+        total_weight_ += weight;
+        rebuild_fenwick_tree();
+    }
+
+    void push_back(T&& value, WeightType weight) {
+        if (weight < 0) {
+            throw std::invalid_argument("Weight cannot be negative.");
+        }
+        elements_.push_back(std::move(value));
+        weights_.push_back(weight);
+        total_weight_ += weight;
+        rebuild_fenwick_tree();
+    }
+
+    void update_weight(size_type index, WeightType new_weight) {
+        if (index >= size()) {
+            throw std::out_of_range("Index out of range in update_weight");
+        }
+        if (new_weight < 0) {
+            throw std::invalid_argument("New weight cannot be negative.");
+        }
+
+        WeightType old_weight = weights_[index];
+        weights_[index] = new_weight;
+
+        total_weight_ -= old_weight;
+        total_weight_ += new_weight;
+
+        ft_.set(static_cast<int>(index), new_weight); // FenwickTree uses int for index
+    }
+
+    // Random Access
+    std::optional<std::reference_wrapper<const T>> get_random() const {
+        if (empty() || total_weight_ <= 0) {
+            return std::nullopt;
+        }
+
+        std::uniform_int_distribution<WeightType> dist(0, total_weight_ - 1);
+        WeightType random_target_sum = dist(gen_);
+
+        size_type selected_index = find_index_for_cumulative_sum(random_target_sum);
+        return std::cref(elements_[selected_index]);
+    }
+
+    // Mutable version of get_random
+    std::optional<std::reference_wrapper<T>> get_random_mut() {
+        if (empty() || total_weight_ <= 0) {
+            return std::nullopt;
+        }
+        // Need mutable generator for non-const method
+        std::uniform_int_distribution<WeightType> dist(0, total_weight_ - 1);
+        WeightType random_target_sum = dist(gen_); // Ok, gen_ is mutable
+
+        size_type selected_index = find_index_for_cumulative_sum(random_target_sum);
+        return std::ref(elements_[selected_index]);
+    }
+
+
+    // Element Access
+    const T& operator[](size_type index) const {
+        return elements_[index];
+    }
+
+    T& operator[](size_type index) {
+        return elements_[index];
+    }
+
+    const T& at(size_type index) const {
+        if (index >= size()) {
+            throw std::out_of_range("Index out of range in at()");
+        }
+        return elements_[index];
+    }
+
+    T& at(size_type index) {
+        if (index >= size()) {
+            throw std::out_of_range("Index out of range in at()");
+        }
+        return elements_[index];
+    }
+
+    // Returns a pair of const ref to element and its weight
+    std::pair<const T&, WeightType> get_entry(size_type index) const {
+        if (index >= size()) {
+            throw std::out_of_range("Index out of range in get_entry");
+        }
+        return {elements_[index], weights_[index]};
+    }
+
+    // Capacity
+    size_type size() const noexcept {
+        return elements_.size();
+    }
+
+    bool empty() const noexcept {
+        return elements_.empty();
+    }
+
+    void clear() noexcept {
+        elements_.clear();
+        weights_.clear();
+        total_weight_ = 0;
+        ft_ = FenwickTree(0); // Re-initialize Fenwick tree
+    }
+
+    void reserve(size_type new_cap) {
+        elements_.reserve(new_cap);
+        weights_.reserve(new_cap);
+        // Fenwick tree is managed based on actual size, not capacity.
+    }
+
+    WeightType total_weight() const noexcept {
+        return total_weight_;
+    }
+
+private:
+    void rebuild_fenwick_tree() {
+        if (weights_.empty()) {
+            ft_ = FenwickTree(0);
+        } else {
+            // FenwickTree constructor from std::vector<long long>
+            // Ensure weights_ is compatible or cast if necessary.
+            // Since WeightType is asserted to be long long, this is fine.
+            ft_ = FenwickTree(weights_);
+        }
+    }
+
+    // Finds the first index `idx` such that prefixSum(idx) > target_sum.
+    // target_sum is a value from [0, total_weight_ - 1].
+    // This means we are looking for the item that "covers" this random value.
+    size_type find_index_for_cumulative_sum(WeightType target_sum) const {
+        // Binary search for the index
+        size_type low = 0;
+        size_type high = size() - 1;
+        size_type ans_idx = size() -1; // Default to last element if something goes wrong, or if all but last have 0 weight
+
+        while(low <= high) {
+            size_type mid = low + (high - low) / 2;
+            // ft_.prefixSum(i) is sum up to and including i.
+            // if ft_.prefixSum(mid) > target_sum, it means mid *might* be our element,
+            // or an element before it.
+            // Example: weights [10,20,5], total 35. target_sum in [0,34]
+            // sums: [10, 30, 35]
+            // target_sum = 0: ft_.prefixSum(0)=10 > 0. ans=0. high=-1. Correct.
+            // target_sum = 9: ft_.prefixSum(0)=10 > 9. ans=0. high=-1. Correct.
+            // target_sum = 10: ft_.prefixSum(0)=10. Not > 10. low=1.
+            //                  mid=1 (low=1, high=2). ft_.prefixSum(1)=30 > 10. ans=1. high=0.
+            //                  Loop ends. ans_idx=1. Correct.
+            // target_sum = 29: ft_.prefixSum(1)=30 > 29. ans=1. high=0. Correct.
+            // target_sum = 30: ft_.prefixSum(1)=30. Not > 30. low=2.
+            //                  mid=2 (low=2, high=2). ft_.prefixSum(2)=35 > 30. ans=2. high=1.
+            //                  Loop ends. ans_idx=2. Correct.
+
+            if (ft_.prefixSum(static_cast<int>(mid)) > target_sum) {
+                ans_idx = mid;
+                if (mid == 0) break; // Avoid underflow with mid-1
+                high = mid - 1;
+            } else {
+                low = mid + 1;
+            }
+        }
+        return ans_idx;
+    }
+
+
+    std::vector<T> elements_;
+    std::vector<WeightType> weights_; // Raw weights
+    FenwickTree ft_;                  // For cumulative sums and selection logic
+    WeightType total_weight_;
+
+    // Random number generation
+    // mutable allows gen_ to be used in const get_random()
+    // However, std::mt19937 is not thread-safe if shared and mutated.
+    // For const correctness, if get_random() is const, it shouldn't change state.
+    // But random number generator inherently changes its internal state.
+    // Common practice is to mark generator `mutable` or pass generator by ref.
+    // Let's make gen_ mutable for now.
+    mutable std::random_device rd_; // Used once to seed gen_
+    mutable std::mt19937 gen_;      // Standard mersenne_twister_engine
+};
+
+} // namespace cpp_utils

--- a/include/fenwick_tree.h
+++ b/include/fenwick_tree.h
@@ -16,7 +16,7 @@ private:
     int n;
     
     // Get the least significant bit
-    int lsb(int x) {
+    int lsb(int x) const {
         return x & (-x);
     }
     
@@ -76,7 +76,7 @@ public:
      * @return The sum of elements from index 0 to i. Returns 0 if i is -1.
      * @complexity O(log n).
      */
-    long long prefixSum(int i) {
+    long long prefixSum(int i) const {
         assert(i >= -1 && i < n && "Index out of bounds in prefixSum");
         if (i < 0) return 0;
         i++; // Convert to 1-indexed
@@ -95,7 +95,7 @@ public:
      * @return The sum of elements in the range [l, r].
      * @complexity O(log n) due to two calls to prefixSum.
      */
-    long long query(int l, int r) {
+    long long query(int l, int r) const {
         assert(l <= r && "Left index cannot be greater than right index in query");
         assert(l >= 0 && r < n && "Indices out of bounds in query");
         return prefixSum(r) - prefixSum(l - 1);
@@ -107,7 +107,7 @@ public:
      * @return The value of the element at index i.
      * @complexity O(log n) as it calls query(i, i).
      */
-    long long get(int i) {
+    long long get(int i) const {
         assert(i >= 0 && i < n && "Index out of bounds in get");
         return query(i, i);
     }
@@ -125,7 +125,7 @@ public:
      * @brief (Debug) Prints the internal tree structure.
      * Useful for debugging purposes.
      */
-    void printTree() {
+    void printTree() const {
         std::cout << "Tree array: ";
         for (int i = 1; i <= n; i++) {
             std::cout << tree[i] << " ";
@@ -138,7 +138,7 @@ public:
      * Useful for debugging purposes. It reconstructs values by calling get().
      * @complexity O(n log n) due to calling get() for each element.
      */
-    void printArray() {
+    void printArray() const {
         std::cout << "Array values: ";
         for (int i = 0; i < n; i++) {
             std::cout << get(i) << " ";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,3 +32,10 @@ gtest_discover_tests(multiset_counter_test)
 add_executable(interning_pool_test test_interning_pool.cpp)
 target_link_libraries(interning_pool_test PRIVATE GTest::gtest GTest::gtest_main)
 gtest_discover_tests(interning_pool_test)
+
+# Add the test executable for WeightedRandomList
+add_executable(weighted_random_list_test test_weighted_random_list.cpp)
+target_link_libraries(weighted_random_list_test PRIVATE GTest::gtest GTest::gtest_main)
+# No need to link WeightedRandomListLib explicitly due to include_directories(${CMAKE_SOURCE_DIR}/include)
+# and it being header-only. GTest linkage is sufficient.
+gtest_discover_tests(weighted_random_list_test)

--- a/tests/test_weighted_random_list.cpp
+++ b/tests/test_weighted_random_list.cpp
@@ -1,0 +1,282 @@
+#include "gtest/gtest.h"
+#include "WeightedRandomList.h" // Adjust path as necessary based on CMake include directories
+#include <string>
+#include <map>
+#include <vector>
+#include <numeric> // For std::accumulate if needed for manual weight sum
+
+// Using namespace for convenience in test file
+using namespace cpp_utils;
+
+// Test fixture for WeightedRandomList
+class WeightedRandomListTest : public ::testing::Test {
+protected:
+    WeightedRandomList<std::string> list_str_;
+    WeightedRandomList<int, long long> list_int_; // Explicitly specify WeightType
+};
+
+TEST_F(WeightedRandomListTest, ConstructorAndInitialState) {
+    EXPECT_EQ(list_str_.size(), 0);
+    EXPECT_TRUE(list_str_.empty());
+    EXPECT_EQ(list_str_.total_weight(), 0);
+
+    WeightedRandomList<int> list_cap(10);
+    EXPECT_EQ(list_cap.size(), 0); // Capacity is reserved, size is still 0
+    EXPECT_TRUE(list_cap.empty());
+    list_cap.reserve(20); // Should not throw, just reserves more
+}
+
+TEST_F(WeightedRandomListTest, PushBack) {
+    list_str_.push_back("apple", 10);
+    EXPECT_EQ(list_str_.size(), 1);
+    EXPECT_FALSE(list_str_.empty());
+    EXPECT_EQ(list_str_.total_weight(), 10);
+    EXPECT_EQ(list_str_[0], "apple");
+    EXPECT_EQ(list_str_.get_entry(0).second, 10);
+
+    list_str_.push_back("banana", 20);
+    EXPECT_EQ(list_str_.size(), 2);
+    EXPECT_EQ(list_str_.total_weight(), 30); // 10 + 20
+    EXPECT_EQ(list_str_[1], "banana");
+    EXPECT_EQ(list_str_.get_entry(1).second, 20);
+
+    // Test move semantics for value
+    std::string cherry_str = "cherry";
+    list_str_.push_back(std::move(cherry_str), 30);
+    EXPECT_EQ(list_str_.size(), 3);
+    EXPECT_EQ(list_str_.total_weight(), 60);
+    EXPECT_EQ(list_str_[2], "cherry");
+    // EXPECT_TRUE(cherry_str.empty()); // Behavior of moved-from string can vary
+}
+
+TEST_F(WeightedRandomListTest, PushBackNegativeWeight) {
+    EXPECT_THROW(list_int_.push_back(1, -5), std::invalid_argument);
+}
+
+TEST_F(WeightedRandomListTest, UpdateWeight) {
+    list_int_.push_back(100, 10);
+    list_int_.push_back(200, 20);
+    list_int_.push_back(300, 30); // Total weight = 60
+
+    list_int_.update_weight(1, 25); // Update 200's weight from 20 to 25
+    EXPECT_EQ(list_int_.get_entry(1).second, 25);
+    EXPECT_EQ(list_int_.total_weight(), 65); // 10 + 25 + 30
+
+    list_int_.update_weight(0, 5); // Update 100's weight from 10 to 5
+    EXPECT_EQ(list_int_.get_entry(0).second, 5);
+    EXPECT_EQ(list_int_.total_weight(), 60); // 5 + 25 + 30
+
+    EXPECT_THROW(list_int_.update_weight(5, 10), std::out_of_range); // Index out of bounds
+    EXPECT_THROW(list_int_.update_weight(0, -10), std::invalid_argument); // Negative weight
+}
+
+TEST_F(WeightedRandomListTest, GetRandomEmptyOrZeroWeight) {
+    // Empty list
+    auto item_opt = list_str_.get_random();
+    EXPECT_FALSE(item_opt.has_value());
+
+    // List with items but all zero weight
+    list_str_.push_back("zero_one", 0);
+    list_str_.push_back("zero_two", 0);
+    EXPECT_EQ(list_str_.total_weight(), 0);
+    item_opt = list_str_.get_random();
+    EXPECT_FALSE(item_opt.has_value());
+
+    // Mutable versions
+    auto item_mut_opt = list_str_.get_random_mut();
+    EXPECT_FALSE(item_mut_opt.has_value());
+}
+
+TEST_F(WeightedRandomListTest, GetRandomSingleItem) {
+    list_int_.push_back(123, 10);
+    auto item_opt = list_int_.get_random();
+    ASSERT_TRUE(item_opt.has_value());
+    EXPECT_EQ(item_opt.value().get(), 123);
+
+    // Mutable
+    auto item_mut_opt = list_int_.get_random_mut();
+    ASSERT_TRUE(item_mut_opt.has_value());
+    EXPECT_EQ(item_mut_opt.value().get(), 123);
+    item_mut_opt.value().get() = 456;
+    EXPECT_EQ(list_int_[0], 456);
+}
+
+TEST_F(WeightedRandomListTest, GetRandomDistribution) {
+    list_str_.push_back("itemA", 10); // Expected ~10%
+    list_str_.push_back("itemB", 80); // Expected ~80%
+    list_str_.push_back("itemC", 10); // Expected ~10%
+    // itemD has 0 weight, should not be selected
+    list_str_.push_back("itemD_zero_weight", 0);
+
+
+    ASSERT_EQ(list_str_.total_weight(), 100);
+
+    std::map<std::string, int> counts;
+    const int num_draws = 20000; // Increased draws for better statistical significance
+
+    for (int i = 0; i < num_draws; ++i) {
+        auto item_opt = list_str_.get_random();
+        ASSERT_TRUE(item_opt.has_value()); // Should always get an item
+        counts[item_opt.value().get()]++;
+    }
+
+    EXPECT_EQ(counts.count("itemD_zero_weight"), 0); // itemD should not be present or count 0
+
+    // Check distribution (approximate)
+    // Allow for some statistical variance, e.g., +/- 2.5% of total draws for 80% item
+    // 80% of 20000 = 16000. 2.5% of 20000 = 500
+    // 10% of 20000 = 2000.  2.5% of 20000 = 500
+
+    // For itemA (10% weight)
+    double pA = static_cast<double>(counts["itemA"]) / num_draws;
+    EXPECT_NEAR(pA, 0.10, 0.025); // Expect 10%, allow margin of error 2.5%
+
+    // For itemB (80% weight)
+    double pB = static_cast<double>(counts["itemB"]) / num_draws;
+    EXPECT_NEAR(pB, 0.80, 0.025); // Expect 80%, allow margin of error 2.5%
+
+    // For itemC (10% weight)
+    double pC = static_cast<double>(counts["itemC"]) / num_draws;
+    EXPECT_NEAR(pC, 0.10, 0.025); // Expect 10%, allow margin of error 2.5%
+
+    // Ensure all draws are accounted for by items with weight
+    EXPECT_EQ(counts["itemA"] + counts["itemB"] + counts["itemC"], num_draws);
+}
+
+
+TEST_F(WeightedRandomListTest, GetRandomDistributionAfterUpdate) {
+    list_str_.push_back("X", 25);
+    list_str_.push_back("Y", 75); // Total 100
+
+    list_str_.update_weight(0, 50); // X now 50
+    list_str_.update_weight(1, 50); // Y now 50. Total still 100, but 50/50 distribution
+
+    ASSERT_EQ(list_str_.total_weight(), 100);
+
+    std::map<std::string, int> counts;
+    const int num_draws = 10000;
+    for (int i = 0; i < num_draws; ++i) {
+        auto item_opt = list_str_.get_random();
+        ASSERT_TRUE(item_opt.has_value());
+        counts[item_opt.value().get()]++;
+    }
+
+    double pX = static_cast<double>(counts["X"]) / num_draws;
+    EXPECT_NEAR(pX, 0.50, 0.03); // Expect 50%, allow margin 3%
+
+    double pY = static_cast<double>(counts["Y"]) / num_draws;
+    EXPECT_NEAR(pY, 0.50, 0.03); // Expect 50%, allow margin 3%
+}
+
+
+TEST_F(WeightedRandomListTest, ElementAccess) {
+    list_str_.push_back("first", 1);
+    list_str_.push_back("second", 1);
+
+    // Const access
+    const auto& const_list = list_str_;
+    EXPECT_EQ(const_list[0], "first");
+    EXPECT_EQ(const_list.at(1), "second");
+    EXPECT_THROW(const_list.at(2), std::out_of_range);
+
+    // Mutable access
+    list_str_[0] = "new_first";
+    EXPECT_EQ(list_str_[0], "new_first");
+    list_str_.at(1) = "new_second";
+    EXPECT_EQ(list_str_.at(1), "new_second");
+    EXPECT_THROW(list_str_.at(2), std::out_of_range);
+}
+
+TEST_F(WeightedRandomListTest, GetEntry) {
+    list_int_.push_back(10, 100);
+    list_int_.push_back(20, 200);
+
+    auto entry0 = list_int_.get_entry(0);
+    EXPECT_EQ(entry0.first, 10);
+    EXPECT_EQ(entry0.second, 100);
+
+    auto entry1 = list_int_.get_entry(1);
+    EXPECT_EQ(entry1.first, 20);
+    EXPECT_EQ(entry1.second, 200);
+
+    EXPECT_THROW(list_int_.get_entry(2), std::out_of_range);
+}
+
+
+TEST_F(WeightedRandomListTest, Clear) {
+    list_str_.push_back("one", 1);
+    list_str_.push_back("two", 2);
+    ASSERT_FALSE(list_str_.empty());
+    ASSERT_EQ(list_str_.size(), 2);
+    ASSERT_EQ(list_str_.total_weight(), 3);
+
+    list_str_.clear();
+    EXPECT_TRUE(list_str_.empty());
+    EXPECT_EQ(list_str_.size(), 0);
+    EXPECT_EQ(list_str_.total_weight(), 0);
+
+    // Check if it's usable after clear
+    list_str_.push_back("three", 3);
+    EXPECT_EQ(list_str_.size(), 1);
+    EXPECT_EQ(list_str_.total_weight(), 3);
+    auto item_opt = list_str_.get_random();
+    ASSERT_TRUE(item_opt.has_value());
+    EXPECT_EQ(item_opt.value().get(), "three");
+}
+
+TEST_F(WeightedRandomListTest, Reserve) {
+    list_int_.reserve(100);
+    // Functionality is primarily to avoid reallocations,
+    // difficult to test behavior directly beyond it not crashing.
+    // Size should still be 0.
+    EXPECT_EQ(list_int_.size(), 0);
+    EXPECT_TRUE(list_int_.empty());
+
+    list_int_.push_back(1,1); // Should still work
+    EXPECT_EQ(list_int_.size(), 1);
+}
+
+TEST_F(WeightedRandomListTest, GetRandomMutableAndModify) {
+    list_str_.push_back("original", 100);
+    list_str_.push_back("another", 1); // Low weight, less likely to be picked
+
+    // Try a few times to increase chance of picking "original" if not perfectly random
+    bool modified = false;
+    for(int i=0; i<10; ++i) { // Try to get the first element
+        auto item_mut_opt = list_str_.get_random_mut();
+        ASSERT_TRUE(item_mut_opt.has_value());
+        if (item_mut_opt.value().get() == "original") {
+             item_mut_opt.value().get() = "modified";
+             modified = true;
+             break;
+        }
+    }
+    ASSERT_TRUE(modified); // Ensure we actually modified it for the test to be meaningful
+
+    // Verify modification
+    bool found_modified = false;
+    bool found_original_still = false;
+    for(size_t i=0; i<list_str_.size(); ++i) {
+        if (list_str_[i] == "modified") found_modified = true;
+        if (list_str_[i] == "original") found_original_still = true;
+    }
+    EXPECT_TRUE(found_modified);
+    EXPECT_FALSE(found_original_still); // "original" should be gone
+    EXPECT_EQ(list_str_.get_entry(0).first, "modified"); // Assuming "original" was at index 0
+}
+
+// Test with a different weight type if we were to change the static_assert
+// For now, WeightType is fixed to long long.
+// If it were a template parameter for FenwickTree as well, we could test e.g. int.
+/*
+TEST_F(WeightedRandomListTest, DifferentWeightType) {
+    WeightedRandomList<std::string, int> list_int_weights; // Hypothetical if WeightType was more flexible
+    list_int_weights.push_back("item", 10);
+    EXPECT_EQ(list_int_weights.total_weight(), 10);
+}
+*/
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This commit introduces a new data structure, `WeightedRandomList<T, WeightType>`, which stores a collection of elements, each associated with a weight. It allows for random selection of elements where the probability of an element being chosen is proportional to its weight.

Key features:
- Elements are stored with associated weights (non-negative `long long`).
- `push_back()` to add elements.
- `update_weight()` to modify weights of existing elements (O(log N)).
- `get_random()` for biased random selection (O(log^2 N)).
- Standard accessors (`[]`, `at()`) and capacity methods (`size`, `empty`, `clear`).

Implementation details:
- Header-only library in `include/WeightedRandomList.h`.
- Uses `FenwickTree` (from `include/fenwick_tree.h`) internally for managing cumulative weights to aid in random selection.
- `push_back` is O(N log N) due to Fenwick tree reconstruction with the current FenwickTree implementation.

Included:
- `include/WeightedRandomList.h`: Core implementation.
- `examples/weighted_random_list_example.cpp`: Usage demonstration.
- `tests/test_weighted_random_list.cpp`: Unit tests using Google Test.
- `docs/README_WeightedRandomList.md`: Documentation.
- Updates to `CMakeLists.txt` (root and tests/) to integrate the new files.

The `FenwickTree` header was also updated to ensure `const`-correctness for its read-only methods, which was necessary for integration with `WeightedRandomList`. All new tests for `WeightedRandomList` pass.