### PR TITLE
Add ThreadSafeCounter data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,10 @@ target_include_directories(MultisetCounterLib INTERFACE ${CMAKE_CURRENT_SOURCE_D
 add_library(WeightedRandomListLib INTERFACE)
 target_include_directories(WeightedRandomListLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define ThreadSafeCounterLib as an interface library (header-only)
+add_library(ThreadSafeCounterLib INTERFACE)
+target_include_directories(ThreadSafeCounterLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -261,6 +265,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         DynamicBitsetLib     # Added for dynamic_bitset_example
         MultisetCounterLib   # Added for multiset_counter_example
         WeightedRandomListLib # Added for weighted_random_list_example
+        ThreadSafeCounterLib # Added for thread_safe_counter_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/docs/README_thread_safe_counter.md
+++ b/docs/README_thread_safe_counter.md
@@ -1,0 +1,161 @@
+# ThreadSafeCounter
+
+## Overview
+
+`ThreadSafeCounter<T, Hash, KeyEqual>` is a C++ template class that provides a thread-safe frequency counter, similar in functionality to Python's `collections.Counter`. It is designed for scenarios where multiple threads need to concurrently increment, decrement, or query counts of items.
+
+The class uses `std::unordered_map` as its underlying storage and protects all access to this map with a `std::mutex` to ensure thread safety.
+
+## Template Parameters
+
+-   `T`: The type of elements to be counted. This type must be hashable and equality comparable.
+-   `Hash`: The hash function to use for elements of type `T`. Defaults to `std::hash<T>`.
+-   `KeyEqual`: The equality comparison function for elements of type `T`. Defaults to `std::equal_to<T>`.
+
+## Features
+
+-   **Thread Safety**: All public methods that access or modify the counter's state are protected by a mutex.
+-   **Rich API**: Offers a comprehensive set of methods for managing and querying counts.
+    -   Adding/subtracting counts: `add()`, `subtract()`.
+    -   Setting specific counts: `set_count()`.
+    -   Querying counts: `count()`, `operator[]` (const).
+    -   Checking for item presence: `contains()`.
+    -   Removing items: `erase()`.
+    -   Utility functions: `clear()`, `size()`, `empty()`, `total()`.
+    -   Retrieving most common items: `most_common()`.
+    -   Copying internal data: `get_data_copy()`.
+-   **Arithmetic Operations**: Supports counter arithmetic (`+`, `-`, `+=`, `-=`) in a thread-safe manner.
+-   **Set Operations**: Supports intersection (`intersection()`) and union (`union_with()`) operations, returning new counters.
+-   **STL-like Interface**: Where appropriate, methods mimic standard C++ container interfaces.
+-   **Construction Flexibility**: Can be constructed from initializer lists (of items or item-count pairs) or iterator ranges.
+-   **Deduction Guides**: Class template argument deduction (CTAD) is supported for easier instantiation.
+
+## Usage
+
+### Basic Operations
+
+```cpp
+#include "thread_safe_counter.hpp"
+#include <iostream>
+#include <string>
+
+int main() {
+    ThreadSafeCounter<std::string> counter;
+
+    // Add items
+    counter.add("apple", 3);
+    counter.add("banana"); // Adds 1 to banana
+    counter.add("apple", 2); // Now apple is 5
+
+    // Get counts
+    std::cout << "Count of apple: " << counter.count("apple") << std::endl;   // Output: 5
+    std::cout << "Count of banana: " << counter["banana"] << std::endl; // Output: 1
+    std::cout << "Count of orange: " << counter.count("orange") << std::endl; // Output: 0
+
+    // Subtract items
+    counter.subtract("apple", 2); // apple is now 3
+    std::cout << "Count of apple after subtract: " << counter.count("apple") << std::endl; // Output: 3
+
+    // Set specific count
+    counter.set_count("banana", 10);
+    std::cout << "Count of banana after set_count: " << counter.count("banana") << std::endl; // Output: 10
+    counter.set_count("apple", 0); // Setting count to 0 removes the item
+    std::cout << "Contains apple after set_count to 0: " << counter.contains("apple") << std::endl; // Output: 0 (false)
+
+
+    // Total items
+    std::cout << "Total items: " << counter.total() << std::endl; // e.g., 10 (if only banana:10 exists)
+
+    // Most common
+    counter.add("grape", 5);
+    counter.add("orange", 8);
+    auto common = counter.most_common(2); // Get top 2
+    for (const auto& p : common) {
+        std::cout << p.first << ": " << p.second << std::endl;
+    }
+    // Example Output:
+    // banana: 10
+    // orange: 8
+}
+
+```
+
+### Multithreaded Usage
+
+`ThreadSafeCounter` ensures that operations from different threads are correctly synchronized.
+
+```cpp
+#include "thread_safe_counter.hpp"
+#include <iostream>
+#include <vector>
+#include <thread>
+#include <string>
+
+void increment_task(ThreadSafeCounter<std::string>& counter, const std::string& item, int times) {
+    for (int i = 0; i < times; ++i) {
+        counter.add(item);
+    }
+}
+
+int main() {
+    ThreadSafeCounter<std::string> concurrent_counter;
+    std::vector<std::thread> threads;
+    int num_threads = 10;
+    int ops_per_thread = 1000;
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back(increment_task, std::ref(concurrent_counter), "event_type_A", ops_per_thread);
+        threads.emplace_back(increment_task, std::ref(concurrent_counter), "event_type_B", ops_per_thread / 2);
+    }
+
+    for (std::thread& t : threads) {
+        if (t.joinable()) {
+            t.join();
+        }
+    }
+
+    std::cout << "Concurrent operations result:" << std::endl;
+    std::cout << "event_type_A: " << concurrent_counter.count("event_type_A") << std::endl;
+    // Expected: num_threads * ops_per_thread
+    std::cout << "event_type_B: " << concurrent_counter.count("event_type_B") << std::endl;
+    // Expected: num_threads * (ops_per_thread / 2)
+
+    return 0;
+}
+```
+
+## Method Reference
+
+(A selection of key methods)
+
+-   `ThreadSafeCounter()`: Default constructor.
+-   `ThreadSafeCounter(std::initializer_list<T> init)`: Constructs from an initializer list of items.
+-   `ThreadSafeCounter(std::initializer_list<std::pair<T, int>> init)`: Constructs from an initializer list of item-count pairs.
+-   `void add(const T& value, int count_val = 1)`: Increments the count of `value` by `count_val`. If `count_val` is negative, it behaves like `subtract`.
+-   `void subtract(const T& value, int count_val = 1)`: Decrements the count of `value` by `count_val`. If the count becomes zero or less, the item is removed from the counter.
+-   `void set_count(const T& key, int val)`: Sets the count of `key` to `val`. If `val` is zero or less, the item is removed.
+-   `[[nodiscard]] int count(const T& value) const`: Returns the count of `value`. Returns 0 if `value` is not in the counter.
+-   `[[nodiscard]] int operator[](const T& value) const`: Equivalent to `count(value)`.
+-   `[[nodiscard]] bool contains(const T& value) const`: Checks if `value` is present in the counter (i.e., its count > 0).
+-   `size_type erase(const T& value)`: Removes `value` from the counter. Returns 1 if an element was removed, 0 otherwise.
+-   `void clear()`: Removes all items from the counter.
+-   `[[nodiscard]] size_type size() const`: Returns the number of unique items in the counter.
+-   `[[nodiscard]] bool empty() const`: Checks if the counter is empty.
+-   `[[nodiscard]] int total() const`: Returns the sum of all counts in the counter.
+-   `[[nodiscard]] std::vector<std::pair<T, int>> most_common(size_type n = 0) const`: Returns a vector of the `n` most common items and their counts. If `n` is 0, all items are returned, sorted by frequency (highest first), with ties broken by key comparison (if `T` is comparable).
+-   `[[nodiscard]] std::unordered_map<T, int, Hash, KeyEqual> get_data_copy() const`: Returns a copy of the underlying `unordered_map`.
+-   `ThreadSafeCounter& operator+=(const ThreadSafeCounter& other)`: Adds counts from `other` counter into `this` counter.
+-   `ThreadSafeCounter& operator-=(const ThreadSafeCounter& other)`: Subtracts counts from `other` counter from `this` counter. Items whose counts become non-positive are removed.
+-   `[[nodiscard]] ThreadSafeCounter operator+(const ThreadSafeCounter& other) const`: Returns a new counter with combined counts.
+-   `[[nodiscard]] ThreadSafeCounter operator-(const ThreadSafeCounter& other) const`: Returns a new counter with subtracted counts. Resulting counts can be negative (items are not removed if count becomes non-positive in this specific operation, matching Python's Counter behavior for `-`).
+-   `[[nodiscard]] ThreadSafeCounter intersection(const ThreadSafeCounter& other) const`: Returns a new counter with counts being the minimum of counts from `this` and `other` for common keys.
+-   `[[nodiscard]] ThreadSafeCounter union_with(const ThreadSafeCounter& other) const`: Returns a new counter with counts being the maximum of counts from `this` and `other` for all keys present in either.
+
+## Thread Safety Considerations
+
+-   All methods are internally synchronized using `std::mutex`.
+-   Operations like `most_common()` and `get_data_copy()` return copies of data, so the returned data is not affected by subsequent modifications to the original counter.
+-   Iterators are not directly provided for the underlying map to avoid complexities with concurrent modification. Instead, methods like `most_common()` or `get_data_copy()` can be used to get a snapshot of the data for iteration.
+-   Copy/Move constructors and assignment operators are implemented with appropriate locking to ensure thread safety during these operations, including deadlock avoidance for self-assignment and assignment between two different counters.
+
+This `ThreadSafeCounter` aims to be a robust and easy-to-use component for multithreaded C++ applications requiring frequency counting.

--- a/examples/thread_safe_counter_example.cpp
+++ b/examples/thread_safe_counter_example.cpp
@@ -1,0 +1,152 @@
+#include "thread_safe_counter.hpp"
+#include <iostream>
+#include <vector>
+#include <thread>
+#include <string>
+#include <chrono> // For std::chrono::milliseconds
+#include <random>   // For std::random_device, std::mt19937, std::uniform_int_distribution
+
+// Function for a worker thread to perform operations on the counter
+void worker_task(ThreadSafeCounter<std::string>& counter, int num_operations, int worker_id) {
+    std::mt19937 rng(std::random_device{}() + worker_id); // Seed with worker_id for different sequences
+    std::uniform_int_distribution<int> op_dist(0, 2); // 0: add "apple", 1: add "banana", 2: subtract "apple"
+    std::uniform_int_distribution<int> val_dist(1, 5);  // Values to add/subtract
+
+    for (int i = 0; i < num_operations; ++i) {
+        int operation = op_dist(rng);
+        int value = val_dist(rng);
+
+        if (operation == 0) {
+            counter.add("apple", value);
+            // std::cout << "Worker " << worker_id << " added " << value << " to apple." << std::endl;
+        } else if (operation == 1) {
+            counter.add("banana", value);
+            // std::cout << "Worker " << worker_id << " added " << value << " to banana." << std::endl;
+        } else { // operation == 2
+            counter.subtract("apple", value);
+            // std::cout << "Worker " << worker_id << " subtracted " << value << " from apple." << std::endl;
+        }
+        // Small delay to increase chances of interleaving
+        std::this_thread::sleep_for(std::chrono::microseconds(rng() % 100));
+    }
+}
+
+int main() {
+    std::cout << "ThreadSafeCounter Example" << std::endl;
+    std::cout << "-------------------------" << std::endl;
+
+    // Basic usage
+    ThreadSafeCounter<std::string> basic_counter;
+    basic_counter.add("hello", 2);
+    basic_counter.add("world", 3);
+    basic_counter.add("hello", 1);
+    std::cout << "Initial counts:" << std::endl;
+    std::cout << "hello: " << basic_counter.count("hello") << std::endl; // Expected: 3
+    std::cout << "world: " << basic_counter.count("world") << std::endl; // Expected: 3
+    std::cout << "Total items: " << basic_counter.total() << std::endl;  // Expected: 6
+    std::cout << std::endl;
+
+    basic_counter.subtract("world", 2);
+    std::cout << "After subtracting 2 from 'world':" << std::endl;
+    std::cout << "world: " << basic_counter.count("world") << std::endl; // Expected: 1
+    std::cout << "Total items: " << basic_counter.total() << std::endl;  // Expected: 4
+    std::cout << std::endl;
+
+    basic_counter.set_count("new_item", 5);
+    std::cout << "After setting 'new_item' to 5:" << std::endl;
+    std::cout << "new_item: " << basic_counter.count("new_item") << std::endl; // Expected: 5
+    std::cout << std::endl;
+
+    std::cout << "Most common (top 2):" << std::endl;
+    for (const auto& pair : basic_counter.most_common(2)) {
+        std::cout << pair.first << ": " << pair.second << std::endl;
+    }
+    std::cout << std::endl;
+
+
+    // Multithreaded usage
+    std::cout << "Multithreaded test:" << std::endl;
+    ThreadSafeCounter<std::string> concurrent_counter;
+    std::vector<std::thread> threads;
+    int num_threads = 5;
+    int operations_per_thread = 1000;
+
+    // Expected final counts can be complex due to subtractions potentially removing items.
+    // We'll just observe the final state.
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back(worker_task, std::ref(concurrent_counter), operations_per_thread, i + 1);
+    }
+
+    for (std::thread& t : threads) {
+        if (t.joinable()) {
+            t.join();
+        }
+    }
+
+    std::cout << "\nFinal counts after multithreaded operations:" << std::endl;
+    std::cout << "apple: " << concurrent_counter.count("apple") << std::endl;
+    std::cout << "banana: " << concurrent_counter.count("banana") << std::endl;
+    std::cout << "Total items in concurrent_counter: " << concurrent_counter.total() << std::endl;
+    std::cout << "Size of concurrent_counter (unique keys): " << concurrent_counter.size() << std::endl;
+
+
+    std::cout << "\nMost common items in concurrent_counter:" << std::endl;
+    for (const auto& pair : concurrent_counter.most_common()) { // Get all
+        std::cout << pair.first << ": " << pair.second << std::endl;
+    }
+    std::cout << std::endl;
+
+    // Test copy constructor and assignment
+    ThreadSafeCounter<std::string> copied_counter = concurrent_counter;
+    std::cout << "Copied counter state:" << std::endl;
+    std::cout << "apple (copied): " << copied_counter.count("apple") << std::endl;
+    std::cout << "banana (copied): " << copied_counter.count("banana") << std::endl;
+
+    ThreadSafeCounter<std::string> assigned_counter;
+    assigned_counter.add("temp", 1);
+    assigned_counter = concurrent_counter;
+    std::cout << "Assigned counter state:" << std::endl;
+    std::cout << "apple (assigned): " << assigned_counter.count("apple") << std::endl;
+    std::cout << "banana (assigned): " << assigned_counter.count("banana") << std::endl;
+    std::cout << "temp (assigned): " << assigned_counter.count("temp") << " (should be 0 if original didn't have it)" << std::endl;
+
+
+    // Test arithmetic operations
+    ThreadSafeCounter<std::string> counter_a;
+    counter_a.add("x", 5);
+    counter_a.add("y", 3);
+
+    ThreadSafeCounter<std::string> counter_b;
+    counter_b.add("y", 2);
+    counter_b.add("z", 4);
+
+    std::cout << "\nArithmetic operations:" << std::endl;
+    ThreadSafeCounter<std::string> counter_sum = counter_a + counter_b;
+    std::cout << "Sum (x:5, y:3) + (y:2, z:4):" << std::endl;
+    std::cout << "x: " << counter_sum.count("x") << " (Expected 5)" << std::endl;
+    std::cout << "y: " << counter_sum.count("y") << " (Expected 5)" << std::endl;
+    std::cout << "z: " << counter_sum.count("z") << " (Expected 4)" << std::endl;
+
+    ThreadSafeCounter<std::string> counter_diff = counter_a - counter_b;
+    std::cout << "Diff (x:5, y:3) - (y:2, z:4):" << std::endl;
+    std::cout << "x: " << counter_diff.count("x") << " (Expected 5)" << std::endl;
+    std::cout << "y: " << counter_diff.count("y") << " (Expected 1)" << std::endl;
+    std::cout << "z: " << counter_diff.count("z") << " (Expected -4, then 0 due to set_count logic)" << std::endl; // Python Counter would show -4. Ours removes if <=0.
+
+    // Test intersection and union
+    ThreadSafeCounter<std::string> intersection_res = counter_a.intersection(counter_b);
+    std::cout << "Intersection (x:5, y:3) & (y:2, z:4):" << std::endl;
+    std::cout << "y: " << intersection_res.count("y") << " (Expected 2)" << std::endl;
+    std::cout << "x: " << intersection_res.count("x") << " (Expected 0)" << std::endl;
+
+    ThreadSafeCounter<std::string> union_res = counter_a.union_with(counter_b);
+    std::cout << "Union (x:5, y:3) | (y:2, z:4):" << std::endl;
+    std::cout << "x: " << union_res.count("x") << " (Expected 5)" << std::endl;
+    std::cout << "y: " << union_res.count("y") << " (Expected 3)" << std::endl;
+    std::cout << "z: " << union_res.count("z") << " (Expected 4)" << std::endl;
+
+    std::cout << "\nExample finished." << std::endl;
+
+    return 0;
+}

--- a/include/thread_safe_counter.hpp
+++ b/include/thread_safe_counter.hpp
@@ -1,0 +1,517 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+#include <algorithm>
+#include <utility>
+#include <iterator>
+#include <initializer_list>
+#include <functional>
+#include <type_traits>
+#include <mutex>
+#include <thread> // For std::this_thread::get_id in debugging, if needed
+
+// Helper to check if a type is std::pair (copied from counter.h)
+template<typename>
+struct is_std_pair_impl : std::false_type {};
+template<typename T1, typename T2>
+struct is_std_pair_impl<std::pair<T1, T2>> : std::true_type {};
+template<typename T>
+constexpr bool is_std_pair_v = is_std_pair_impl<std::remove_cv_t<T>>::value;
+
+// Helper for std::is_lt_comparable_v (C++20 has std::totally_ordered, C++17 needs a helper)
+namespace detail {
+    template <typename U, typename = void> // Changed T to U to avoid conflict
+    struct is_lt_comparable : std::false_type {};
+
+    template <typename U> // Changed T to U to avoid conflict
+    struct is_lt_comparable<U, std::void_t<decltype(std::declval<U>() < std::declval<U>())>> : std::true_type {};
+} // namespace detail
+
+template<typename U> // Changed T to U to avoid conflict
+constexpr bool is_lt_comparable_v = detail::is_lt_comparable<U>::value;
+
+
+/**
+ * @brief A thread-safe generic frequency counter, similar to Python's collections.Counter.
+ * This class uses a std::mutex to protect its internal data, allowing for safe
+ * concurrent access and modification from multiple threads.
+ *
+ * @tparam T The type of elements to count (must be hashable)
+ * @tparam Hash Hash function for T (defaults to std::hash<T>)
+ * @tparam KeyEqual Equality comparison for T (defaults to std::equal_to<T>)
+ */
+template<typename T,
+         typename Hash = std::hash<T>,
+         typename KeyEqual = std::equal_to<T>>
+class ThreadSafeCounter {
+public:
+    using key_type = T;
+    using mapped_type = int;
+    using value_type = std::pair<const T, int>;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    // Note: Direct reference/pointer to internal map elements is unsafe for concurrent access.
+    // Methods will return copies or values instead.
+
+private:
+    using container_type = std::unordered_map<T, int, Hash, KeyEqual>;
+    container_type counts_;
+    mutable std::mutex mutex_; // Mutex to protect counts_
+
+public:
+    // Constructors
+    ThreadSafeCounter() = default;
+
+    explicit ThreadSafeCounter(size_type bucket_count,
+                               const Hash& hash = Hash{},
+                               const KeyEqual& equal = KeyEqual{})
+        : counts_(bucket_count, hash, equal) {}
+
+    template <typename SfinaeDummy = void>
+    ThreadSafeCounter(std::initializer_list<T> init,
+                      typename std::enable_if_t<std::is_void_v<SfinaeDummy> && !is_std_pair_v<T>>* = nullptr) {
+        // No lock needed here as it's a constructor, object not yet shared.
+        counts_.reserve(init.size());
+        for (const auto& val : init) {
+            counts_[val]++;
+        }
+    }
+
+    template<typename InputIt>
+    ThreadSafeCounter(InputIt first, InputIt last) {
+        // No lock needed here as it's a constructor.
+        if constexpr (std::is_base_of_v<std::forward_iterator_tag,
+                      typename std::iterator_traits<InputIt>::iterator_category>) {
+            counts_.reserve(std::distance(first, last));
+        }
+        for (auto it = first; it != last; ++it) {
+            counts_[*it]++;
+        }
+    }
+
+    ThreadSafeCounter(std::initializer_list<std::pair<T, int>> init) {
+        // No lock needed here as it's a constructor.
+        counts_.reserve(init.size());
+        for (const auto& [key, count] : init) {
+            if (count > 0) {
+                counts_[key] = count;
+            }
+        }
+    }
+
+    // Copy constructor: needs to lock the source's mutex
+    ThreadSafeCounter(const ThreadSafeCounter& other) {
+        std::lock_guard<std::mutex> lock(other.mutex_);
+        counts_ = other.counts_;
+    }
+
+    // Move constructor: needs to lock the source's mutex
+    // (though technically moving from an rvalue should be safe if source is not used after move)
+    ThreadSafeCounter(ThreadSafeCounter&& other) noexcept {
+        std::lock_guard<std::mutex> lock(other.mutex_);
+        counts_ = std::move(other.counts_);
+    }
+
+    // Copy assignment: needs to lock both mutexes (or use a lock manager for deadlock safety)
+    ThreadSafeCounter& operator=(const ThreadSafeCounter& other) {
+        if (this == &other) {
+            return *this;
+        }
+        std::unique_lock<std::mutex> lock_this(mutex_, std::defer_lock);
+        std::unique_lock<std::mutex> lock_other(other.mutex_, std::defer_lock);
+        std::lock(lock_this, lock_other); // Deadlock avoidance
+        counts_ = other.counts_;
+        return *this;
+    }
+
+    // Move assignment: needs to lock both mutexes
+    ThreadSafeCounter& operator=(ThreadSafeCounter&& other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+        std::unique_lock<std::mutex> lock_this(mutex_, std::defer_lock);
+        std::unique_lock<std::mutex> lock_other(other.mutex_, std::defer_lock);
+        std::lock(lock_this, lock_other); // Deadlock avoidance
+        counts_ = std::move(other.counts_);
+        // Clear the source map after move under its lock
+        other.counts_.clear();
+        return *this;
+    }
+
+    // Core operations
+    void add(const T& value, int count_val = 1) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (count_val > 0) {
+            counts_[value] += count_val;
+        } else if (count_val < 0) {
+            _subtract_nolock(value, -count_val);
+        }
+    }
+
+    void add(T&& value, int count_val = 1) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (count_val > 0) {
+            counts_[std::move(value)] += count_val;
+        } else if (count_val < 0) {
+            // Need to be careful with move if key already exists.
+            // Find first, then decide. For simplicity, let's just use the const T& version for subtraction.
+            // This could be optimized if profiling showed it as a bottleneck.
+            _subtract_nolock(value, -count_val);
+        }
+    }
+
+    void subtract(const T& value, int count_val = 1) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        _subtract_nolock(value, count_val);
+    }
+
+    // Internal subtract without locking, assumes lock is held
+private:
+    void _subtract_nolock(const T& value, int count_val) {
+        if (count_val == 0) return; // Subtracting 0 changes nothing.
+                                    // Note: count_val here is the amount to decrement by.
+                                    // So if original call was subtract(key, -5), count_val here is -5.
+                                    // This means we are effectively adding 5.
+                                    // Python's Counter.subtract({'a': -5}) means c['a'] += 5.
+                                    // So, if subtract(key, X) is called, we modify by -X.
+                                    // Let's assume count_val in _subtract_nolock is the actual value from `other` counter or amount.
+                                    // The public subtract method: subtract(value, amount_to_subtract)
+                                    // calls _subtract_nolock(value, amount_to_subtract)
+                                    // The public add method: add(value, amount_to_add)
+                                    // if amount_to_add < 0, calls _subtract_nolock(value, -amount_to_add)
+
+        // To align with Python's Counter.subtract behavior (which can create negative counts):
+        // counts_[value] -= amount_to_subtract;
+        // This means if 'value' is not present, it's default-initialized to 0, then subtracted.
+        // So, if not present, counts_[value] becomes -amount_to_subtract.
+
+        // Let's make count_val always positive for the logic of decrementing
+        // No, the current interface of _subtract_nolock is: subtract 'count_val' (if positive) from the item.
+        // The `add` method calls it with `_subtract_nolock(value, -negative_add_amount)`, so `count_val` becomes positive.
+        // The `subtract` method calls it with `_subtract_nolock(value, positive_subtract_amount)`.
+        // So `count_val` in `_subtract_nolock` is effectively always the positive magnitude to decrement by.
+
+        // Original _subtract_nolock logic:
+        // if (count_val <= 0) return; // count_val is magnitude to subtract
+        // auto it = counts_.find(value);
+        // if (it != counts_.end()) {
+        //    it->second -= count_val;
+        //    if (it->second <= 0) {
+        //        counts_.erase(it); // THIS IS THE LINE TO CHANGE BEHAVIOR
+        //    }
+        // }
+        // This means if item not found, nothing happens. Python's subtract would make it -count_val.
+
+        // New logic for _subtract_nolock to align with Python's Counter.subtract():
+        // Here, `count_val` is the (positive) amount by which to decrement the count of `value`.
+        if (count_val <= 0) return; // Guard: only subtract positive magnitudes.
+
+        auto it = counts_.find(value);
+        if (it != counts_.end()) {
+            it->second -= count_val;
+            // No erase: allow counts to become zero or negative.
+        } else {
+            // If value was not present, subtracting count_val makes its count -count_val.
+            counts_[value] = -count_val;
+        }
+    }
+public:
+
+    [[nodiscard]] int count(const T& value) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (const auto it = counts_.find(value); it != counts_.end()) {
+            return it->second;
+        }
+        return 0;
+    }
+
+    // operator[] for reading: same as count()
+    [[nodiscard]] int operator[](const T& value) const {
+        return count(value);
+    }
+
+    // Note: A non-const operator[] that returns a reference `int&` is problematic for thread safety
+    // because the lock would be released before the caller modifies the value.
+    // Instead, provide explicit add/subtract methods, or a method that takes a functor to modify the value.
+    // For simplicity, we'll stick to add/subtract and count.
+    // If direct modification like map[key] = val is desired, it should be a separate method
+    // that takes key and value, e.g., set_count(key, val).
+
+    void set_count(const T& key, int val) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (val > 0) {
+            counts_[key] = val;
+        } else {
+            counts_.erase(key); // Remove if count is zero or negative
+        }
+    }
+
+
+    [[nodiscard]] bool contains(const T& value) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = counts_.find(value);
+        if (it != counts_.end()) {
+            return it->second > 0; // Mimic Python's Counter: only true if count > 0
+        }
+        return false; // Not found or count <= 0
+    }
+
+    size_type erase(const T& value) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return counts_.erase(value);
+    }
+
+    void clear() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        counts_.clear();
+    }
+
+    [[nodiscard]] size_type size() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        // Mimic Python's len(Counter), which counts items with positive counts.
+        size_type positive_count_size = 0;
+        for (const auto& pair : counts_) {
+            if (pair.second > 0) {
+                positive_count_size++;
+            }
+        }
+        return positive_count_size;
+    }
+
+    [[nodiscard]] bool empty() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return counts_.empty();
+    }
+
+    // Iterator support is tricky for thread-safe containers if iterators can be invalidated.
+    // A common approach is to return a copy of the data or provide a way to iterate under lock.
+    // For simplicity, `most_common` and `get_data_copy` return copies.
+    // Direct begin()/end() returning iterators to the internal map are omitted for safety.
+
+    [[nodiscard]] std::vector<std::pair<T, int>> most_common(size_type n = 0) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::vector<std::pair<T, int>> items;
+        items.reserve(counts_.size());
+
+        for (const auto& pair : counts_) {
+            items.push_back(pair); // pair is const&, so key is copied, int is copied
+        }
+
+        if (n > 0 && n < items.size()) {
+            std::partial_sort(items.begin(), items.begin() + n, items.end(),
+                            [](const auto& a, const auto& b) {
+                                if (a.second != b.second) {
+                                    return a.second > b.second;
+                                }
+                                // Consistent tie-breaking if T is comparable
+                                if constexpr (is_lt_comparable_v<T>) {
+                                   return a.first < b.first;
+                                }
+                                return false; // Or some other consistent tie-breaking
+                            });
+            items.resize(n);
+        } else {
+            std::sort(items.begin(), items.end(),
+                     [](const auto& a, const auto& b) {
+                         if (a.second != b.second) {
+                             return a.second > b.second;
+                         }
+                         if constexpr (is_lt_comparable_v<T>) {
+                            return a.first < b.first;
+                         }
+                         return false;
+                     });
+        }
+        return items;
+    }
+
+    // Arithmetic operations: these create a new counter or modify `this` counter.
+    // For `this` modification, lock is internal. For returning new, they operate on copies.
+
+    ThreadSafeCounter& operator+=(const ThreadSafeCounter& other) {
+        std::unique_lock<std::mutex> lock_this(mutex_, std::defer_lock);
+        std::unique_lock<std::mutex> lock_other(other.mutex_, std::defer_lock);
+        std::lock(lock_this, lock_other);
+
+        for (const auto& [key, count_val] : other.counts_) {
+            counts_[key] += count_val;
+        }
+        return *this;
+    }
+
+    ThreadSafeCounter& operator-=(const ThreadSafeCounter& other) {
+        std::unique_lock<std::mutex> lock_this(mutex_, std::defer_lock);
+        std::unique_lock<std::mutex> lock_other(other.mutex_, std::defer_lock);
+        std::lock(lock_this, lock_other);
+
+        for (const auto& [key, count_val] : other.counts_) {
+            _subtract_nolock(key, count_val); // Use internal subtract that assumes lock
+        }
+        return *this;
+    }
+
+    // These return by value, so they create a temporary.
+    // The temporary's operations are on copies of data from `this` and `other`.
+    [[nodiscard]] ThreadSafeCounter operator+(const ThreadSafeCounter& other) const {
+        ThreadSafeCounter result; // Default constructor
+        {
+            std::unique_lock<std::mutex> lock_this(mutex_, std::defer_lock);
+            std::unique_lock<std::mutex> lock_other(other.mutex_, std::defer_lock);
+            std::lock(lock_this, lock_other);
+            result.counts_ = this->counts_; // Copy our data
+            for (const auto& [key, count_val] : other.counts_) {
+                result.counts_[key] += count_val;
+            }
+        }
+        return result;
+    }
+
+    [[nodiscard]] ThreadSafeCounter operator-(const ThreadSafeCounter& other) const {
+        ThreadSafeCounter result;
+        {
+            std::unique_lock<std::mutex> lock_this(mutex_, std::defer_lock);
+            std::unique_lock<std::mutex> lock_other(other.mutex_, std::defer_lock);
+            std::lock(lock_this, lock_other);
+            result.counts_ = this->counts_; // Start with a copy of this counter's data
+
+            for (const auto& pair_in_other : other.counts_) {
+                const T& key = pair_in_other.first;
+                int val_in_other = pair_in_other.second;
+
+                if (val_in_other == 0) {
+                    // If key is not in result, and we subtract 0, it remains not in result.
+                    // If key is in result, and we subtract 0, its count is unchanged.
+                    // So, optimize by skipping if other's count for this key is 0.
+                    continue;
+                }
+
+                auto it = result.counts_.find(key);
+                if (it != result.counts_.end()) { // Key was in `this` (and thus in `result`)
+                    it->second -= val_in_other;
+                } else { // Key was not in `this`, so effectively 0 - val_in_other
+                    result.counts_[key] = -val_in_other;
+                }
+            }
+        }
+        return result;
+    }
+
+    // Comparison operators
+    [[nodiscard]] bool operator==(const ThreadSafeCounter& other) const {
+        std::unique_lock<std::mutex> lock_this(mutex_, std::defer_lock);
+        std::unique_lock<std::mutex> lock_other(other.mutex_, std::defer_lock);
+        std::lock(lock_this, lock_other);
+        return counts_ == other.counts_;
+    }
+
+    [[nodiscard]] bool operator!=(const ThreadSafeCounter& other) const {
+        // This will call operator==, which handles locking.
+        return !(*this == other);
+    }
+
+    // Utility methods
+    [[nodiscard]] int total() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        int sum = 0;
+        for (const auto& [key, count_val] : counts_) {
+            sum += count_val;
+        }
+        return sum;
+    }
+
+    // Method to get a copy of the internal data (thread-safe)
+    [[nodiscard]] std::unordered_map<T, int, Hash, KeyEqual> get_data_copy() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return counts_;
+    }
+
+    // For operations like reserve, rehash, load_factor, etc., that affect the underlying unordered_map
+    // These are less common for a counter but can be exposed if needed.
+    void reserve(size_type n) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        counts_.reserve(n);
+    }
+
+    [[nodiscard]] size_type bucket_count() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return counts_.bucket_count();
+    }
+
+    [[nodiscard]] float load_factor() const { // unordered_map uses float
+        std::lock_guard<std::mutex> lock(mutex_);
+        return counts_.load_factor();
+    }
+
+    [[nodiscard]] float max_load_factor() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return counts_.max_load_factor();
+    }
+
+    void max_load_factor(float ml) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        counts_.max_load_factor(ml);
+    }
+
+    void rehash(size_type n) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        counts_.rehash(n);
+    }
+
+    // Set operations similar to Python's Counter
+    // These operations return new ThreadSafeCounter objects.
+    [[nodiscard]] ThreadSafeCounter intersection(const ThreadSafeCounter& other) const {
+        ThreadSafeCounter result;
+        std::unique_lock<std::mutex> lock_this(mutex_, std::defer_lock);
+        std::unique_lock<std::mutex> lock_other(other.mutex_, std::defer_lock);
+        std::lock(lock_this, lock_other);
+
+        for (const auto& [key, count_val] : this->counts_) {
+            if (auto it = other.counts_.find(key); it != other.counts_.end()) {
+                result.counts_[key] = std::min(count_val, it->second);
+            }
+        }
+        return result;
+    }
+
+    [[nodiscard]] ThreadSafeCounter union_with(const ThreadSafeCounter& other) const { // elements() equivalent
+        ThreadSafeCounter result;
+        std::unique_lock<std::mutex> lock_this(mutex_, std::defer_lock);
+        std::unique_lock<std::mutex> lock_other(other.mutex_, std::defer_lock);
+        std::lock(lock_this, lock_other);
+
+        result.counts_ = this->counts_; // Start with a copy of this
+        for (const auto& [key, count_val] : other.counts_) {
+            auto it = result.counts_.find(key);
+            if (it != result.counts_.end()) {
+                it->second = std::max(it->second, count_val);
+            } else {
+                result.counts_[key] = count_val;
+            }
+        }
+        return result;
+    }
+};
+
+// Deduction guides (similar to Counter, adjusted for ThreadSafeCounter)
+template<typename InputIt>
+ThreadSafeCounter(InputIt, InputIt) -> ThreadSafeCounter<typename std::iterator_traits<InputIt>::value_type>;
+
+template<
+    typename T_Actual,
+    typename SfinaeDummy = void
+>
+ThreadSafeCounter(
+    std::initializer_list<T_Actual> init,
+    typename std::enable_if_t<
+        std::is_void_v<SfinaeDummy> &&
+        !is_std_pair_v<T_Actual>
+    >* = nullptr
+) -> ThreadSafeCounter<T_Actual>;
+
+template<typename T_Param> // Renamed T to T_Param to avoid conflict with class T
+ThreadSafeCounter(std::initializer_list<std::pair<T_Param, int>>) -> ThreadSafeCounter<T_Param>;
+
+// #pragma once // Redundant, but okay. // Moved is_lt_comparable_v to the top

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,3 +39,10 @@ target_link_libraries(weighted_random_list_test PRIVATE GTest::gtest GTest::gtes
 # No need to link WeightedRandomListLib explicitly due to include_directories(${CMAKE_SOURCE_DIR}/include)
 # and it being header-only. GTest linkage is sufficient.
 gtest_discover_tests(weighted_random_list_test)
+
+# Add the test executable for ThreadSafeCounter
+add_executable(thread_safe_counter_test test_thread_safe_counter.cpp)
+target_link_libraries(thread_safe_counter_test PRIVATE GTest::gtest GTest::gtest_main)
+# No need to link ThreadSafeCounterLib explicitly due to include_directories(${CMAKE_SOURCE_DIR}/include)
+# and it being header-only. GTest linkage is sufficient.
+gtest_discover_tests(thread_safe_counter_test)

--- a/tests/test_thread_safe_counter.cpp
+++ b/tests/test_thread_safe_counter.cpp
@@ -1,0 +1,469 @@
+#include "gtest/gtest.h"
+#include "thread_safe_counter.hpp"
+#include <thread>
+#include <vector>
+#include <string>
+#include <numeric> // For std::iota
+#include <set>     // For checking keys in most_common
+#include <string_view> // For string literals if needed, but string should be fine
+
+// For "s" literal
+using namespace std::string_literals;
+
+// Basic tests (single-threaded context)
+TEST(ThreadSafeCounterTest, Initialization) {
+    ThreadSafeCounter<std::string> c1;
+    ASSERT_TRUE(c1.empty());
+    ASSERT_EQ(c1.size(), 0);
+
+    ThreadSafeCounter<int> c2({1, 2, 2, 3, 3, 3});
+    ASSERT_FALSE(c2.empty());
+    ASSERT_EQ(c2.size(), 3);
+    ASSERT_EQ(c2.count(1), 1);
+    ASSERT_EQ(c2.count(2), 2);
+    ASSERT_EQ(c2.count(3), 3);
+    ASSERT_EQ(c2.count(4), 0);
+
+    ThreadSafeCounter<char> c3({{ 'a', 2 }, { 'b', 3 }});
+    ASSERT_EQ(c3.count('a'), 2);
+    ASSERT_EQ(c3.count('b'), 3);
+    ASSERT_EQ(c3.total(), 5);
+}
+
+TEST(ThreadSafeCounterTest, AddAndCount) {
+    ThreadSafeCounter<std::string> counter;
+    counter.add("apple");
+    ASSERT_EQ(counter.count("apple"), 1);
+    counter.add("apple", 2);
+    ASSERT_EQ(counter.count("apple"), 3);
+    counter.add("banana");
+    ASSERT_EQ(counter.count("banana"), 1);
+    ASSERT_EQ(counter.size(), 2);
+    ASSERT_EQ(counter.total(), 4);
+}
+
+TEST(ThreadSafeCounterTest, Subtract) {
+    ThreadSafeCounter<std::string> counter;
+    counter.add("apple", 5); // apple: 5
+    counter.subtract("apple", 2); // apple: 3
+    ASSERT_EQ(counter.count("apple"), 3);
+    ASSERT_TRUE(counter.contains("apple"));
+
+    counter.subtract("apple", 3); // apple: 3 - 3 = 0. Count becomes 0.
+    ASSERT_EQ(counter.count("apple"), 0);
+    ASSERT_FALSE(counter.contains("apple")); // contains checks for count > 0
+    ASSERT_EQ(counter.size(), 0); // Item 'apple' exists with count 0, so not counted in size().
+
+    counter.add("banana", 2); // banana: 2, apple: 0. size() should be 1 (for banana).
+    ASSERT_EQ(counter.size(), 1);
+    counter.subtract("banana", 5); // banana: 2 - 5 = -3. apple: 0. size() should be 0.
+    ASSERT_EQ(counter.count("banana"), -3);
+    ASSERT_FALSE(counter.contains("banana")); // count is not > 0
+    ASSERT_EQ(counter.size(), 0); // apple (0), banana (-3). No positive counts.
+
+    counter.add("orange", 3); // orange: 3, apple: 0, banana: -3. size() is 1 (for orange).
+    ASSERT_EQ(counter.size(), 1);
+    counter.subtract("non_existent", 2); // non_existent: -2 is created. orange: 3, apple: 0, banana: -3. size() is 1.
+    ASSERT_EQ(counter.count("orange"), 3);
+    ASSERT_TRUE(counter.contains("orange"));
+    ASSERT_EQ(counter.count("non_existent"), -2);
+    ASSERT_FALSE(counter.contains("non_existent"));
+    ASSERT_EQ(counter.size(), 1); // apple (0), banana (-3), orange (3), non_existent (-2). Only orange has positive count.
+}
+
+TEST(ThreadSafeCounterTest, SetCount) {
+    ThreadSafeCounter<std::string> counter;
+    counter.set_count("apple", 5);
+    ASSERT_EQ(counter.count("apple"), 5);
+    ASSERT_TRUE(counter.contains("apple"));
+
+    counter.set_count("apple", 0); // Setting to 0 should remove
+    ASSERT_EQ(counter.count("apple"), 0);
+    ASSERT_FALSE(counter.contains("apple"));
+
+    counter.set_count("banana", 3);
+    ASSERT_EQ(counter.count("banana"), 3);
+    counter.set_count("apple", 2); // Add apple back
+    ASSERT_EQ(counter.count("apple"), 2);
+    ASSERT_EQ(counter.size(), 2);
+}
+
+
+TEST(ThreadSafeCounterTest, ContainsEraseClear) {
+    ThreadSafeCounter<int> counter({1, 2, 2, 3});
+    ASSERT_TRUE(counter.contains(1));
+    ASSERT_TRUE(counter.contains(2));
+    ASSERT_FALSE(counter.contains(4));
+
+    ASSERT_EQ(counter.erase(2), 1); // Erase '2' (count was 2)
+    ASSERT_FALSE(counter.contains(2));
+    ASSERT_EQ(counter.count(2), 0);
+    ASSERT_EQ(counter.size(), 2); // 1 and 3 remain
+
+    ASSERT_EQ(counter.erase(5), 0); // Erase non-existent
+
+    counter.clear();
+    ASSERT_TRUE(counter.empty());
+    ASSERT_EQ(counter.size(), 0);
+    ASSERT_FALSE(counter.contains(1));
+}
+
+TEST(ThreadSafeCounterTest, MostCommon) {
+    ThreadSafeCounter<std::string> counter({
+        {"a", 1}, {"b", 5}, {"c", 2}, {"d", 5}, {"e", 3}
+    });
+    auto common = counter.most_common(3);
+    ASSERT_EQ(common.size(), 3);
+    // Order for ties (b and d both have 5) depends on internal tie-breaking (e.g. key order)
+    // Assuming 'b' < 'd' for string comparison
+    ASSERT_EQ(common[0].first, "b"); ASSERT_EQ(common[0].second, 5);
+    ASSERT_EQ(common[1].first, "d"); ASSERT_EQ(common[1].second, 5);
+    ASSERT_EQ(common[2].first, "e"); ASSERT_EQ(common[2].second, 3);
+
+    auto all_common = counter.most_common(); // Get all
+    ASSERT_EQ(all_common.size(), 5);
+    // Check if all original elements are present
+    std::set<std::string> keys;
+    for(const auto& p : all_common) keys.insert(p.first);
+    ASSERT_TRUE(keys.count("a") && keys.count("b") && keys.count("c") && keys.count("d") && keys.count("e"));
+
+
+    ThreadSafeCounter<int> empty_counter;
+    ASSERT_TRUE(empty_counter.most_common().empty());
+    ASSERT_TRUE(empty_counter.most_common(5).empty());
+}
+
+TEST(ThreadSafeCounterTest, CopyAndAssignment) {
+    ThreadSafeCounter<std::string> original;
+    original.add("apple", 3);
+    original.add("banana", 2);
+
+    ThreadSafeCounter<std::string> copy_constructed = original;
+    ASSERT_EQ(copy_constructed.count("apple"), 3);
+    ASSERT_EQ(copy_constructed.count("banana"), 2);
+    ASSERT_EQ(copy_constructed.size(), 2);
+
+    ThreadSafeCounter<std::string> copy_assigned;
+    copy_assigned.add("orange", 1); // To ensure it gets overwritten
+    copy_assigned = original;
+    ASSERT_EQ(copy_assigned.count("apple"), 3);
+    ASSERT_EQ(copy_assigned.count("banana"), 2);
+    ASSERT_EQ(copy_assigned.count("orange"), 0); // Should be gone
+    ASSERT_EQ(copy_assigned.size(), 2);
+
+    // Test self-assignment
+    copy_assigned = copy_assigned;
+    ASSERT_EQ(copy_assigned.count("apple"), 3);
+    ASSERT_EQ(copy_assigned.count("banana"), 2);
+
+    // Test move construction
+    ThreadSafeCounter<std::string> moved_from = original; // make a copy first
+    ThreadSafeCounter<std::string> moved_to(std::move(moved_from));
+    ASSERT_EQ(moved_to.count("apple"), 3);
+    ASSERT_EQ(moved_to.count("banana"), 2);
+    // Standard doesn't guarantee source state for map after move, but our impl clears it
+    ASSERT_TRUE(moved_from.empty());
+
+    // Test move assignment
+    ThreadSafeCounter<std::string> another_moved_from;
+    another_moved_from.add("grape", 10);
+    moved_to = std::move(another_moved_from);
+    ASSERT_EQ(moved_to.count("grape"), 10);
+    ASSERT_EQ(moved_to.count("apple"), 0); // Old content gone
+    ASSERT_TRUE(another_moved_from.empty());
+}
+
+
+TEST(ThreadSafeCounterTest, ArithmeticOperators) {
+    ThreadSafeCounter<char> c1({{'a', 1}, {'b', 2}});
+    ThreadSafeCounter<char> c2({{'b', 3}, {'c', 4}});
+
+    // Operator+
+    ThreadSafeCounter<char> c_sum = c1 + c2;
+    ASSERT_EQ(c_sum.count('a'), 1);
+    ASSERT_EQ(c_sum.count('b'), 5); // 2 + 3
+    ASSERT_EQ(c_sum.count('c'), 4);
+    ASSERT_EQ(c_sum.size(), 3); // a(1), b(5), c(4) are all positive
+
+    // Operator-
+    ThreadSafeCounter<char> c_diff = c1 - c2;
+    ASSERT_EQ(c_diff.count('a'), 1);
+    ASSERT_EQ(c_diff.count('b'), -1); // 2 - 3 = -1. Our impl with set_count will remove if <=0.
+                                     // The operator- itself can generate negative, then set_count cleans.
+                                     // Let's check the direct result of operator-
+    // The current implementation of operator- will store negative values if they result.
+    // And `count` will return them. `set_count` is for explicit setting.
+    // `subtract` method will remove if count <=0.
+    // The `operator-` as implemented will result in `counts_` having negative values.
+    // `count()` will return this. Items are only removed if their count becomes <=0 *during a subtract operation*
+    // or if `set_count` is used with a non-positive value.
+    // This behavior matches Python's Counter for subtraction.
+    ASSERT_EQ(c_diff.count('b'), -1);
+    ASSERT_EQ(c_diff.count('c'), -4); // 0 - 4
+    ASSERT_EQ(c_diff.size(), 1); // Only 'a' (count 1) is positive. b(-1), c(-4) are not counted by size().
+
+    // Operator+=
+    ThreadSafeCounter<char> c_sum_assign = c1;
+    c_sum_assign += c2;
+    ASSERT_EQ(c_sum_assign.count('a'), 1);
+    ASSERT_EQ(c_sum_assign.count('b'), 5);
+    ASSERT_EQ(c_sum_assign.count('c'), 4);
+
+    // Operator-=
+    ThreadSafeCounter<char> c_diff_assign = c1; // c1 is {{'a', 1}, {'b', 2}}
+    c_diff_assign -= c2; // c2 is {{'b', 3}, {'c', 4}}
+    // Expected:
+    // 'a': remains 1
+    // 'b': 2 - 3 = -1. _subtract_nolock now allows negative counts.
+    // 'c': not in c1. _subtract_nolock for ('c', 4) will create 'c' with count -4.
+    ASSERT_EQ(c_diff_assign.count('a'), 1);
+    ASSERT_EQ(c_diff_assign.count('b'), -1);
+    // contains() checks for count > 0.
+    ASSERT_FALSE(c_diff_assign.contains('b')); // count is -1
+    ASSERT_EQ(c_diff_assign.count('c'), -4);
+    ASSERT_FALSE(c_diff_assign.contains('c')); // count is -4
+    ASSERT_EQ(c_diff_assign.size(), 1); // Only 'a' (count 1) is positive. b(-1), c(-4) are not counted by size().
+}
+
+TEST(ThreadSafeCounterTest, SetOperations) {
+    ThreadSafeCounter<char> c1({{'a', 5}, {'b', 3}, {'c', 1}});
+    ThreadSafeCounter<char> c2({{'b', 2}, {'c', 4}, {'d', 2}});
+
+    // Intersection
+    ThreadSafeCounter<char> intersection = c1.intersection(c2);
+    ASSERT_EQ(intersection.count('a'), 0);
+    ASSERT_EQ(intersection.count('b'), 2); // min(3, 2)
+    ASSERT_EQ(intersection.count('c'), 1); // min(1, 4)
+    ASSERT_EQ(intersection.count('d'), 0);
+    ASSERT_EQ(intersection.size(), 2);
+
+    // Union
+    ThreadSafeCounter<char> uni = c1.union_with(c2);
+    ASSERT_EQ(uni.count('a'), 5); // max(5, 0)
+    ASSERT_EQ(uni.count('b'), 3); // max(3, 2)
+    ASSERT_EQ(uni.count('c'), 4); // max(1, 4)
+    ASSERT_EQ(uni.count('d'), 2); // max(0, 2)
+    ASSERT_EQ(uni.size(), 4);
+}
+
+// Thread safety tests
+TEST(ThreadSafeCounterTest, ConcurrentAdd) {
+    ThreadSafeCounter<int> counter;
+    std::vector<std::thread> threads;
+    int num_threads = 10;
+    int ops_per_thread = 1000;
+    int key_to_increment = 1;
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&counter, key_to_increment, ops_per_thread]() {
+            for (int j = 0; j < ops_per_thread; ++j) {
+                counter.add(key_to_increment);
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    ASSERT_EQ(counter.count(key_to_increment), num_threads * ops_per_thread);
+    ASSERT_EQ(counter.size(), 1);
+}
+
+TEST(ThreadSafeCounterTest, ConcurrentAddDifferentKeys) {
+    ThreadSafeCounter<int> counter;
+    std::vector<std::thread> threads;
+    int num_threads = 10;
+    int ops_per_thread = 100; // Reduced ops to make it faster
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&counter, i, ops_per_thread]() { // i is the key for this thread
+            for (int j = 0; j < ops_per_thread; ++j) {
+                counter.add(i); // Each thread increments its own key
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    ASSERT_EQ(counter.size(), num_threads);
+    for (int i = 0; i < num_threads; ++i) {
+        ASSERT_EQ(counter.count(i), ops_per_thread);
+    }
+}
+
+TEST(ThreadSafeCounterTest, ConcurrentAddSubtractSameKey) {
+    ThreadSafeCounter<int> counter;
+    std::vector<std::thread> threads;
+    int num_threads = 10;
+    int ops_per_thread = 1000;
+    int key = 7;
+
+    // Each pair of threads: one adds, one subtracts
+    for (int i = 0; i < num_threads / 2; ++i) {
+        threads.emplace_back([&counter, key, ops_per_thread]() {
+            for (int j = 0; j < ops_per_thread; ++j) {
+                counter.add(key, 1);
+            }
+        });
+        threads.emplace_back([&counter, key, ops_per_thread]() {
+            for (int j = 0; j < ops_per_thread; ++j) {
+                counter.subtract(key, 1);
+            }
+        });
+    }
+    // If num_threads is odd, one more adder thread
+    if (num_threads % 2 != 0) {
+        threads.emplace_back([&counter, key, ops_per_thread]() {
+            for (int j = 0; j < ops_per_thread; ++j) {
+                counter.add(key, 1);
+            }
+        });
+    }
+
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // If num_threads is even, final count should be 0.
+    // If num_threads is odd, final count should be ops_per_thread.
+    int expected_count = (num_threads % 2 != 0) ? ops_per_thread : 0;
+    ASSERT_EQ(counter.count(key), expected_count);
+    if (expected_count == 0) {
+        ASSERT_FALSE(counter.contains(key));
+        ASSERT_EQ(counter.size(), 0);
+    } else {
+        ASSERT_TRUE(counter.contains(key));
+        ASSERT_EQ(counter.size(), 1);
+    }
+}
+
+
+TEST(ThreadSafeCounterTest, ConcurrentSetCount) {
+    ThreadSafeCounter<std::string> counter;
+    std::vector<std::thread> threads;
+    int num_threads = 5; // Fewer threads, as it's more about last-write-wins
+
+    std::string key = "test_key";
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&counter, key, i]() {
+            // Each thread attempts to set the count to its own index + 1
+            // Sleep a bit to encourage interleaving, though not guaranteed
+            std::this_thread::sleep_for(std::chrono::microseconds(i * 10));
+            counter.set_count(key, i + 1);
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // The final count is not strictly deterministic due to thread scheduling.
+    // However, it must be one of the values set by the threads (1 to num_threads).
+    int final_count = counter.count(key);
+    ASSERT_GE(final_count, 1);
+    ASSERT_LE(final_count, num_threads);
+    if (final_count > 0) {
+         ASSERT_TRUE(counter.contains(key));
+    } else { // If some thread managed to set it to 0 (e.g. if values could be 0)
+         ASSERT_FALSE(counter.contains(key));
+    }
+}
+
+
+TEST(ThreadSafeCounterTest, ConcurrentMostCommon) {
+    ThreadSafeCounter<int> counter;
+    std::vector<std::thread> threads;
+    int num_add_threads = 5;
+    int items_per_thread = 10; // Each thread adds 0 to 9
+
+    for (int i = 0; i < num_add_threads; ++i) {
+        threads.emplace_back([&counter, items_per_thread, i]() {
+            for (int j = 0; j < items_per_thread; ++j) {
+                counter.add(j, i + 1); // Add varying amounts to make counts different
+            }
+        });
+    }
+
+    std::vector<std::pair<int, int>> common_items;
+    // Thread to concurrently call most_common
+    threads.emplace_back([&counter, &common_items]() {
+        // Call most_common multiple times to increase chance of catching issues
+        for(int k=0; k<10; ++k) {
+            common_items = counter.most_common(5);
+            // Basic check: size should be <= 5. Content can vary.
+            ASSERT_LE(common_items.size(), 5);
+            std::this_thread::sleep_for(std::chrono::microseconds(50));
+        }
+    });
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // After all threads join, check final state from main thread
+    auto final_common = counter.most_common(items_per_thread); // Get all distinct items
+    ASSERT_LE(final_common.size(), items_per_thread); // Should have at most 10 distinct keys (0-9)
+
+    int total_sum_of_counts = 0;
+    for(const auto& p : final_common) {
+        total_sum_of_counts += p.second;
+    }
+    ASSERT_EQ(counter.total(), total_sum_of_counts);
+    // The sum of counts for each key `j` should be sum_{i=0 to num_add_threads-1} (i+1)
+    // = items_per_thread * (sum of 1 to num_add_threads)
+    // = items_per_thread * (num_add_threads * (num_add_threads + 1) / 2)
+    int expected_total_sum = 0;
+    for (int j=0; j < items_per_thread; ++j) { // for each key 0-9
+        int expected_count_for_key_j = 0;
+        for (int i=0; i < num_add_threads; ++i) { // each thread i adds (i+1) to key j
+            expected_count_for_key_j += (i+1);
+        }
+        ASSERT_EQ(counter.count(j), expected_count_for_key_j);
+        expected_total_sum += expected_count_for_key_j;
+    }
+    ASSERT_EQ(counter.total(), expected_total_sum);
+
+    // The `common_items` from the concurrent thread is harder to verify precisely,
+    // but we ensured its size was okay during its execution.
+}
+
+// Test for deduction guides (compile-time check)
+TEST(ThreadSafeCounterTest, DeductionGuides) {
+    std::vector<int> v = {1, 2, 2, 3};
+    ThreadSafeCounter c_from_iter(v.begin(), v.end()); // Should deduce ThreadSafeCounter<int>
+    ASSERT_EQ(c_from_iter.count(2), 2);
+
+    ThreadSafeCounter c_from_init_list = {1, 2, 2, 3}; // Should deduce ThreadSafeCounter<int>
+    ASSERT_EQ(c_from_init_list.count(2), 2);
+
+    // Explicitly create pairs for the initializer list
+    ThreadSafeCounter c_from_pair_list = {
+        std::pair<std::string, int>(std::string("a"), 1),
+        std::pair<std::string, int>(std::string("b"), 2)
+    }; // Should deduce ThreadSafeCounter<std::string>
+    ASSERT_EQ(c_from_pair_list.count("b"), 2);
+
+    // Simpler form that should also work with CTAD for pairs if T is specified
+    ThreadSafeCounter<std::string> c_from_pair_list_simpler = {{"a", 1}, {"b", 2}};
+    ASSERT_EQ(c_from_pair_list_simpler.count("b"), 2);
+
+    // Test auto-deduction with simpler pair form
+    ThreadSafeCounter c_from_pair_list_auto = {std::pair("a"s, 1), std::pair("b"s, 2)};
+    ASSERT_EQ(c_from_pair_list_auto.count("b"s), 2);
+
+
+    // Suppress unused variable warnings for the above
+    (void)c_from_iter;
+    (void)c_from_init_list;
+    (void)c_from_pair_list;
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This commit introduces a new ThreadSafeCounter class, designed to function similarly to Python's collections.Counter but with thread safety for concurrent operations.

Key features and changes:
- Implemented ThreadSafeCounter in `include/thread_safe_counter.hpp`.
- Added usage examples in `examples/thread_safe_counter_example.cpp`.
- Included comprehensive unit tests in `tests/test_thread_safe_counter.cpp`.
- Updated CMakeLists.txt files to integrate the new component, example, and tests.
- Created documentation in `docs/README_thread_safe_counter.md`.

The implementation ensures that methods like add, subtract, count, contains, and size are thread-safe using std::mutex. Behavior regarding zero and negative counts has been aligned with Python's Counter where appropriate:
  - `subtract` and `operator-=` can result in zero or negative counts for items.
  - `operator-` (binary) also allows zero or negative counts.
  - `contains` returns true only if an item's count is strictly positive.
  - `size` reports the number of items with strictly positive counts.
  - `set_count` erases items if their count is set to zero or less.