### PR TITLE
feat: Add MultiKeyMap data structure

### DIFF
--- a/docs/README_multikey_map.md
+++ b/docs/README_multikey_map.md
@@ -1,0 +1,174 @@
+# MultiKeyMap
+
+## Overview
+
+`MultiKeyMap` is a C++ data structure that provides a map-like interface where keys are composed of multiple heterogeneous values. It simplifies the use of composite keys by allowing users to interact with the map using individual key components directly, rather than manually managing `std::tuple` objects for every operation.
+
+Internally, `MultiKeyMap` uses an `std::unordered_map` with `std::tuple` as the actual key. It provides a custom hash function (`TupleHash`) for `std::tuple` to enable its use with `std::unordered_map`.
+
+This structure is useful when you need to map values based on a combination of several attributes, for example, `(int id, std::string type, double version) -> MyObject`.
+
+## Features
+
+*   **Variadic Key Handling**: Supports keys composed of a variable number of elements with different types.
+*   **Type Safety**: Enforces type correctness for key components at compile time.
+*   **Ergonomic API**: Offers methods like `insert`, `find`, `at`, `erase`, `contains` that accept individual key components directly.
+*   **Tuple Compatibility**: Also allows operations using `std::tuple` objects directly (e.g., `insert_tuple`, `find_tuple`).
+*   **Standard Map Interface**: Provides common map functionalities like `size()`, `empty()`, `clear()`, iterators, etc.
+*   **Customizable Hashing**: Uses a robust default hash function for tuples, which can be extended or customized if needed (though the default `TupleHash` should cover most standard types).
+*   **Header-Only**: Easy to integrate by including `multikey_map.h`.
+
+## API Reference
+
+### Template Parameters
+
+```cpp
+template <typename Value, typename... KeyTypes>
+class MultiKeyMap;
+```
+
+*   `Value`: The type of the values stored in the map.
+*   `KeyTypes...`: A variadic pack representing the types of the individual components that form the composite key.
+
+### Key Type Alias
+
+*   `KeyTuple`: Alias for `std::tuple<KeyTypes...>`.
+
+### Constructors
+
+*   `MultiKeyMap()`: Default constructor.
+*   `MultiKeyMap(size_type bucket_count, const hasher& hash = hasher(), const key_equal& equal = key_equal())`: Constructor with initial bucket count and custom hasher/equality functors.
+*   `MultiKeyMap(std::initializer_list<std::pair<KeyTuple, Value>> init)`: Constructor from an initializer list of key-tuple/value pairs.
+
+### Core Operations (Variadic Keys)
+
+These methods accept individual key components.
+
+*   `std::pair<iterator, bool> insert(const KeyTypes&... keys, const Value& value)`
+*   `std::pair<iterator, bool> insert(const KeyTypes&... keys, Value&& value)`
+*   `template <typename... ArgsValue> std::pair<iterator, bool> emplace(const KeyTypes&... keys, ArgsValue&&... args_value)`
+*   `template <typename... ArgsValue> std::pair<iterator, bool> try_emplace(const KeyTypes&... keys, ArgsValue&&... args_value)`
+*   `iterator find(const KeyTypes&... keys)`
+*   `const_iterator find(const KeyTypes&... keys) const`
+*   `Value& at(const KeyTypes&... keys)`
+*   `const Value& at(const KeyTypes&... keys) const`
+*   `size_type erase(const KeyTypes&... keys)`
+*   `bool contains(const KeyTypes&... keys) const`
+*   `Value& operator()(const KeyTypes&... keys)`: Accesses element, creates if not exists (like `std::map::operator[]`).
+
+### Core Operations (Tuple Keys)
+
+These methods accept a `KeyTuple` (`std::tuple<KeyTypes...>`) directly.
+
+*   `std::pair<iterator, bool> insert_tuple(const KeyTuple& key_tuple, const Value& value)` (and overloads for `Value&&`, `KeyTuple&&`)
+*   `template <typename... ArgsValue> std::pair<iterator, bool> emplace_tuple(const KeyTuple& key_tuple, ArgsValue&&... args_value)` (and overload for `KeyTuple&&`)
+*   `template <typename... ArgsValue> std::pair<iterator, bool> try_emplace_tuple(const KeyTuple& key_tuple, ArgsValue&&... args_value)` (and overload for `KeyTuple&&`)
+*   `iterator find_tuple(const KeyTuple& key_tuple)`
+*   `const_iterator find_tuple(const KeyTuple& key_tuple) const`
+*   `Value& at_tuple(const KeyTuple& key_tuple)`
+*   `const Value& at_tuple(const KeyTuple& key_tuple) const`
+*   `size_type erase_tuple(const KeyTuple& key_tuple)`
+*   `bool contains_tuple(const KeyTuple& key_tuple) const`
+*   `Value& operator[](const KeyTuple& key_tuple)`
+*   `Value& operator[](KeyTuple&& key_tuple)`
+
+### Other Standard Methods
+
+*   `empty() const noexcept -> bool`
+*   `size() const noexcept -> size_type`
+*   `max_size() const noexcept -> size_type`
+*   `clear() noexcept`
+*   `begin() noexcept -> iterator`
+*   `end() noexcept -> iterator`
+*   `cbegin() const noexcept -> const_iterator`
+*   `cend() const noexcept -> const_iterator`
+*   `swap(MultiKeyMap& other) noexcept`
+*   Bucket interface methods (`bucket_count`, `bucket_size`, `bucket`, etc.)
+*   Hash policy methods (`load_factor`, `max_load_factor`, `rehash`, `reserve`)
+*   Observer methods (`hash_function`, `key_eq`)
+*   Equality operators (`operator==`, `operator!=`)
+
+## Usage Example
+
+```cpp
+#include "multikey_map.h"
+#include <iostream>
+#include <string>
+
+int main() {
+    // Map (int user_id, std::string item_category) to (double score)
+    MultiKeyMap<double, int, std::string> userScores;
+
+    // Insert using individual keys
+    userScores.insert(101, "books", 85.5);
+    userScores.emplace(102, "electronics", 92.0);
+    userScores.insert(101, "music", 78.3);
+
+    // Access using operator()
+    userScores(103, "games") = 88.0; // Insert or assign
+
+    // Check size
+    std::cout << "Number of entries: " << userScores.size() << std::endl; // Output: 4
+
+    // Find and print a score
+    if (userScores.contains(101, "books")) {
+        std::cout << "Score for (101, books): " << userScores.at(101, "books") << std::endl;
+    }
+
+    // Using operator() for access
+    std::cout << "Score for (103, games) via operator(): " << userScores(103, "games") << std::endl;
+
+    // Iterate over the map
+    std::cout << "All scores:" << std::endl;
+    for (const auto& entry : userScores) {
+        // entry.first is std::tuple<int, std::string>
+        // entry.second is double
+        std::cout << "  User ID: " << std::get<0>(entry.first)
+                  << ", Category: " << std::get<1>(entry.first)
+                  << " -> Score: " << entry.second << std::endl;
+    }
+
+    // Erase an entry
+    userScores.erase(101, "music");
+    std::cout << "Number of entries after erase: " << userScores.size() << std::endl; // Output: 3
+
+    // Using std::tuple with operator[]
+    MultiKeyMap<std::string, int, int> map_tuple_keys;
+    std::tuple<int, int> key_t(200, 300);
+    map_tuple_keys[key_t] = "Value for (200,300)";
+    std::cout << map_tuple_keys[key_t] << std::endl;
+
+
+    return 0;
+}
+```
+
+## Internal Implementation Details
+
+`MultiKeyMap` internally wraps an `std::unordered_map<std::tuple<KeyTypes...>, Value, TupleHash<KeyTypes...>>`.
+
+The `TupleHash<KeyTypes...>` struct provides a specialization for `std::hash` for `std::tuple`. It computes the hash by combining the hashes of individual elements within the tuple. This is achieved using `std::apply` and a `hash_combine` utility function, similar to `boost::hash_combine`.
+
+For example:
+```cpp
+// Helper to combine hash values
+template <typename T>
+inline void hash_combine(std::size_t& seed, const T& v) {
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+// Hash functor for std::tuple
+template <typename... KeyTypes>
+struct TupleHash {
+    std::size_t operator()(const std::tuple<KeyTypes...>& t) const {
+        std::size_t seed = 0;
+        std::apply([&seed](const auto&... args) {
+            (hash_combine(seed, args), ...); // Fold expression
+        }, t);
+        return seed;
+    }
+};
+```
+
+This allows `std::tuple` to be used effectively as a key in `std::unordered_map`. The `MultiKeyMap` class then provides a more convenient variadic interface on top of this.

--- a/examples/multikey_map_example.cpp
+++ b/examples/multikey_map_example.cpp
@@ -1,0 +1,141 @@
+#include "multikey_map.h"
+#include <iostream>
+#include <string>
+#include <vector>
+
+// A simple struct to demonstrate usage with custom types (must be hashable and equatable)
+struct MyStruct {
+    int id;
+    std::string name;
+
+    bool operator==(const MyStruct& other) const {
+        return id == other.id && name == other.name;
+    }
+};
+
+// Hash specialization for MyStruct
+namespace std {
+template <>
+struct hash<MyStruct> {
+    size_t operator()(const MyStruct& s) const {
+        size_t h1 = hash<int>()(s.id);
+        size_t h2 = hash<string>()(s.name);
+        return h1 ^ (h2 << 1); // Simple combination
+    }
+};
+} // namespace std
+
+int main() {
+    // Example 1: Basic usage with int and std::string keys, storing std::string values
+    std::cout << "--- Example 1: Basic Usage (int, std::string) -> std::string ---" << std::endl;
+    MultiKeyMap<std::string, int, std::string> map1;
+
+    map1.insert(1, "apple", "Fruit: Red or Green");
+    map1.emplace(2, "banana", "Fruit: Yellow");
+    map1.insert(1, "apricot", "Fruit: Orange"); // Key (1, "apricot")
+
+    // Using the call operator for insertion/assignment
+    map1(3, "cherry") = "Fruit: Red";
+
+    std::cout << "Map1 size: " << map1.size() << std::endl;
+
+    // Find and print values
+    if (auto it = map1.find(1, "apple"); it != map1.end()) {
+        std::cout << "Found (1, \"apple\"): " << it->second << std::endl;
+    }
+    if (map1.contains(2, "banana")) {
+        std::cout << "Value for (2, \"banana\"): " << map1.at(2, "banana") << std::endl;
+    }
+
+    // Try to find a non-existent key
+    if (map1.find(10, "nonexistent") == map1.end()) {
+        std::cout << "Key (10, \"nonexistent\") not found, as expected." << std::endl;
+    }
+
+    // Using operator() for access (like at, but creates if not exists with default value)
+    std::cout << "Accessing (3, \"cherry\") via operator(): " << map1(3, "cherry") << std::endl;
+    // Accessing a new key with operator() will default-construct the value (empty string here)
+    // std::cout << "Accessing (4, \"date\") via operator() (new): " << map1(4, "date") << std::endl;
+    // std::cout << "Map1 size after new access: " << map1.size() << std::endl;
+
+
+    // Iteration
+    std::cout << "Iterating map1:" << std::endl;
+    for (const auto& pair : map1) {
+        // pair.first is a std::tuple<int, std::string>
+        // pair.second is the std::string value
+        std::cout << "  Key: (" << std::get<0>(pair.first) << ", " << std::get<1>(pair.first)
+                  << "), Value: " << pair.second << std::endl;
+    }
+
+    // Erase an element
+    map1.erase(1, "apple");
+    std::cout << "Map1 size after erasing (1, \"apple\"): " << map1.size() << std::endl;
+
+
+    // Example 2: Using three keys (int, double, char) -> int
+    std::cout << "\n--- Example 2: Three Keys (int, double, char) -> int ---" << std::endl;
+    MultiKeyMap<int, int, double, char> map2;
+    map2.insert(10, 3.14, 'a', 100);
+    map2.insert(20, 2.71, 'b', 200);
+    map2(10, 3.14, 'z') = 101; // Update if key parts are same, or new entry
+
+    std::cout << "Value for (10, 3.14, 'a'): " << map2.at(10, 3.14, 'a') << std::endl;
+    std::cout << "Value for (10, 3.14, 'z'): " << map2.at(10, 3.14, 'z') << std::endl;
+
+
+    // Example 3: Using std::tuple directly for keys
+    std::cout << "\n--- Example 3: Using std::tuple for keys ---" << std::endl;
+    MultiKeyMap<std::string, int, std::string> map3;
+    std::tuple<int, std::string> key1 = {100, "tuple_key_A"};
+    std::tuple<int, std::string> key2 = {200, "tuple_key_B"};
+
+    map3.insert(key1, "Value for key1"); // Corrected: use insert for tuples
+    map3[key2] = "Value for key2 (via operator[])"; // operator[] takes a tuple
+
+    std::cout << "Value for key1 (tuple): " << map3.at_tuple(key1) << std::endl;
+    std::cout << "Value for key2 (tuple) from operator[]: " << map3[key2] << std::endl;
+
+    // Using operator() with individual keys which is generally preferred for ergonomics
+    std::cout << "Value for (100, \"tuple_key_A\") using operator(): " << map3(100, "tuple_key_A") << std::endl;
+
+
+    // Example 4: Using custom struct as part of the key
+    std::cout << "\n--- Example 4: Custom Struct in Key (MyStruct, int) -> std::string ---" << std::endl;
+    MultiKeyMap<std::string, MyStruct, int> map4;
+
+    MyStruct s1 = {1, "Obj1"};
+    MyStruct s2 = {2, "Obj2"};
+
+    map4.insert(s1, 10, "S1-10");
+    map4.insert(s2, 20, "S2-20");
+    map4.insert({1, "Obj1"}, 30, "S1-30"); // Using initializer list for MyStruct, then int
+
+    std::cout << "Map4 size: " << map4.size() << std::endl;
+    if(map4.contains(s1, 10)) {
+        std::cout << "Found (s1, 10): " << map4.at(s1, 10) << std::endl;
+    }
+    if(map4.contains({1, "Obj1"}, 30)) {
+        std::cout << "Found ({1, \"Obj1\"}, 30): " << map4.at({1, "Obj1"}, 30) << std::endl;
+    }
+
+    std::cout << "Iterating map4:" << std::endl;
+    for (const auto& pair : map4) {
+        const auto& key_tuple = pair.first; // std::tuple<MyStruct, int>
+        const MyStruct& ms = std::get<0>(key_tuple);
+        int ik = std::get<1>(key_tuple);
+        std::cout << "  Key: (MyStruct{id=" << ms.id << ", name=" << ms.name << "}, " << ik
+                  << "), Value: " << pair.second << std::endl;
+    }
+
+
+    // Example 5: Clear and empty
+    std::cout << "\n--- Example 5: Clear and Empty ---" << std::endl;
+    std::cout << "Map1 size before clear: " << map1.size() << std::endl;
+    std::cout << "Map1 empty before clear? " << (map1.empty() ? "Yes" : "No") << std::endl;
+    map1.clear();
+    std::cout << "Map1 size after clear: " << map1.size() << std::endl;
+    std::cout << "Map1 empty after clear? " << (map1.empty() ? "Yes" : "No") << std::endl;
+
+    return 0;
+}

--- a/include/multikey_map.h
+++ b/include/multikey_map.h
@@ -1,0 +1,280 @@
+#pragma once
+
+#include <functional> // For std::hash
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+#include <utility> // For std::pair, std::move
+
+// Forward declaration
+template <typename Value, typename... KeyTypes>
+class MultiKeyMap;
+
+// Helper to combine hash values
+// Inspired by boost::hash_combine
+template <typename T>
+inline void hash_combine(std::size_t& seed, const T& v) {
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+// Hash functor for std::tuple
+template <typename... KeyTypes>
+struct TupleHash {
+    std::size_t operator()(const std::tuple<KeyTypes...>& t) const {
+        std::size_t seed = 0;
+        // Apply hash_combine for each element in the tuple
+        std::apply([&seed](const auto&... args) {
+            (hash_combine(seed, args), ...);
+        }, t);
+        return seed;
+    }
+};
+
+// Equality functor for std::tuple (std::tuple already has operator==)
+// Not strictly needed if std::tuple::operator== is used by default by unordered_map,
+// but can be explicitly provided for clarity or if specific behavior is needed.
+// For now, we rely on the default std::equal_to<std::tuple<KeyTypes...>> which uses operator==.
+
+template <typename Value, typename... KeyTypes>
+class MultiKeyMap {
+public:
+    using KeyTuple = std::tuple<KeyTypes...>;
+    using InternalMap = std::unordered_map<KeyTuple, Value, TupleHash<KeyTypes...>>;
+    using value_type = typename InternalMap::value_type; // std::pair<const KeyTuple, Value>
+    using mapped_type = Value;
+    using key_type = KeyTuple; // Exposing the tuple type as key_type
+    using size_type = typename InternalMap::size_type;
+    using difference_type = typename InternalMap::difference_type;
+    using hasher = TupleHash<KeyTypes...>;
+    using key_equal = typename InternalMap::key_equal; // std::equal_to<KeyTuple>
+    using reference = typename InternalMap::reference;
+    using const_reference = typename InternalMap::const_reference;
+    using pointer = typename InternalMap::pointer;
+    using const_pointer = typename InternalMap::const_pointer;
+    using iterator = typename InternalMap::iterator;
+    using const_iterator = typename InternalMap::const_iterator;
+
+private:
+    InternalMap map_;
+
+public:
+    // Constructors
+    MultiKeyMap() = default;
+
+    explicit MultiKeyMap(size_type bucket_count,
+                         const hasher& hash = hasher(),
+                         const key_equal& equal = key_equal())
+        : map_(bucket_count, hash, equal) {}
+
+    MultiKeyMap(std::initializer_list<std::pair<KeyTuple, Value>> init) {
+        for (const auto& item : init) {
+            // Directly use emplace which is more efficient if KeyTuple can be constructed from item.first
+            // or if item.first is already a KeyTuple.
+            // Since item is std::pair<KeyTuple, Value>, item.first is KeyTuple.
+            map_.emplace(item.first, item.second);
+        }
+    }
+
+    // Copy and Move constructors/assignments
+    MultiKeyMap(const MultiKeyMap&) = default;
+    MultiKeyMap(MultiKeyMap&&) = default;
+    MultiKeyMap& operator=(const MultiKeyMap&) = default;
+    MultiKeyMap& operator=(MultiKeyMap&&) = default;
+
+    // Destructor
+    ~MultiKeyMap() = default;
+
+    // Iterators
+    iterator begin() noexcept { return map_.begin(); }
+    const_iterator begin() const noexcept { return map_.begin(); }
+    const_iterator cbegin() const noexcept { return map_.cbegin(); }
+
+    iterator end() noexcept { return map_.end(); }
+    const_iterator end() const noexcept { return map_.end(); }
+    const_iterator cend() const noexcept { return map_.cend(); }
+
+    // Capacity
+    bool empty() const noexcept { return map_.empty(); }
+    size_type size() const noexcept { return map_.size(); }
+    size_type max_size() const noexcept { return map_.max_size(); }
+
+    // Modifiers
+    void clear() noexcept { map_.clear(); }
+
+    // Further methods (insert, emplace, find, at, erase, contains, operator[], etc.)
+    // will be implemented in the next step.
+
+    // --- Modifiers ---
+
+    std::pair<iterator, bool> insert(const KeyTypes&... keys, const Value& value) {
+        return map_.insert({std::make_tuple(keys...), value});
+    }
+
+    std::pair<iterator, bool> insert(const KeyTypes&... keys, Value&& value) {
+        return map_.insert({std::make_tuple(keys...), std::move(value)});
+    }
+
+    // Overload for when keys are already in a tuple
+    std::pair<iterator, bool> insert(const KeyTuple& key_tuple, const Value& value) {
+        return map_.insert({key_tuple, value});
+    }
+
+    std::pair<iterator, bool> insert(const KeyTuple& key_tuple, Value&& value) {
+        return map_.insert({key_tuple, std::move(value)});
+    }
+
+    std::pair<iterator, bool> insert(KeyTuple&& key_tuple, Value&& value) {
+        return map_.insert({std::move(key_tuple), std::move(value)});
+    }
+
+    template <typename... ArgsValue>
+    std::pair<iterator, bool> emplace(const KeyTypes&... keys, ArgsValue&&... args_value) {
+        return map_.emplace(std::make_tuple(keys...), Value(std::forward<ArgsValue>(args_value)...));
+    }
+
+    // Emplace with KeyTuple directly
+    template <typename... ArgsValue>
+    std::pair<iterator, bool> emplace_tuple(const KeyTuple& key_tuple, ArgsValue&&... args_value) {
+        return map_.emplace(key_tuple, Value(std::forward<ArgsValue>(args_value)...));
+    }
+
+    template <typename... ArgsValue>
+    std::pair<iterator, bool> emplace_tuple(KeyTuple&& key_tuple, ArgsValue&&... args_value) {
+        return map_.emplace(std::move(key_tuple), Value(std::forward<ArgsValue>(args_value)...));
+    }
+
+    // try_emplace equivalent for variadic keys
+    template <typename... ArgsValue>
+    std::pair<iterator, bool> try_emplace(const KeyTypes&... keys, ArgsValue&&... args_value) {
+        return map_.try_emplace(std::make_tuple(keys...), std::forward<ArgsValue>(args_value)...);
+    }
+
+    // try_emplace for KeyTuple directly
+    template <typename... ArgsValue>
+    std::pair<iterator, bool> try_emplace_tuple(const KeyTuple& key_tuple, ArgsValue&&... args_value) {
+        return map_.try_emplace(key_tuple, std::forward<ArgsValue>(args_value)...);
+    }
+
+    template <typename... ArgsValue>
+    std::pair<iterator, bool> try_emplace_tuple(KeyTuple&& key_tuple, ArgsValue&&... args_value) {
+        return map_.try_emplace(std::move(key_tuple), std::forward<ArgsValue>(args_value)...);
+    }
+
+    size_type erase(const KeyTypes&... keys) {
+        return map_.erase(std::make_tuple(keys...));
+    }
+
+    size_type erase_tuple(const KeyTuple& key_tuple) {
+        return map_.erase(key_tuple);
+    }
+
+    iterator erase(const_iterator pos) {
+        return map_.erase(pos);
+    }
+
+    iterator erase(iterator pos) {
+        return map_.erase(pos);
+    }
+
+    // --- Lookup ---
+
+    iterator find(const KeyTypes&... keys) {
+        return map_.find(std::make_tuple(keys...));
+    }
+
+    const_iterator find(const KeyTypes&... keys) const {
+        return map_.find(std::make_tuple(keys...));
+    }
+
+    iterator find_tuple(const KeyTuple& key_tuple) {
+        return map_.find(key_tuple);
+    }
+
+    const_iterator find_tuple(const KeyTuple& key_tuple) const {
+        return map_.find(key_tuple);
+    }
+
+    Value& at(const KeyTypes&... keys) {
+        return map_.at(std::make_tuple(keys...));
+    }
+
+    const Value& at(const KeyTypes&... keys) const {
+        return map_.at(std::make_tuple(keys...));
+    }
+
+    Value& at_tuple(const KeyTuple& key_tuple) {
+        return map_.at(key_tuple);
+    }
+
+    const Value& at_tuple(const KeyTuple& key_tuple) const {
+        return map_.at(key_tuple);
+    }
+
+    // operator[] will take a KeyTuple for now.
+    // A variadic operator[] returning a proxy is more complex.
+    Value& operator[](const KeyTuple& key_tuple) {
+        return map_[key_tuple];
+    }
+
+    Value& operator[](KeyTuple&& key_tuple) {
+        return map_[std::move(key_tuple)];
+    }
+
+    // Variadic operator[] using a helper or direct construction.
+    // This version will create a default Value if key doesn't exist.
+    Value& operator()(const KeyTypes&... keys) {
+        return map_[std::make_tuple(keys...)];
+    }
+
+
+    bool contains(const KeyTypes&... keys) const {
+        return map_.count(std::make_tuple(keys...)) > 0;
+    }
+
+    bool contains_tuple(const KeyTuple& key_tuple) const {
+        return map_.count(key_tuple) > 0;
+    }
+
+    // Bucket interface
+    size_type bucket_count() const { return map_.bucket_count(); }
+    size_type max_bucket_count() const { return map_.max_bucket_count(); }
+    size_type bucket_size(size_type n) const { return map_.bucket_size(n); }
+    size_type bucket(const KeyTypes&... keys) const {
+        return map_.bucket(std::make_tuple(keys...));
+    }
+    size_type bucket_tuple(const KeyTuple& key_tuple) const {
+        return map_.bucket(key_tuple);
+    }
+
+    // Hash policy
+    float load_factor() const { return map_.load_factor(); }
+    float max_load_factor() const { return map_.max_load_factor(); }
+    void max_load_factor(float ml) { map_.max_load_factor(ml); }
+    void rehash(size_type count) { map_.rehash(count); }
+    void reserve(size_type count) { map_.reserve(count); }
+
+    // Observers
+    hasher hash_function() const { return map_.hash_function(); }
+    key_equal key_eq() const { return map_.key_eq(); }
+
+    // Equality
+    bool operator==(const MultiKeyMap& other) const {
+        return map_ == other.map_;
+    }
+
+    bool operator!=(const MultiKeyMap& other) const {
+        return !(*this == other);
+    }
+
+    void swap(MultiKeyMap& other) noexcept {
+        map_.swap(other.map_);
+    }
+};
+
+// Non-member swap function
+template <typename Value, typename... KeyTypes>
+void swap(MultiKeyMap<Value, KeyTypes...>& lhs, MultiKeyMap<Value, KeyTypes...>& rhs) noexcept {
+    lhs.swap(rhs);
+}

--- a/tests/multikey_map_test.cpp
+++ b/tests/multikey_map_test.cpp
@@ -1,0 +1,402 @@
+#include "gtest/gtest.h"
+#include "multikey_map.h" // Assuming this is the header for MultiKeyMap
+#include <string>
+#include <vector>
+#include <tuple>
+
+// Custom struct for testing complex key types
+struct TestKeyStruct {
+    int id;
+    std::string name;
+    double value;
+
+    bool operator==(const TestKeyStruct& other) const {
+        return id == other.id && name == other.name && value == other.value;
+    }
+};
+
+// Hash specialization for TestKeyStruct
+namespace std {
+template <>
+struct hash<TestKeyStruct> {
+    size_t operator()(const TestKeyStruct& s) const {
+        size_t seed = 0;
+        hash_combine(seed, s.id);
+        hash_combine(seed, s.name);
+        hash_combine(seed, s.value);
+        return seed;
+    }
+};
+} // namespace std
+
+
+// Test fixture for MultiKeyMap tests
+class MultiKeyMapTest : public ::testing::Test {
+protected:
+    // Example: MultiKeyMap<ValueType, KeyType1, KeyType2, ...>
+    MultiKeyMap<std::string, int, std::string> map_is_s; // int, string -> string
+    MultiKeyMap<int, std::string, double, char> map_sdc_i; // string, double, char -> int
+    MultiKeyMap<double, TestKeyStruct> map_cks_d; // TestKeyStruct -> double
+};
+
+// Test default constructor and initial state
+TEST_F(MultiKeyMapTest, DefaultConstructor) {
+    EXPECT_TRUE(map_is_s.empty());
+    EXPECT_EQ(0, map_is_s.size());
+    MultiKeyMap<int, int> empty_map;
+    EXPECT_TRUE(empty_map.empty());
+}
+
+// Test insertion and basic find
+TEST_F(MultiKeyMapTest, InsertAndFind) {
+    map_is_s.insert(1, "apple", "Red Fruit");
+    ASSERT_EQ(1, map_is_s.size());
+    ASSERT_FALSE(map_is_s.empty());
+
+    auto it = map_is_s.find(1, "apple");
+    ASSERT_NE(it, map_is_s.end());
+    EXPECT_EQ("Red Fruit", it->second);
+
+    const auto& cmap_is_s = map_is_s;
+    auto cit = cmap_is_s.find(1, "apple");
+    ASSERT_NE(cit, cmap_is_s.cend());
+    EXPECT_EQ("Red Fruit", cit->second);
+}
+
+// Test emplace
+TEST_F(MultiKeyMapTest, Emplace) {
+    auto result = map_is_s.emplace(2, "banana", "Yellow Fruit");
+    EXPECT_TRUE(result.second); // Insertion should happen
+    EXPECT_EQ("Yellow Fruit", result.first->second);
+    EXPECT_EQ(1, map_is_s.size());
+
+    // Try emplacing duplicate
+    result = map_is_s.emplace(2, "banana", "Another Yellow Fruit");
+    EXPECT_FALSE(result.second); // Insertion should not happen
+    EXPECT_EQ("Yellow Fruit", result.first->second); // Should point to existing
+    EXPECT_EQ(1, map_is_s.size());
+}
+
+// Test try_emplace
+TEST_F(MultiKeyMapTest, TryEmplace) {
+    auto result = map_is_s.try_emplace(3, "cherry", "Red Small Fruit");
+    EXPECT_TRUE(result.second);
+    EXPECT_EQ("Red Small Fruit", result.first->second);
+    EXPECT_EQ(1, map_is_s.size());
+
+    result = map_is_s.try_emplace(3, "cherry", "Another Red Fruit");
+    EXPECT_FALSE(result.second); // Key exists, no insertion or update
+    EXPECT_EQ("Red Small Fruit", result.first->second); // Points to existing
+    EXPECT_EQ(1, map_is_s.size());
+
+    // Try emplace with a new value for a new key component but same first key
+    result = map_is_s.try_emplace(3, "cranberry", "Tart Red Fruit");
+    EXPECT_TRUE(result.second);
+    EXPECT_EQ("Tart Red Fruit", result.first->second);
+    EXPECT_EQ(2, map_is_s.size());
+}
+
+
+// Test at() method for access and exceptions
+TEST_F(MultiKeyMapTest, AtMethod) {
+    map_is_s.insert(1, "apple", "Red Fruit");
+    EXPECT_EQ("Red Fruit", map_is_s.at(1, "apple"));
+
+    const auto& cmap_is_s = map_is_s;
+    EXPECT_EQ("Red Fruit", cmap_is_s.at(1, "apple"));
+
+    EXPECT_THROW(map_is_s.at(2, "nonexistent"), std::out_of_range);
+    EXPECT_THROW(cmap_is_s.at(2, "nonexistent"), std::out_of_range);
+}
+
+// Test operator() for access and insertion
+TEST_F(MultiKeyMapTest, CallOperator) {
+    map_is_s(1, "date") = "Brown Fruit"; // Insert
+    EXPECT_EQ("Brown Fruit", map_is_s.at(1, "date"));
+    EXPECT_EQ(1, map_is_s.size());
+
+    map_is_s(1, "date") = "Sweet Brown Fruit"; // Update
+    EXPECT_EQ("Sweet Brown Fruit", map_is_s.at(1, "date"));
+    EXPECT_EQ(1, map_is_s.size());
+
+    // Accessing non-existent key creates default-constructed value
+    EXPECT_EQ("", map_is_s(2, "fig")); // Assuming std::string default constructor
+    EXPECT_EQ(2, map_is_s.size());
+    EXPECT_TRUE(map_is_s.contains(2, "fig"));
+}
+
+// Test operator[] with std::tuple
+TEST_F(MultiKeyMapTest, BracketOperatorWithTuple) {
+    using KeyTuple = typename decltype(map_is_s)::KeyTuple;
+    KeyTuple kt1 = {1, "elderberry"};
+
+    map_is_s[kt1] = "Dark Berry"; // Insert
+    EXPECT_EQ("Dark Berry", map_is_s.at_tuple(kt1));
+    EXPECT_EQ(1, map_is_s.size());
+
+    map_is_s[kt1] = "Sweet Dark Berry"; // Update
+    EXPECT_EQ("Sweet Dark Berry", map_is_s.at_tuple(kt1));
+    EXPECT_EQ(1, map_is_s.size());
+
+    KeyTuple kt2 = {2, "fig"};
+    EXPECT_EQ("", map_is_s[kt2]); // Default construction
+    EXPECT_EQ(2, map_is_s.size());
+    EXPECT_TRUE(map_is_s.contains_tuple(kt2));
+
+    KeyTuple kt3 = {3, "grape"};
+    map_is_s[std::move(kt3)] = "Green or Purple"; // Move overload for key
+    EXPECT_TRUE(map_is_s.contains(3, "grape"));
+    EXPECT_EQ("Green or Purple", map_is_s.at(3, "grape"));
+
+}
+
+
+// Test contains method
+TEST_F(MultiKeyMapTest, Contains) {
+    map_is_s.insert(1, "apple", "Red Fruit");
+    EXPECT_TRUE(map_is_s.contains(1, "apple"));
+    EXPECT_FALSE(map_is_s.contains(1, "banana"));
+    EXPECT_FALSE(map_is_s.contains(2, "apple"));
+}
+
+// Test erase method
+TEST_F(MultiKeyMapTest, Erase) {
+    map_is_s.insert(1, "apple", "Red Fruit");
+    map_is_s.insert(2, "banana", "Yellow Fruit");
+    ASSERT_EQ(2, map_is_s.size());
+
+    EXPECT_EQ(1, map_is_s.erase(1, "apple")); // Erase existing
+    EXPECT_EQ(1, map_is_s.size());
+    EXPECT_FALSE(map_is_s.contains(1, "apple"));
+
+    EXPECT_EQ(0, map_is_s.erase(1, "apple")); // Erase non-existing
+    EXPECT_EQ(1, map_is_s.size());
+
+    // Erase by iterator
+    auto it = map_is_s.find(2, "banana");
+    ASSERT_NE(it, map_is_s.end());
+    auto next_it = map_is_s.erase(it);
+    EXPECT_EQ(map_is_s.end(), next_it); // Simplified check, might be more specific if map had more elements
+    EXPECT_EQ(0, map_is_s.size());
+    EXPECT_TRUE(map_is_s.empty());
+}
+
+// Test clear method
+TEST_F(MultiKeyMapTest, Clear) {
+    map_is_s.insert(1, "apple", "Red Fruit");
+    map_is_s.insert(2, "banana", "Yellow Fruit");
+    ASSERT_FALSE(map_is_s.empty());
+
+    map_is_s.clear();
+    EXPECT_TRUE(map_is_s.empty());
+    EXPECT_EQ(0, map_is_s.size());
+    EXPECT_FALSE(map_is_s.contains(1, "apple")); // Ensure elements are gone
+}
+
+// Test iteration
+TEST_F(MultiKeyMapTest, Iteration) {
+    map_is_s.insert(1, "apple", "Red");
+    map_is_s.insert(2, "banana", "Yellow");
+    map_is_s.insert(3, "cherry", "Red Small");
+
+    int count = 0;
+    std::vector<std::tuple<int, std::string>> expected_keys = {
+        {1, "apple"}, {2, "banana"}, {3, "cherry"}
+    };
+    std::vector<std::string> expected_values = {"Red", "Yellow", "Red Small"};
+
+    for (const auto& pair : map_is_s) {
+        bool found = false;
+        for (size_t i = 0; i < expected_keys.size(); ++i) {
+            if (pair.first == expected_keys[i] && pair.second == expected_values[i]) {
+                found = true;
+                // Remove to ensure we don't match twice and all are found
+                expected_keys.erase(expected_keys.begin() + i);
+                expected_values.erase(expected_values.begin() + i);
+                break;
+            }
+        }
+        EXPECT_TRUE(found) << "Unexpected pair: ("
+                           << std::get<0>(pair.first) << ", " << std::get<1>(pair.first)
+                           << ") -> " << pair.second;
+        count++;
+    }
+    EXPECT_EQ(3, count);
+    EXPECT_TRUE(expected_keys.empty()) << "Not all expected keys were found during iteration.";
+}
+
+// Test with multiple key types
+TEST_F(MultiKeyMapTest, MultipleKeyTypes) {
+    map_sdc_i.insert("key1", 3.14, 'a', 100);
+    map_sdc_i.insert("key2", 2.71, 'b', 200);
+
+    EXPECT_EQ(100, map_sdc_i.at("key1", 3.14, 'a'));
+    EXPECT_TRUE(map_sdc_i.contains("key2", 2.71, 'b'));
+    EXPECT_FALSE(map_sdc_i.contains("key1", 3.14, 'x'));
+}
+
+// Test with custom struct as key
+TEST_F(MultiKeyMapTest, CustomStructKey) {
+    TestKeyStruct k1 = {1, "one", 1.0};
+    TestKeyStruct k2 = {2, "two", 2.0};
+
+    map_cks_d.insert(k1, 100.0);
+    map_cks_d.insert(k2, 200.0);
+
+    ASSERT_EQ(2, map_cks_d.size());
+    EXPECT_DOUBLE_EQ(100.0, map_cks_d.at(k1));
+
+    // Test find with a temporary equivalent key
+    EXPECT_DOUBLE_EQ(200.0, map_cks_d.at({2, "two", 2.0}));
+
+    EXPECT_TRUE(map_cks_d.contains({1, "one", 1.0}));
+    EXPECT_FALSE(map_cks_d.contains({3, "three", 3.0}));
+}
+
+// Test initializer list constructor
+TEST_F(MultiKeyMapTest, InitializerListConstructor) {
+    using KeyTuple = MultiKeyMap<std::string, int, std::string>::KeyTuple;
+    MultiKeyMap<std::string, int, std::string> map_init = {
+        {std::make_tuple(1, "one"), "uno"},
+        {std::make_tuple(2, "two"), "dos"},
+        {KeyTuple{3, "three"}, "tres"} // Another way to create tuple
+    };
+
+    ASSERT_EQ(3, map_init.size());
+    EXPECT_EQ("uno", map_init.at(1, "one"));
+    EXPECT_EQ("dos", map_init.at(2, "two"));
+    EXPECT_EQ("tres", map_init.at_tuple({3, "three"}));
+}
+
+// Test copy constructor
+TEST_F(MultiKeyMapTest, CopyConstructor) {
+    map_is_s.insert(1, "copy", "original_value");
+    MultiKeyMap<std::string, int, std::string> copy_map(map_is_s);
+
+    ASSERT_EQ(1, copy_map.size());
+    EXPECT_EQ("original_value", copy_map.at(1, "copy"));
+    // Ensure modifying copy doesn't affect original
+    copy_map.insert(2, "new", "new_value");
+    EXPECT_EQ(1, map_is_s.size());
+    EXPECT_FALSE(map_is_s.contains(2, "new"));
+}
+
+// Test copy assignment
+TEST_F(MultiKeyMapTest, CopyAssignment) {
+    map_is_s.insert(1, "assign", "val1");
+    MultiKeyMap<std::string, int, std::string> assigned_map;
+    assigned_map.insert(10, "old", "old_val");
+
+    assigned_map = map_is_s;
+    ASSERT_EQ(1, assigned_map.size());
+    EXPECT_EQ("val1", assigned_map.at(1, "assign"));
+    EXPECT_FALSE(assigned_map.contains(10, "old"));
+
+    // Ensure modifying assigned_map doesn't affect original
+    assigned_map.insert(2, "new_in_assigned", "val2");
+    EXPECT_EQ(1, map_is_s.size());
+}
+
+// Test move constructor
+TEST_F(MultiKeyMapTest, MoveConstructor) {
+    map_is_s.insert(1, "move_val", "original_move");
+    MultiKeyMap<std::string, int, std::string> moved_map(std::move(map_is_s));
+
+    ASSERT_EQ(1, moved_map.size());
+    EXPECT_EQ("original_move", moved_map.at(1, "move_val"));
+    // Original map_is_s should be in a valid but unspecified state (likely empty)
+    // EXPECT_TRUE(map_is_s.empty()); // This depends on std::unordered_map move behavior
+}
+
+// Test move assignment
+TEST_F(MultiKeyMapTest, MoveAssignment) {
+    map_is_s.insert(1, "move_assign_val", "val_to_move");
+    MultiKeyMap<std::string, int, std::string> target_map;
+    target_map.insert(100, "target_old", "old_target_val");
+
+    target_map = std::move(map_is_s);
+    ASSERT_EQ(1, target_map.size());
+    EXPECT_EQ("val_to_move", target_map.at(1, "move_assign_val"));
+    EXPECT_FALSE(target_map.contains(100, "target_old"));
+    // EXPECT_TRUE(map_is_s.empty()); // Original map_is_s state
+}
+
+// Test swap
+TEST_F(MultiKeyMapTest, Swap) {
+    map_is_s.insert(1, "map1_key", "map1_val");
+    MultiKeyMap<std::string, int, std::string> map2_is_s;
+    map2_is_s.insert(2, "map2_key", "map2_val");
+
+    map_is_s.swap(map2_is_s);
+
+    EXPECT_TRUE(map_is_s.contains(2, "map2_key"));
+    EXPECT_EQ("map2_val", map_is_s.at(2, "map2_key"));
+    EXPECT_FALSE(map_is_s.contains(1, "map1_key"));
+    EXPECT_EQ(1, map_is_s.size());
+
+    EXPECT_TRUE(map2_is_s.contains(1, "map1_key"));
+    EXPECT_EQ("map1_val", map2_is_s.at(1, "map1_key"));
+    EXPECT_FALSE(map2_is_s.contains(2, "map2_key"));
+    EXPECT_EQ(1, map2_is_s.size());
+
+    // Test non-member swap
+    swap(map_is_s, map2_is_s); // Swap back
+    EXPECT_TRUE(map_is_s.contains(1, "map1_key"));
+    EXPECT_TRUE(map2_is_s.contains(2, "map2_key"));
+}
+
+
+// Test hash policies and bucket interface (basic pass-through checks)
+TEST_F(MultiKeyMapTest, HashPolicyAndBuckets) {
+    map_is_s.insert(1, "a", "1a");
+    map_is_s.insert(2, "b", "2b");
+    map_is_s.insert(3, "c", "3c");
+
+    EXPECT_GT(map_is_s.bucket_count(), 0);
+    EXPECT_NO_THROW(map_is_s.load_factor());
+    EXPECT_NO_THROW(map_is_s.max_load_factor());
+    EXPECT_NO_THROW(map_is_s.max_load_factor(2.0f));
+
+    size_t bucket_for_key = map_is_s.bucket(1, "a");
+    EXPECT_LT(bucket_for_key, map_is_s.bucket_count());
+    EXPECT_GT(map_is_s.bucket_size(bucket_for_key), 0);
+
+    map_is_s.rehash(100);
+    EXPECT_GE(map_is_s.bucket_count(), 100 / map_is_s.max_load_factor());
+
+    map_is_s.reserve(50); // Reserve space for 50 elements
+    // Actual bucket_count change due to reserve is implementation-defined based on load factor
+}
+
+// Test equality operators
+TEST_F(MultiKeyMapTest, EqualityOperators) {
+    MultiKeyMap<std::string, int, std::string> map_a;
+    MultiKeyMap<std::string, int, std::string> map_b;
+
+    map_a.insert(1, "key", "valueA");
+    map_b.insert(1, "key", "valueA");
+    EXPECT_TRUE(map_a == map_b);
+    EXPECT_FALSE(map_a != map_b);
+
+    map_b.insert(2, "key2", "valueB");
+    EXPECT_FALSE(map_a == map_b);
+    EXPECT_TRUE(map_a != map_b);
+
+    map_a.insert(2, "key2", "valueDifferent");
+    EXPECT_FALSE(map_a == map_b); // Different values for same key structure
+
+    map_a.at(2,"key2") = "valueB"; // Make values same
+    EXPECT_TRUE(map_a == map_b);
+}
+
+// Test with empty key set (edge case, though our current design requires at least one KeyType)
+// This test is more conceptual for variadic templates.
+// MultiKeyMap<std::string> map_no_keys; // This would not compile with current design.
+// To support this, KeyTuple would need specialization for empty pack,
+// and TupleHash would need to handle it (e.g. return 0).
+// For now, we assume KeyTypes... is not empty.
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Implements a MultiKeyMap class that allows using multiple heterogeneous keys for an unordered map. It internally uses std::tuple for the composite key and provides a custom TupleHash.

Includes:
- include/multikey_map.h: Header-only implementation.
- examples/multikey_map_example.cpp: Usage example.
- tests/multikey_map_test.cpp: Unit tests.
- docs/README_multikey_map.md: Documentation.

CMakeLists.txt files were not explicitly changed as existing globbing patterns automatically pick up the new example and test files.