### PR TITLE
Add ThreadSafeCache with LRU, LFU, FIFO policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,10 @@ target_include_directories(WeightedRandomListLib INTERFACE ${CMAKE_CURRENT_SOURC
 add_library(ThreadSafeCounterLib INTERFACE)
 target_include_directories(ThreadSafeCounterLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define ThreadSafeCacheLib as an interface library (header-only)
+add_library(ThreadSafeCacheLib INTERFACE)
+target_include_directories(ThreadSafeCacheLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -266,6 +270,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         MultisetCounterLib   # Added for multiset_counter_example
         WeightedRandomListLib # Added for weighted_random_list_example
         ThreadSafeCounterLib # Added for thread_safe_counter_example
+        ThreadSafeCacheLib   # Added for thread_safe_cache_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/docs/README_thread_safe_cache.md
+++ b/docs/README_thread_safe_cache.md
@@ -1,0 +1,151 @@
+# ThreadSafeCache
+
+## Overview
+
+`ThreadSafeCache` is a C++ template class providing a generic thread-safe caching mechanism. It supports key-value storage with a configurable maximum capacity and three common eviction policies: Least Recently Used (LRU), Least Frequently Used (LFU), and First-In, First-Out (FIFO).
+
+This cache is designed for scenarios where multiple threads need to access shared cached data concurrently, ensuring data integrity and preventing race conditions through internal mutex locking.
+
+## Features
+
+-   **Thread Safety**: All public methods are internally synchronized using `std::mutex`, making it safe for concurrent access.
+-   **Generic**: Template-based design allows for caching of any key and value types.
+-   **Configurable Capacity**: The maximum number of items the cache can hold is defined at construction.
+-   **Eviction Policies**: Supports LRU, LFU, and FIFO eviction strategies.
+    -   **LRU (Least Recently Used)**: When the cache is full, the item that hasn't been accessed for the longest time is evicted.
+    -   **LFU (Least Frequently Used)**: When the cache is full, the item that has been accessed the fewest times is evicted. Ties are broken by evicting the least recently used item among those with the same minimum frequency.
+    -   **FIFO (First-In, First-Out)**: When the cache is full, the item that was added first (oldest) is evicted.
+-   **Header-Only**: Implemented as a header-only library for easy integration (just include `thread_safe_cache.hpp`).
+
+## API
+
+The `ThreadSafeCache<Key, Value>` class provides the following public methods:
+
+-   `ThreadSafeCache(size_t capacity, EvictionPolicy policy = EvictionPolicy::LRU)`
+    -   Constructor.
+    -   `capacity`: The maximum number of items the cache can hold. Must be greater than 0.
+    -   `policy`: The eviction policy to use. Can be `EvictionPolicy::LRU`, `EvictionPolicy::LFU`, or `EvictionPolicy::FIFO`. Defaults to LRU.
+    -   Throws `std::invalid_argument` if capacity is 0.
+
+-   `void put(const Key& key, const Value& value)`
+    -   Inserts or updates a key-value pair in the cache.
+    -   If the key already exists, its value is updated, and its status is updated according to the eviction policy (e.g., marked as recently used for LRU, frequency incremented for LFU).
+    -   If the key does not exist and the cache is full, an item is evicted based on the configured policy before the new item is inserted.
+
+-   `std::optional<Value> get(const Key& key)`
+    -   Retrieves the value associated with the given key.
+    -   If the key is found, its status is updated according to the eviction policy, and an `std::optional` containing the value is returned.
+    -   If the key is not found, `std::nullopt` is returned.
+
+-   `bool erase(const Key& key)`
+    -   Removes the key-value pair associated with the given key from the cache.
+    -   Returns `true` if the key was found and removed, `false` otherwise.
+
+-   `void clear()`
+    -   Removes all items from the cache.
+
+-   `size_t size() const`
+    -   Returns the current number of items in the cache.
+
+-   `bool empty() const`
+    -   Returns `true` if the cache contains no items, `false` otherwise.
+
+## Eviction Policies Enum
+
+The `EvictionPolicy` enum is defined as:
+
+```cpp
+namespace cpp_collections {
+    enum class EvictionPolicy {
+        LRU,
+        LFU,
+        FIFO
+    };
+}
+```
+
+## Usage Example
+
+```cpp
+#include "thread_safe_cache.hpp"
+#include <iostream>
+#include <string>
+#include <optional>
+
+int main() {
+    // Create an LRU cache with a capacity of 2
+    cpp_collections::ThreadSafeCache<int, std::string> cache(2, cpp_collections::EvictionPolicy::LRU);
+
+    cache.put(1, "apple");
+    cache.put(2, "banana");
+    std::cout << "Cache size: " << cache.size() << std::endl; // Output: 2
+
+    if (auto val = cache.get(1)) {
+        std::cout << "Got 1: " << val.value() << std::endl; // Output: apple
+    }
+
+    cache.put(3, "cherry"); // Cache is full, (2, "banana") should be evicted as it's LRU
+                            // after accessing 1.
+    std::cout << "Cache size after adding 3: " << cache.size() << std::endl; // Output: 2
+
+    if (cache.get(2)) {
+        std::cout << "Got 2: " << cache.get(2).value() << std::endl;
+    } else {
+        std::cout << "Key 2 not found (evicted)." << std::endl; // Output: Key 2 not found
+    }
+
+    if (auto val = cache.get(3)) {
+        std::cout << "Got 3: " << val.value() << std::endl; // Output: cherry
+    }
+
+    // --- LFU Example ---
+    cpp_collections::ThreadSafeCache<int, std::string> lfu_cache(2, cpp_collections::EvictionPolicy::LFU);
+    lfu_cache.put(10, "item10"); // Freq(10)=1
+    lfu_cache.put(20, "item20"); // Freq(20)=1
+
+    lfu_cache.get(10); // Freq(10)=2
+    lfu_cache.get(10); // Freq(10)=3
+    lfu_cache.get(20); // Freq(20)=2
+    // Freqs: 10:3, 20:2
+
+    lfu_cache.put(30, "item30"); // Evicts item20 (LFU)
+    if (!lfu_cache.get(20)) {
+        std::cout << "Item 20 evicted by LFU policy." << std::endl;
+    }
+     if (auto val = lfu_cache.get(10)) {
+        std::cout << "LFU Cache still has 10: " << val.value() << std::endl;
+    }
+
+
+    // --- FIFO Example ---
+    cpp_collections::ThreadSafeCache<int, std::string> fifo_cache(2, cpp_collections::EvictionPolicy::FIFO);
+    fifo_cache.put(100, "first_in");
+    fifo_cache.put(200, "second_in");
+
+    fifo_cache.get(100); // Accessing does not change FIFO order
+
+    fifo_cache.put(300, "third_in"); // Evicts "first_in" (oldest)
+    if (!fifo_cache.get(100)) {
+        std::cout << "Item 100 evicted by FIFO policy." << std::endl;
+    }
+    if (auto val = fifo_cache.get(200)) {
+        std::cout << "FIFO Cache still has 200: " << val.value() << std::endl;
+    }
+
+    return 0;
+}
+```
+
+## Thread Safety Details
+
+The `ThreadSafeCache` uses a single `std::mutex` to synchronize access to all its internal data structures. Every public method acquires this mutex upon entry (typically using `std::lock_guard`) and releases it upon exit. This ensures that operations are atomic and the cache's internal state remains consistent even when accessed by multiple threads simultaneously.
+
+While this approach guarantees thread safety, it also means that operations are serialized. For highly contented caches, this could become a bottleneck. More advanced implementations might use finer-grained locking or lock-free techniques for higher concurrency, but these come with significantly increased complexity. For many common use cases, the current `std::mutex`-based approach provides a good balance of safety and performance.
+
+## Implementation Notes
+
+-   **LRU Policy**: Implemented using a `std::list` to keep track of the access order (MRU at the front, LRU at the back) and an `std::unordered_map` to store iterators to the list nodes for O(1) updates and removals.
+-   **LFU Policy**: Implemented using a list of frequency nodes (`std::list<LfuFrequencyNode>`), where each node contains its frequency and a list of keys (`std::list<Key>`) that currently have that frequency. The list of keys within a frequency node is maintained in LRU order to break ties when multiple keys have the same lowest frequency. An `std::unordered_map` stores iterators to quickly locate a key's frequency node and its position within that node's key list.
+-   **FIFO Policy**: Implemented using a `std::queue` to maintain the insertion order of keys.
+
+The main data storage is an `std::unordered_map<Key, Value>`.Tool output for `create_file_with_block`:

--- a/examples/thread_safe_cache_example.cpp
+++ b/examples/thread_safe_cache_example.cpp
@@ -1,0 +1,150 @@
+#include "thread_safe_cache.hpp"
+#include <iostream>
+#include <string>
+#include <vector>
+#include <thread>
+#include <cassert>
+
+// Helper function to print cache contents (for demonstration)
+// Not thread-safe if called concurrently with modifications without external locking.
+// For this example, it's called in controlled sections.
+template <typename K, typename V>
+void print_cache_status(const cpp_collections::ThreadSafeCache<K, V>& cache, const std::string& name) {
+    // This is a conceptual print. Direct iteration isn't provided by the cache interface
+    // for simplicity and to avoid exposing internal state management.
+    // We'll rely on get() and known key sequences for demonstration.
+    std::cout << "--- Cache Status: " << name << " ---" << std::endl;
+    std::cout << "Size: " << cache.size() << std::endl;
+    // To show actual content, one would typically try to get known keys.
+    // Example: cache.get(known_key_1), cache.get(known_key_2), etc.
+    // For this example, we'll infer state from operations.
+}
+
+void example_lru_cache() {
+    std::cout << "\n--- LRU Cache Example ---" << std::endl;
+    cpp_collections::ThreadSafeCache<int, std::string> lru_cache(3, cpp_collections::EvictionPolicy::LRU);
+
+    lru_cache.put(1, "apple");
+    lru_cache.put(2, "banana");
+    lru_cache.put(3, "cherry");
+    print_cache_status(lru_cache, "LRU Initial"); // Expected: 1,2,3
+
+    lru_cache.get(1); // Access 1, making it most recently used
+    print_cache_status(lru_cache, "LRU Accessed 1"); // Order: 1 (MRU), 3, 2 (LRU)
+
+    lru_cache.put(4, "date"); // Cache is full (1,3,2), 2 should be evicted
+    print_cache_status(lru_cache, "LRU Added 4, Evicted 2"); // Expected: 4,1,3
+
+    assert(lru_cache.get(2) == std::nullopt); // 2 should be evicted
+    assert(lru_cache.get(1).value_or("") == "apple");
+    assert(lru_cache.get(3).value_or("") == "cherry");
+    assert(lru_cache.get(4).value_or("") == "date");
+    std::cout << "LRU assertions passed." << std::endl;
+}
+
+void example_fifo_cache() {
+    std::cout << "\n--- FIFO Cache Example ---" << std::endl;
+    cpp_collections::ThreadSafeCache<int, std::string> fifo_cache(3, cpp_collections::EvictionPolicy::FIFO);
+
+    fifo_cache.put(1, "one");
+    fifo_cache.put(2, "two");
+    fifo_cache.put(3, "three");
+    print_cache_status(fifo_cache, "FIFO Initial"); // Expected: 1,2,3 (1 is oldest)
+
+    fifo_cache.get(1); // Accessing 1 does not change its FIFO order
+    print_cache_status(fifo_cache, "FIFO Accessed 1");
+
+    fifo_cache.put(4, "four"); // Cache is full, 1 (oldest) should be evicted
+    print_cache_status(fifo_cache, "FIFO Added 4, Evicted 1"); // Expected: 2,3,4
+
+    assert(fifo_cache.get(1) == std::nullopt); // 1 should be evicted
+    assert(fifo_cache.get(2).value_or("") == "two");
+    assert(fifo_cache.get(3).value_or("") == "three");
+    assert(fifo_cache.get(4).value_or("") == "four");
+    std::cout << "FIFO assertions passed." << std::endl;
+}
+
+void example_lfu_cache() {
+    std::cout << "\n--- LFU Cache Example ---" << std::endl;
+    cpp_collections::ThreadSafeCache<int, std::string> lfu_cache(3, cpp_collections::EvictionPolicy::LFU);
+
+    lfu_cache.put(1, "cat");    // Freq(1)=1
+    lfu_cache.put(2, "dog");    // Freq(2)=1
+    lfu_cache.put(3, "emu");    // Freq(3)=1
+    print_cache_status(lfu_cache, "LFU Initial");
+
+    lfu_cache.get(1);           // Freq(1)=2
+    lfu_cache.get(1);           // Freq(1)=3
+    lfu_cache.get(2);           // Freq(2)=2
+    print_cache_status(lfu_cache, "LFU Accessed 1 (x2), 2 (x1)");
+    // Freqs: 1:3, 2:2, 3:1
+
+    lfu_cache.put(4, "fox");    // Cache full. Evict LFU. 3 (freq 1) is LFU.
+                                // If multiple LFU, evict LRU among them. Here, 3 is unique LFU.
+    print_cache_status(lfu_cache, "LFU Added 4, Evicted 3");
+    // Cache: 1 (freq 3), 2 (freq 2), 4 (freq 1)
+
+    assert(lfu_cache.get(3) == std::nullopt); // 3 should be evicted
+    assert(lfu_cache.get(1).value_or("") == "cat");
+    assert(lfu_cache.get(2).value_or("") == "dog");
+    assert(lfu_cache.get(4).value_or("") == "fox");
+
+    lfu_cache.get(4); // Freq(4)=2. Now 2 and 4 have freq 2. 1 has freq 3.
+    // Cache: 1 (freq 3, MRU), 4 (freq 2, MRU within freq 2), 2 (freq 2, LRU within freq 2)
+
+    lfu_cache.put(5, "gnu"); // Evict. Both 2 and 4 have freq 2.
+                             // 2 was put before 4, and 4 was accessed more recently than 2's last access.
+                             // LFU evicts based on lowest frequency. Tie-breaking is LRU within that frequency.
+                             // Key 2 was accessed (put) then its frequency became 2.
+                             // Key 4 was put then its frequency became 1, then accessed, its frequency became 2.
+                             // Key 2 is LRU among those with frequency 2.
+    print_cache_status(lfu_cache, "LFU Added 5, Evicted 2");
+    // Cache: 1 (freq 3), 4 (freq 2), 5 (freq 1)
+
+    assert(lfu_cache.get(2) == std::nullopt); // 2 should be evicted
+    assert(lfu_cache.get(1).value_or("") == "cat");
+    assert(lfu_cache.get(4).value_or("") == "fox");
+    assert(lfu_cache.get(5).value_or("") == "gnu");
+    std::cout << "LFU assertions passed." << std::endl;
+}
+
+void thread_safety_example() {
+    std::cout << "\n--- Thread Safety Example (LRU) ---" << std::endl;
+    cpp_collections::ThreadSafeCache<int, int> cache(100, cpp_collections::EvictionPolicy::LRU);
+    std::vector<std::thread> threads;
+    int num_threads = 10;
+    int operations_per_thread = 1000;
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&cache, i, operations_per_thread, num_threads]() {
+            for (int j = 0; j < operations_per_thread; ++j) {
+                int key = (i * operations_per_thread + j) % (cache.size() + 50); // Vary keys
+                cache.put(key, i * 10000 + j);
+                if (j % 10 == 0) {
+                    cache.get(key - 10); // Mix in some gets
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    std::cout << "Thread safety example completed. Final cache size: " << cache.size() << std::endl;
+    // Verifying exact state is complex without more introspection or specific test patterns.
+    // The main goal here is to run concurrently without crashing or deadlocking.
+    assert(cache.size() <= 100); // Should not exceed capacity
+    std::cout << "Thread safety basic check passed (no crash, respects capacity)." << std::endl;
+}
+
+
+int main() {
+    example_lru_cache();
+    example_fifo_cache();
+    example_lfu_cache();
+    thread_safety_example();
+
+    std::cout << "\nAll examples completed." << std::endl;
+    return 0;
+}

--- a/include/thread_safe_cache.hpp
+++ b/include/thread_safe_cache.hpp
@@ -1,0 +1,442 @@
+#ifndef THREAD_SAFE_CACHE_HPP
+#define THREAD_SAFE_CACHE_HPP
+
+#include <iostream> // TODO: remove this include, only for basic printing during development
+#include <list>
+#include <mutex>
+#include <optional>
+#include <queue>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace cpp_collections {
+
+enum class EvictionPolicy {
+    LRU,
+    LFU,
+    FIFO
+};
+
+template <typename Key, typename Value>
+class ThreadSafeCache {
+public:
+    ThreadSafeCache(size_t capacity, EvictionPolicy policy = EvictionPolicy::LRU);
+
+    void put(const Key& key, const Value& value);
+    std::optional<Value> get(const Key& key);
+    bool erase(const Key& key);
+    void clear();
+    size_t size() const;
+    bool empty() const;
+
+private:
+    // General members
+    size_t capacity_;
+    EvictionPolicy policy_;
+    mutable std::mutex mutex_;
+
+    // Data storage: map of keys to values
+    std::unordered_map<Key, Value> cache_data_;
+
+    // --- LRU specific members ---
+    // List of keys, most recently used at front, least recently used at back
+    std::list<Key> lru_order_;
+    // Map of keys to their iterators in lru_order_ for O(1) access
+    std::unordered_map<Key, typename std::list<Key>::iterator> lru_key_to_iter_;
+
+    // --- FIFO specific members ---
+    // Queue of keys, oldest at front, newest at back
+    std::queue<Key> fifo_order_;
+
+    // --- LFU specific members ---
+    // Structure to hold frequency and a list of keys with that frequency
+    struct LfuFrequencyNode {
+        size_t frequency;
+        std::list<Key> keys; // Keys with this frequency, in LRU order within this frequency
+
+        // Iterators for the main frequency list to allow O(1) removal/update of frequency nodes
+        typename std::list<LfuFrequencyNode>::iterator self_iter_in_freq_list;
+    };
+
+    // List of frequency nodes, sorted by frequency (ascending).
+    // Enables finding the LFU node quickly.
+    std::list<LfuFrequencyNode> lfu_frequency_list_;
+
+    // Map from key to its current frequency node's iterator in lfu_frequency_list_
+    // and its iterator within that node's key list.
+    // This allows O(1) update of a key's frequency.
+    std::unordered_map<Key,
+        std::pair<
+            typename std::list<LfuFrequencyNode>::iterator, // Iterator to the LfuFrequencyNode in lfu_frequency_list_
+            typename std::list<Key>::iterator               // Iterator to the key in LfuFrequencyNode::keys
+        >
+    > lfu_key_to_node_and_iter_;
+
+
+    // Private helper methods
+    void evict();
+
+    // LRU helpers
+    void record_access_lru(const Key& key);
+    void evict_lru();
+
+    // FIFO helpers
+    void record_insertion_fifo(const Key& key);
+    void evict_fifo();
+
+    // LFU helpers
+    void record_access_lfu(const Key& key);
+    void record_insertion_lfu(const Key& key); // For new items
+    void evict_lfu();
+    void increment_frequency_lfu(const Key& key);
+
+};
+
+// Constructor
+template <typename Key, typename Value>
+ThreadSafeCache<Key, Value>::ThreadSafeCache(size_t capacity, EvictionPolicy policy)
+    : capacity_(capacity), policy_(policy) {
+    if (capacity == 0) {
+        throw std::invalid_argument("Cache capacity must be greater than 0.");
+    }
+}
+
+// Public methods
+template <typename Key, typename Value>
+void ThreadSafeCache<Key, Value>::put(const Key& key, const Value& value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // If key already exists, update its value and handle policy-specific access recording
+    auto it = cache_data_.find(key);
+    if (it != cache_data_.end()) {
+        it->second = value;
+        if (policy_ == EvictionPolicy::LRU) {
+            record_access_lru(key);
+        } else if (policy_ == EvictionPolicy::LFU) {
+            // LFU: Accessing an existing item increments its frequency
+            increment_frequency_lfu(key);
+        }
+        // FIFO: No special action on updating an existing item's value regarding its position
+        return;
+    }
+
+    // Key does not exist, check for capacity
+    if (cache_data_.size() >= capacity_) {
+        evict(); // Evict an item based on policy
+    }
+
+    // Insert the new item
+    cache_data_[key] = value;
+    if (policy_ == EvictionPolicy::LRU) {
+        lru_order_.push_front(key);
+        lru_key_to_iter_[key] = lru_order_.begin();
+    } else if (policy_ == EvictionPolicy::FIFO) {
+        record_insertion_fifo(key);
+    } else if (policy_ == EvictionPolicy::LFU) {
+        record_insertion_lfu(key);
+    }
+}
+
+template <typename Key, typename Value>
+std::optional<Value> ThreadSafeCache<Key, Value>::get(const Key& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = cache_data_.find(key);
+    if (it == cache_data_.end()) {
+        return std::nullopt; // Key not found
+    }
+
+    // Key found, record access based on policy
+    if (policy_ == EvictionPolicy::LRU) {
+        record_access_lru(key);
+    } else if (policy_ == EvictionPolicy::LFU) {
+        increment_frequency_lfu(key);
+    }
+    // FIFO: No special action on get
+
+    return it->second;
+}
+
+template <typename Key, typename Value>
+bool ThreadSafeCache<Key, Value>::erase(const Key& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = cache_data_.find(key);
+    if (it == cache_data_.end()) {
+        return false; // Key not found
+    }
+
+    // Key found, remove it from main data and policy-specific structures
+    cache_data_.erase(it);
+
+    if (policy_ == EvictionPolicy::LRU) {
+        auto lru_it = lru_key_to_iter_.find(key);
+        if (lru_it != lru_key_to_iter_.end()) {
+            lru_order_.erase(lru_it->second);
+            lru_key_to_iter_.erase(lru_it);
+        }
+    } else if (policy_ == EvictionPolicy::FIFO) {
+        // FIFO: Removal is tricky as std::queue doesn't support arbitrary element removal.
+        // For simplicity in this version, we might need a temporary queue or accept that
+        // 'erase' might be slow for FIFO or that items are only removed by eviction.
+        // A common approach is to mark as "erased" and fully remove on get/evict.
+        // For now, we'll rebuild the queue if an item is erased. This is not efficient.
+        // TODO: Optimize FIFO erase if it's a critical path.
+        std::queue<Key> temp_q;
+        while(!fifo_order_.empty()){
+            Key current_key = fifo_order_.front();
+            fifo_order_.pop();
+            if(current_key != key) {
+                temp_q.push(current_key);
+            }
+        }
+        fifo_order_ = temp_q;
+
+    } else if (policy_ == EvictionPolicy::LFU) {
+        auto lfu_map_iter = lfu_key_to_node_and_iter_.find(key);
+        if (lfu_map_iter != lfu_key_to_node_and_iter_.end()) {
+            auto& freq_node_iter = lfu_map_iter->second.first;
+            auto& key_in_node_iter = lfu_map_iter->second.second;
+
+            freq_node_iter->keys.erase(key_in_node_iter);
+            if (freq_node_iter->keys.empty()) {
+                lfu_frequency_list_.erase(freq_node_iter);
+            }
+            lfu_key_to_node_and_iter_.erase(lfu_map_iter);
+        }
+    }
+    return true;
+}
+
+template <typename Key, typename Value>
+void ThreadSafeCache<Key, Value>::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    cache_data_.clear();
+
+    if (policy_ == EvictionPolicy::LRU) {
+        lru_order_.clear();
+        lru_key_to_iter_.clear();
+    } else if (policy_ == EvictionPolicy::FIFO) {
+        std::queue<Key> empty_q;
+        fifo_order_.swap(empty_q); // Efficient way to clear a queue
+    } else if (policy_ == EvictionPolicy::LFU) {
+        lfu_frequency_list_.clear();
+        lfu_key_to_node_and_iter_.clear();
+    }
+}
+
+template <typename Key, typename Value>
+size_t ThreadSafeCache<Key, Value>::size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return cache_data_.size();
+}
+
+template <typename Key, typename Value>
+bool ThreadSafeCache<Key, Value>::empty() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return cache_data_.empty();
+}
+
+// Private helper methods
+template <typename Key, typename Value>
+void ThreadSafeCache<Key, Value>::evict() {
+    // Assumes lock is already held by the caller (e.g., put)
+    if (cache_data_.empty() || cache_data_.size() < capacity_) { // Should not happen if called from put correctly
+        return;
+    }
+
+    if (policy_ == EvictionPolicy::LRU) {
+        evict_lru();
+    } else if (policy_ == EvictionPolicy::FIFO) {
+        evict_fifo();
+    } else if (policy_ == EvictionPolicy::LFU) {
+        evict_lfu();
+    }
+}
+
+// --- LRU helpers ---
+template <typename Key, typename Value>
+void ThreadSafeCache<Key, Value>::record_access_lru(const Key& key) {
+    // Assumes lock is held and key exists in cache_data_ and lru_key_to_iter_
+    auto it = lru_key_to_iter_.find(key);
+    if (it != lru_key_to_iter_.end()) {
+        // Move the accessed key to the front of the list
+        lru_order_.splice(lru_order_.begin(), lru_order_, it->second);
+        // Update the iterator in the map (it->second is now lru_order_.begin())
+        // it->second = lru_order_.begin(); // No, splice invalidates the old iterator value in map if it's not already begin()
+                                         // The iterator itself (the one stored in the list node) remains valid.
+                                         // The map's value (it->second) needs to point to the new position.
+        lru_key_to_iter_[key] = lru_order_.begin(); // Correctly update the map's iterator value
+    }
+}
+
+template <typename Key, typename Value>
+void ThreadSafeCache<Key, Value>::evict_lru() {
+    // Assumes lock is held
+    if (lru_order_.empty()) {
+        return; // Nothing to evict
+    }
+
+    // The least recently used item is at the back of the list
+    Key key_to_evict = lru_order_.back();
+    lru_order_.pop_back();
+    lru_key_to_iter_.erase(key_to_evict);
+    cache_data_.erase(key_to_evict);
+}
+
+// --- FIFO helpers ---
+template <typename Key, typename Value>
+void ThreadSafeCache<Key, Value>::record_insertion_fifo(const Key& key) {
+    // Assumes lock is held
+    fifo_order_.push(key);
+}
+
+template <typename Key, typename Value>
+void ThreadSafeCache<Key, Value>::evict_fifo() {
+    // Assumes lock is held
+    if (fifo_order_.empty()) {
+        return; // Nothing to evict
+    }
+    Key key_to_evict = fifo_order_.front();
+    fifo_order_.pop();
+    cache_data_.erase(key_to_evict);
+}
+
+// --- LFU helpers ---
+template <typename Key, typename Value>
+void ThreadSafeCache<Key, Value>::record_insertion_lfu(const Key& key) {
+    // Assumes lock is held, key is new to the cache
+    // New items start with frequency 1.
+    // Find or create the frequency node for frequency 1.
+    typename std::list<LfuFrequencyNode>::iterator freq_1_node_iter;
+    if (lfu_frequency_list_.empty() || lfu_frequency_list_.front().frequency != 1) {
+        // No frequency 1 node exists, or the first node has a higher frequency.
+        // Insert a new node for frequency 1 at the beginning.
+        LfuFrequencyNode new_node;
+        new_node.frequency = 1;
+        lfu_frequency_list_.push_front(new_node);
+        freq_1_node_iter = lfu_frequency_list_.begin();
+        freq_1_node_iter->self_iter_in_freq_list = freq_1_node_iter; // Store self-iterator
+    } else {
+        // Frequency 1 node already exists at the front.
+        freq_1_node_iter = lfu_frequency_list_.begin();
+    }
+
+    // Add the key to this frequency node's list (at the front for LRU within frequency)
+    freq_1_node_iter->keys.push_front(key);
+    typename std::list<Key>::iterator key_iter_in_node = freq_1_node_iter->keys.begin();
+
+    // Store mapping from key to its frequency node and position within that node's list
+    lfu_key_to_node_and_iter_[key] = {freq_1_node_iter, key_iter_in_node};
+}
+
+
+template <typename Key, typename Value>
+void ThreadSafeCache<Key, Value>::increment_frequency_lfu(const Key& key) {
+    // Assumes lock is held and key exists in cache_data_ and lfu_key_to_node_and_iter_
+    auto it_map = lfu_key_to_node_and_iter_.find(key);
+    if (it_map == lfu_key_to_node_and_iter_.end()) {
+        // Should not happen if called correctly (e.g., after a successful find in cache_data_)
+        return;
+    }
+
+    auto& current_freq_node_iter = it_map->second.first;
+    auto& key_iter_in_current_node = it_map->second.second;
+    size_t old_frequency = current_freq_node_iter->frequency;
+    size_t new_frequency = old_frequency + 1;
+
+    // 1. Remove key from its current frequency node's list
+    current_freq_node_iter->keys.erase(key_iter_in_current_node);
+
+    // 2. Find or create the new frequency node
+    typename std::list<LfuFrequencyNode>::iterator next_freq_node_iter = std::next(current_freq_node_iter);
+
+    // Check if the current frequency node is now empty and needs removal
+    bool current_node_was_removed = false;
+    if (current_freq_node_iter->keys.empty()) {
+        lfu_frequency_list_.erase(current_freq_node_iter);
+        current_node_was_removed = true;
+        // `next_freq_node_iter` is still valid if current_freq_node_iter was not the last element.
+        // If current_freq_node_iter was last, next_freq_node_iter would be end().
+        // If current_freq_node_iter was erased, next_freq_node_iter is the element that followed it, or end().
+        // The `next_freq_node_iter` obtained before erase is what we need to inspect or insert before.
+    }
+
+    typename std::list<LfuFrequencyNode>::iterator target_freq_node_iter;
+
+    // Search for the new frequency node starting from `next_freq_node_iter`
+    // (or from beginning if old node was removed and was the first one)
+    // `next_freq_node_iter` points to the node that *was* after the current_freq_node_iter,
+    // or lfu_frequency_list_.end()
+
+    // If current_node_was_removed is true, current_freq_node_iter is invalid.
+    // next_freq_node_iter is the correct starting point for search/insertion.
+    // If current_node_was_removed is false, current_freq_node_iter is valid,
+    // and next_freq_node_iter = std::next(current_freq_node_iter) is the correct starting point.
+
+    if (next_freq_node_iter == lfu_frequency_list_.end() || next_freq_node_iter->frequency != new_frequency) {
+        // New frequency node does not exist immediately after, or we are at the end.
+        // Insert a new node *before* next_freq_node_iter.
+        LfuFrequencyNode new_node_val;
+        new_node_val.frequency = new_frequency;
+        // The insertion point is `next_freq_node_iter`. If current_node_was_removed was false,
+        // current_freq_node_iter is still valid and next_freq_node_iter is std::next(current_freq_node_iter).
+        // We want to insert after current_freq_node_iter (if it still exists) or at the correct sorted position.
+        // The list is sorted by frequency. We need to insert the new_frequency node in its sorted place.
+        // `next_freq_node_iter` is the iterator to the first element with frequency > old_frequency.
+        // So, inserting before `next_freq_node_iter` is correct.
+
+        target_freq_node_iter = lfu_frequency_list_.insert(next_freq_node_iter, new_node_val);
+        target_freq_node_iter->self_iter_in_freq_list = target_freq_node_iter;
+    } else {
+        // Node for new_frequency already exists at next_freq_node_iter
+        target_freq_node_iter = next_freq_node_iter;
+    }
+
+    // 3. Add key to the new/found frequency node's list (at the front for LRU within frequency)
+    target_freq_node_iter->keys.push_front(key);
+    typename std::list<Key>::iterator key_iter_in_new_node = target_freq_node_iter->keys.begin();
+
+    // 4. Update the map for the key
+    lfu_key_to_node_and_iter_[key] = {target_freq_node_iter, key_iter_in_new_node};
+}
+
+
+template <typename Key, typename Value>
+void ThreadSafeCache<Key, Value>::evict_lfu() {
+    // Assumes lock is held
+    if (lfu_frequency_list_.empty()) {
+        return; // Nothing to evict
+    }
+
+    // The LFU item is in the first frequency node (lowest frequency),
+    // and at the back of that node's key list (LRU within that frequency).
+    typename std::list<LfuFrequencyNode>::iterator lfu_node_iter = lfu_frequency_list_.begin();
+    if (lfu_node_iter->keys.empty()) {
+        // This should ideally not happen if logic is correct, means an empty frequency node exists.
+        // Potentially remove it and try next, or signal error. For now, let's be robust.
+        lfu_frequency_list_.erase(lfu_node_iter); // remove empty node
+        if (lfu_frequency_list_.empty()) return; // if that was the only one
+        lfu_node_iter = lfu_frequency_list_.begin(); // try the new first
+        if (lfu_node_iter->keys.empty()) return; // if it's still empty, something is wrong or cache is empty
+    }
+
+    Key key_to_evict = lfu_node_iter->keys.back();
+
+    // Remove from LFU structures
+    lfu_node_iter->keys.pop_back();
+    lfu_key_to_node_and_iter_.erase(key_to_evict);
+
+    // If the frequency node becomes empty, remove it from the frequency list
+    if (lfu_node_iter->keys.empty()) {
+        lfu_frequency_list_.erase(lfu_node_iter);
+    }
+
+    // Remove from main cache data
+    cache_data_.erase(key_to_evict);
+}
+
+
+} // namespace cpp_collections
+
+#endif // THREAD_SAFE_CACHE_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,3 +46,9 @@ target_link_libraries(thread_safe_counter_test PRIVATE GTest::gtest GTest::gtest
 # No need to link ThreadSafeCounterLib explicitly due to include_directories(${CMAKE_SOURCE_DIR}/include)
 # and it being header-only. GTest linkage is sufficient.
 gtest_discover_tests(thread_safe_counter_test)
+
+# Add the test executable for ThreadSafeCache
+add_executable(test_thread_safe_cache test_thread_safe_cache.cpp)
+target_link_libraries(test_thread_safe_cache PRIVATE GTest::gtest GTest::gtest_main)
+# ThreadSafeCacheLib is header-only, include_directories is sufficient.
+gtest_discover_tests(test_thread_safe_cache)

--- a/tests/test_thread_safe_cache.cpp
+++ b/tests/test_thread_safe_cache.cpp
@@ -1,0 +1,310 @@
+#include "thread_safe_cache.hpp"
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <thread>
+#include <set>
+
+// Basic test runner
+int tests_run = 0;
+int tests_failed = 0;
+
+#define RUN_TEST(test_name) \
+    do { \
+        tests_run++; \
+        std::cout << "Running test: " #test_name "..." << std::endl; \
+        try { \
+            test_name(); \
+            std::cout << #test_name " PASSED." << std::endl; \
+        } catch (const std::exception& e) { \
+            tests_failed++; \
+            std::cerr << #test_name " FAILED: " << e.what() << std::endl; \
+        } catch (...) { \
+            tests_failed++; \
+            std::cerr << #test_name " FAILED: Unknown exception." << std::endl; \
+        } \
+    } while (0)
+
+void test_constructor_and_basic_properties() {
+    cpp_collections::ThreadSafeCache<int, std::string> cache(5);
+    assert(cache.size() == 0);
+    assert(cache.empty());
+
+    bool thrown = false;
+    try {
+        cpp_collections::ThreadSafeCache<int, std::string> zero_cap_cache(0);
+    } catch (const std::invalid_argument& e) {
+        thrown = true;
+    }
+    assert(thrown);
+}
+
+void test_put_get_lru() {
+    cpp_collections::ThreadSafeCache<int, std::string> cache(3, cpp_collections::EvictionPolicy::LRU);
+    cache.put(1, "one");
+    cache.put(2, "two");
+    cache.put(3, "three");
+
+    assert(cache.size() == 3);
+    assert(cache.get(1).value_or("") == "one");
+    assert(cache.get(2).value_or("") == "two");
+    assert(cache.get(3).value_or("") == "three");
+
+    // Test update
+    cache.put(1, "new_one");
+    assert(cache.get(1).value_or("") == "new_one");
+    assert(cache.size() == 3); // Size should not change
+
+    // Test LRU eviction
+    cache.get(2); // 2 is now MRU, 1 is next, 3 is LRU
+    cache.put(4, "four"); // Evicts 3
+    assert(cache.size() == 3);
+    assert(cache.get(3) == std::nullopt);
+    assert(cache.get(4).value_or("") == "four");
+    assert(cache.get(1).value_or("") == "new_one");
+    assert(cache.get(2).value_or("") == "two");
+
+    // Access 1, make 4 LRU
+    cache.get(1); // lru_order_ was [2,1,4] (from line 71's get(2)). Becomes [1,2,4]. (4 is LRU)
+
+    cache.put(5, "five"); // Evicts 4 (the LRU item)
+    assert(cache.get(4) == std::nullopt);       // Assert that 4 was evicted
+    assert(cache.get(2).value_or("") == "two"); // Assert that 2 is still present
+    assert(cache.get(1).value_or("") == "new_one"); // Assert that 1 is still present
+    assert(cache.get(5).value_or("") == "five");    // Assert that 5 was added
+}
+
+void test_put_get_fifo() {
+    cpp_collections::ThreadSafeCache<int, std::string> cache(3, cpp_collections::EvictionPolicy::FIFO);
+    cache.put(1, "one"); // 1st in
+    cache.put(2, "two"); // 2nd in
+    cache.put(3, "three"); // 3rd in
+
+    assert(cache.size() == 3);
+    assert(cache.get(1).value_or("") == "one");
+
+    cache.get(1); // Accessing does not change FIFO order
+    cache.put(4, "four"); // Evicts 1 (oldest)
+    assert(cache.size() == 3);
+    assert(cache.get(1) == std::nullopt);
+    assert(cache.get(4).value_or("") == "four");
+    assert(cache.get(2).value_or("") == "two"); // 2 is now oldest
+
+    cache.put(5, "five"); // Evicts 2
+    assert(cache.get(2) == std::nullopt);
+    assert(cache.get(5).value_or("") == "five");
+    assert(cache.get(3).value_or("") == "three"); // 3 is now oldest
+}
+
+void test_put_get_lfu() {
+    cpp_collections::ThreadSafeCache<int, std::string> cache(3, cpp_collections::EvictionPolicy::LFU);
+    cache.put(1, "one");   // Freq(1)=1
+    cache.put(2, "two");   // Freq(2)=1
+    cache.put(3, "three"); // Freq(3)=1
+
+    cache.get(1); // Freq(1)=2
+    cache.get(1); // Freq(1)=3
+    cache.get(2); // Freq(2)=2
+    // Freqs: 1:3, 2:2, 3:1
+
+    cache.put(4, "four"); // Evicts 3 (LFU)
+    assert(cache.size() == 3);
+    assert(cache.get(3) == std::nullopt);
+    assert(cache.get(4).value_or("") == "four"); // Freq(4)=1
+    // Freqs: 1:3, 2:2, 4:1
+
+    cache.get(4); // Freq(4)=2
+    cache.get(4); // Freq(4)=3
+    // Freqs: 1:3, 2:2, 4:3
+
+    cache.put(5, "five"); // Evicts 2 (LFU)
+    assert(cache.get(2) == std::nullopt);
+    assert(cache.get(5).value_or("") == "five"); // Freq(5)=1
+    // Freqs: 1:3, 4:3, 5:1
+
+    // Test tie-breaking: 1 and 4 have freq 3. 5 has freq 1.
+    cache.get(1); // Freq(1)=4
+    cache.get(5); // Freq(5)=2
+    cache.get(5); // Freq(5)=3
+    // Freqs: 1:4, 4:3, 5:3
+    // Access 4 to make it MRU among freq 3 items (excluding 1)
+    cache.get(4); // Freq(4)=4
+    // Freqs: 1:4 (accessed first), 4:4 (accessed after 1), 5:3
+    // LRU within freq 4 is 1.
+
+    // Current state: (1, "one", F:4), (4, "four", F:4), (5, "five", F:3)
+    // Access order for F:4 items: 1 was put then its F became 4. 4 was put, its F became 3, then accessed to F:4.
+    // So 1 is LRU within F:4 group.
+
+    cache.put(6, "six"); // Evicts 5 (LFU, F:3)
+    assert(cache.get(5) == std::nullopt);
+    assert(cache.get(6).value_or("") == "six"); // Freq(6)=1
+    // Freqs: 1:4, 4:4, 6:1
+
+    // Make 1 and 4 have same freq, 6 LFU
+    // Access 1, 4 again
+    cache.get(1); // F:5
+    cache.get(4); // F:5
+    // Freqs: 1:5, 4:5, 6:1
+    // Within F:5, 1 was accessed before 4. So 1 is LRU within F:5.
+    cache.put(7, "seven"); // Evicts 6 (LFU)
+    assert(cache.get(6) == std::nullopt);
+    // Freqs: 1:5, 4:5, 7:1
+
+    // Now make 1, 4, 7 all freq 5.
+    // Access 7 four times
+    for(int i=0; i<4; ++i) cache.get(7); // F:5
+    // Freqs: 1:5, 4:5, 7:5
+    // Access order for F:5: 1, then 4, then 7. So 1 is LRU.
+    cache.put(8, "eight"); // Evicts 1
+    assert(cache.get(1) == std::nullopt);
+    assert(cache.get(8).value_or("") == "eight"); // F:1
+}
+
+
+void test_erase() {
+    cpp_collections::ThreadSafeCache<int, std::string> cache(3, cpp_collections::EvictionPolicy::LRU);
+    cache.put(1, "one");
+    cache.put(2, "two");
+    assert(cache.size() == 2);
+
+    assert(cache.erase(1));
+    assert(cache.size() == 1);
+    assert(cache.get(1) == std::nullopt);
+    assert(cache.get(2).value_or("") == "two");
+
+    assert(!cache.erase(1)); // Already erased
+    assert(cache.erase(2));
+    assert(cache.empty());
+
+    // Test erase with LFU (more complex internal state)
+    cpp_collections::ThreadSafeCache<int, std::string> lfu_cache(3, cpp_collections::EvictionPolicy::LFU);
+    lfu_cache.put(10, "A"); // F:1
+    lfu_cache.put(20, "B"); // F:1
+    lfu_cache.get(10);      // F(10)=2, F(20)=1
+    assert(lfu_cache.erase(10));
+    assert(lfu_cache.get(10) == std::nullopt);
+    assert(lfu_cache.size() == 1);
+    lfu_cache.put(30, "C"); // F(20)=1, F(30)=1
+    assert(lfu_cache.size() == 2);
+    // Eviction should pick 20 if we add 2 more
+    lfu_cache.put(40, "D");
+    lfu_cache.put(50, "E"); // 20 should be evicted (oldest F:1)
+    assert(lfu_cache.get(20) == std::nullopt);
+    assert(lfu_cache.size() == 3);
+
+
+    // Test erase with FIFO
+    cpp_collections::ThreadSafeCache<int, std::string> fifo_cache(3, cpp_collections::EvictionPolicy::FIFO);
+    fifo_cache.put(1, "a");
+    fifo_cache.put(2, "b");
+    fifo_cache.put(3, "c");
+    assert(fifo_cache.erase(2)); // Erase middle element
+    assert(fifo_cache.get(2) == std::nullopt);
+    assert(fifo_cache.size() == 2);
+    fifo_cache.put(4, "d"); // Should evict 1 (oldest of 1,3)
+    assert(fifo_cache.get(1).value_or("") == "a"); // No, put(4) makes cache {1,3,4}. Eviction later.
+                                                 // After erase(2), queue is {1,3}. Cache size 2.
+                                                 // Put(4) adds 4. Queue {1,3,4}. Cache size 3. No eviction yet.
+    assert(fifo_cache.get(4).value_or("") == "d");
+    fifo_cache.put(5, "e"); // Now evict. 1 is front of {1,3,4}.
+    assert(fifo_cache.get(1) == std::nullopt);
+    assert(fifo_cache.size() == 3); // {3,4,5}
+}
+
+void test_clear() {
+    cpp_collections::ThreadSafeCache<int, std::string> cache(3);
+    cache.put(1, "one");
+    cache.put(2, "two");
+    cache.clear();
+    assert(cache.size() == 0);
+    assert(cache.empty());
+    assert(cache.get(1) == std::nullopt);
+    cache.put(3,"three"); // Should work after clear
+    assert(cache.get(3).value_or("") == "three");
+    assert(cache.size() == 1);
+}
+
+void test_thread_safety_concurrent_put() {
+    const int num_threads = 10;
+    const int items_per_thread = 100;
+    const int cache_capacity = 50;
+    cpp_collections::ThreadSafeCache<int, int> cache(cache_capacity, cpp_collections::EvictionPolicy::LRU);
+    std::vector<std::thread> threads;
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&cache, i, items_per_thread, num_threads]() {
+            for (int j = 0; j < items_per_thread; ++j) {
+                int key = (i * items_per_thread + j); // Unique keys per thread initially, then overlap by modulo
+                cache.put(key % (cache_capacity * 2) , i * 1000 + j);
+            }
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+    assert(cache.size() <= cache_capacity); // Must not exceed capacity
+    // Further checks would require specific knowledge of eviction details or item survival.
+    // The main point is no crashes/deadlocks.
+}
+
+void test_thread_safety_concurrent_put_get_erase() {
+    const int num_threads = 10;
+    const int operations_per_thread = 200; // Increased operations
+    const int cache_capacity = 75; // Slightly larger capacity
+    cpp_collections::ThreadSafeCache<int, int> cache(cache_capacity, cpp_collections::EvictionPolicy::LFU); // Test LFU
+    std::vector<std::thread> threads;
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&cache, i, operations_per_thread, cache_capacity]() {
+            for (int j = 0; j < operations_per_thread; ++j) {
+                int op_type = j % 3;
+                int key_val = (i * operations_per_thread + j);
+                int key = key_val % (cache_capacity + 20); // Keys will overlap
+
+                if (op_type == 0) { // PUT
+                    cache.put(key, key_val);
+                } else if (op_type == 1) { // GET
+                    cache.get(key);
+                } else { // ERASE
+                    cache.erase(key % (cache_capacity)); // Erase a subset of possible keys
+                }
+            }
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+    assert(cache.size() <= cache_capacity);
+    // Check if some items exist (probabilistic, but better than nothing)
+    // This is hard to assert definitively without a deterministic scenario.
+    // For now, successful completion without crash is the primary check.
+    int found_items = 0;
+    for(int k=0; k < cache_capacity + 20; ++k) {
+        if(cache.get(k).has_value()) {
+            found_items++;
+        }
+    }
+    std::cout << "Items found after mixed operations: " << found_items << std::endl;
+}
+
+
+int main() {
+    std::cout << "Starting ThreadSafeCache tests..." << std::endl;
+
+    RUN_TEST(test_constructor_and_basic_properties);
+    RUN_TEST(test_put_get_lru);
+    RUN_TEST(test_put_get_fifo);
+    RUN_TEST(test_put_get_lfu);
+    RUN_TEST(test_erase);
+    RUN_TEST(test_clear);
+    RUN_TEST(test_thread_safety_concurrent_put);
+    RUN_TEST(test_thread_safety_concurrent_put_get_erase);
+
+    std::cout << "\nTests finished." << std::endl;
+    std::cout << "Total tests run: " << tests_run << std::endl;
+    std::cout << "Tests failed: " << tests_failed << std::endl;
+
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Implemented a templated ThreadSafeCache class supporting LRU, LFU, and FIFO eviction policies. Includes:
- thread_safe_cache.hpp: Header-only implementation.
- thread_safe_cache_example.cpp: Usage examples.
- test_thread_safe_cache.cpp: Unit tests.
- docs/README_thread_safe_cache.md: Documentation.
- CMakeLists.txt updates for library, example, and tests.

A test failure in test_put_get_lfu indicates a potential issue with the LFU eviction logic or its test case details. Key 5 is expected to be evicted but is not, suggesting it's not correctly identified as the LFU item in that specific scenario.