### PR TITLE
feat: Implement ValueIndexMap utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,10 @@ target_include_directories(IdPoolLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/inclu
 add_library(FlatMapLib INTERFACE)
 target_include_directories(FlatMapLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define ValueIndexMapLib as an interface library (header-only)
+add_library(ValueIndexMapLib INTERFACE)
+target_include_directories(ValueIndexMapLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -296,6 +300,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         TopNByRatioSelectorLib
         IdPoolLib            # Added for id_pool_example
         FlatMapLib           # Added for flat_map_example
+        ValueIndexMapLib     # Added for value_index_map_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/examples/value_index_map_example.cpp
+++ b/examples/value_index_map_example.cpp
@@ -1,0 +1,129 @@
+#include "../include/value_index_map.h"
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cassert> // For assert()
+
+// A custom struct to demonstrate usage with user-defined types
+struct Port {
+    std::string name;
+    int speed_gbps;
+
+    bool operator==(const Port& other) const {
+        return name == other.name && speed_gbps == other.speed_gbps;
+    }
+};
+
+// Custom hash for Port struct
+struct PortHash {
+    std::size_t operator()(const Port& p) const {
+        return std::hash<std::string>()(p.name) ^ (std::hash<int>()(p.speed_gbps) << 1);
+    }
+};
+
+int main() {
+    std::cout << "--- ValueIndexMap Example ---" << std::endl;
+
+    // Example 1: Using std::string
+    std::cout << "\n--- Example 1: std::string ---" << std::endl;
+    ValueIndexMap<std::string> str_map;
+
+    std::cout << "Inserting 'apple', 'banana', 'cherry'..." << std::endl;
+    size_t idx_apple = str_map.insert("apple");
+    size_t idx_banana = str_map.insert("banana");
+    size_t idx_cherry = str_map.insert("cherry");
+
+    std::cout << "'apple' inserted at index: " << idx_apple << std::endl;
+    std::cout << "'banana' inserted at index: " << idx_banana << std::endl;
+    std::cout << "'cherry' inserted at index: " << idx_cherry << std::endl;
+
+    std::cout << "Current map size: " << str_map.size() << std::endl;
+
+    std::cout << "Index of 'banana': " << str_map.index_of("banana").value_or(-1) << std::endl;
+    if (const std::string* val = str_map.value_at(idx_apple)) {
+        std::cout << "Value at index " << idx_apple << ": " << *val << std::endl;
+    }
+
+    std::cout << "Iterating through map:" << std::endl;
+    for (const auto& str_val : str_map) {
+        std::cout << "  Value: " << str_val << " (Index: " << str_map.index_of(str_val).value() << ")" << std::endl;
+    }
+
+    // Example 2: Using integers
+    std::cout << "\n--- Example 2: int ---" << std::endl;
+    ValueIndexMap<int> int_map;
+    int_map.insert(1001);
+    int_map.insert(2002);
+    int_map.insert(1001); // Idempotent
+
+    std::cout << "Integer map size: " << int_map.size() << std::endl; // Should be 2
+    std::cout << "Index of 2002: " << int_map.index_of(2002).value_or(-1) << std::endl;
+
+    // Example 3: Using Custom Struct (Port) with Custom Hash
+    std::cout << "\n--- Example 3: Custom Struct (Port) ---" << std::endl;
+    ValueIndexMap<Port, PortHash> port_map;
+
+    Port p1 = {"eth0/1", 100};
+    Port p2 = {"eth0/2", 40};
+    Port p3 = {"eth0/1", 100}; // Same as p1
+
+    size_t idx_p1 = port_map.insert(p1);
+    size_t idx_p2 = port_map.insert(p2);
+    size_t idx_p3 = port_map.insert(p3); // Idempotent
+
+    std::cout << "Port map size: " << port_map.size() << std::endl; // Should be 2
+    std::cout << "Index of Port{'eth0/1', 100}: " << port_map.index_of(p1).value_or(-1) << std::endl;
+    assert(idx_p1 == idx_p3);
+
+    if (const Port* port_val = port_map.value_at(idx_p2)) {
+        std::cout << "Value at index " << idx_p2 << ": { Name: " << port_val->name
+                  << ", Speed: " << port_val->speed_gbps << "Gbps }" << std::endl;
+    }
+
+    // Example 4: Serialization and Deserialization
+    std::cout << "\n--- Example 4: Serialization/Deserialization ---" << std::endl;
+    const std::vector<Port>& serialized_ports = port_map.get_values_for_serialization();
+    std::cout << "Serialized data contains " << serialized_ports.size() << " ports." << std::endl;
+
+    ValueIndexMap<Port, PortHash> new_port_map(serialized_ports); // Deserialize
+    std::cout << "Deserialized port map size: " << new_port_map.size() << std::endl;
+    assert(new_port_map.size() == port_map.size());
+    assert(new_port_map.index_of(p1) == port_map.index_of(p1));
+    assert(new_port_map.index_of(p2) == port_map.index_of(p2));
+    std::cout << "Deserialization successful and data matches." << std::endl;
+
+
+    // Example 5: Erase
+    std::cout << "\n--- Example 5: Erase ---" << std::endl;
+    std::cout << "Original str_map elements: ";
+    for(const auto& s : str_map) { std::cout << s << "(" << str_map.index_of(s).value() << ") "; }
+    std::cout << std::endl;
+
+    std::cout << "Erasing 'banana' (index " << str_map.index_of("banana").value() << ")" << std::endl;
+    str_map.erase("banana"); // 'cherry' (idx 2) will move to 'banana's slot (idx 1)
+
+    std::cout << "str_map after erasing 'banana':" << std::endl;
+    for (const auto& str_val : str_map) {
+        std::cout << "  Value: " << str_val << " (Index: " << str_map.index_of(str_val).value() << ")" << std::endl;
+    }
+    assert(str_map.size() == 2);
+    assert(str_map.index_of("apple").value() == 0);
+    assert(str_map.index_of("cherry").value() == 1); // Cherry moved
+
+    // Example 6: Seal
+    std::cout << "\n--- Example 6: Seal ---" << std::endl;
+    std::cout << "Sealing str_map..." << std::endl;
+    str_map.seal();
+    std::cout << "Is str_map sealed? " << (str_map.is_sealed() ? "Yes" : "No") << std::endl;
+
+    std::cout << "Attempting to insert 'date' into sealed map..." << std::endl;
+    try {
+        str_map.insert("date");
+    } catch (const std::logic_error& e) {
+        std::cout << "Caught expected exception: " << e.what() << std::endl;
+    }
+    assert(str_map.size() == 2); // Size should not change
+
+    std::cout << "\n--- ValueIndexMap Example End ---" << std::endl;
+    return 0;
+}

--- a/include/value_index_map.h
+++ b/include/value_index_map.h
@@ -1,0 +1,286 @@
+#ifndef VALUE_INDEX_MAP_H
+#define VALUE_INDEX_MAP_H
+
+#include <vector>
+#include <unordered_map>
+#include <optional>
+#include <stdexcept> // For std::out_of_range (later for sealed exceptions)
+
+// Forward declaration for custom hash/equality later
+template<typename T, typename Hash, typename KeyEqual>
+class ValueIndexMap;
+
+// Default template arguments will be specified in the actual class definition
+template<
+    typename T,
+    typename Hash = std::hash<T>,
+    typename KeyEqual = std::equal_to<T>
+>
+class ValueIndexMap {
+public:
+    // Types
+    using value_type = T;
+    using size_type = size_t;
+    using mapped_type = size_type;
+
+    // Constructors
+    ValueIndexMap() = default;
+
+    // Copy constructor
+    ValueIndexMap(const ValueIndexMap& other)
+        : to_index_(other.to_index_), from_index_(other.from_index_), sealed_(other.sealed_) {}
+
+    // Move constructor
+    ValueIndexMap(ValueIndexMap&& other) noexcept
+        : to_index_(std::move(other.to_index_)),
+          from_index_(std::move(other.from_index_)),
+          sealed_(other.sealed_) {
+        other.sealed_ = false; // Reset moved-from object state
+    }
+
+    // Copy assignment
+    ValueIndexMap& operator=(const ValueIndexMap& other) {
+        if (this != &other) {
+            to_index_ = other.to_index_;
+            from_index_ = other.from_index_;
+            sealed_ = other.sealed_;
+        }
+        return *this;
+    }
+
+    // Move assignment
+    ValueIndexMap& operator=(ValueIndexMap&& other) noexcept {
+        if (this != &other) {
+            // If 'this' is sealed, this operation effectively replaces its state.
+            // The sealed status of 'this' will become that of 'other'.
+            to_index_ = std::move(other.to_index_);
+            from_index_ = std::move(other.from_index_);
+            sealed_ = other.sealed_; // Adopt sealed state from source
+
+            // Clear other to a valid, default-constructed state
+            // No need to check other.sealed_ before clearing, as it's being gutted.
+            other.to_index_.clear();
+            other.from_index_.clear();
+            other.sealed_ = false; // Moved-from object is no longer sealed and is empty.
+        }
+        return *this;
+    }
+
+    // Serialization: Returns a const reference to the internal vector of values.
+    // This vector alone is sufficient to reconstruct the map.
+    const std::vector<T>& get_values_for_serialization() const {
+        return from_index_;
+    }
+
+    // Deserialization: Constructor from a vector of values (copying version)
+    // Assumes values are unique and their order defines their index.
+    explicit ValueIndexMap(const std::vector<T>& values)
+        : sealed_(false) // A deserialized map is not sealed by default
+    {
+        from_index_.reserve(values.size());
+        to_index_.reserve(values.size());
+        for (const auto& value : values) {
+            size_type new_index = from_index_.size();
+            from_index_.push_back(value);
+            // Check for duplicates during deserialization
+            if (!to_index_.emplace(from_index_.back(), new_index).second) {
+                // Rollback partial construction and throw
+                from_index_.clear();
+                to_index_.clear();
+                throw std::invalid_argument("Duplicate value found in input vector during deserialization. Values must be unique.");
+            }
+        }
+    }
+
+    // Deserialization: Constructor from a vector of values (moving version)
+    // Assumes values are unique and their order defines their index.
+    explicit ValueIndexMap(std::vector<T>&& values)
+        : from_index_(std::move(values)), // Move the input vector
+          sealed_(false) // A deserialized map is not sealed by default
+    {
+        to_index_.reserve(from_index_.size());
+        for (size_type i = 0; i < from_index_.size(); ++i) {
+            // Use the value already in from_index_ (which was moved)
+            // Check for duplicates during deserialization
+            if (!to_index_.emplace(from_index_[i], i).second) {
+                // Rollback partial construction and throw
+                // Note: from_index_ still holds the moved data, but map is inconsistent.
+                // Clearing them ensures a clean state for the exception.
+                from_index_.clear();
+                to_index_.clear();
+                throw std::invalid_argument("Duplicate value found in input vector during deserialization. Values must be unique.");
+            }
+        }
+    }
+
+    // Insert or retrieve index
+    size_type insert(const T& value) {
+        if (sealed_) {
+            // Behavior for sealed map will be defined in step 2
+            // For now, let's throw or handle error appropriately
+            throw std::logic_error("Map is sealed, cannot insert new values.");
+        }
+        auto it = to_index_.find(value);
+        if (it != to_index_.end()) {
+            return it->second; // Value already exists, return its index
+        }
+
+        size_type new_index = from_index_.size();
+        from_index_.push_back(value);
+        to_index_[value] = new_index; // Or to_index_.emplace(value, new_index);
+        return new_index;
+    }
+
+    // Overload for rvalue references to allow moving values into the map
+    size_type insert(T&& value) {
+        if (sealed_) {
+            throw std::logic_error("Map is sealed, cannot insert new values.");
+        }
+        auto it = to_index_.find(value); // Find requires const T&, so value is fine
+        if (it != to_index_.end()) {
+            return it->second;
+        }
+
+        size_type new_index = from_index_.size();
+        // Use emplace_back for potential move efficiency if T is movable
+        from_index_.emplace_back(std::move(value));
+        // After moving `value` into `from_index_`, we need to insert into `to_index_`
+        // using the instance now stored in `from_index_` to ensure consistency
+        // if `value` itself was a proxy or if its state changed upon move.
+        // However, `unordered_map` keys are typically copied/moved on insertion.
+        // The key for `to_index_` should be equivalent to what's in `from_index_`.
+        // `from_index_.back()` gives access to the moved-in value.
+        to_index_[from_index_.back()] = new_index;
+        return new_index;
+    }
+
+
+    // Query if present
+    std::optional<size_type> index_of(const T& value) const {
+        auto it = to_index_.find(value);
+        if (it != to_index_.end()) {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+
+    // Reverse lookup
+    const T* value_at(size_type index) const {
+        if (index < from_index_.size()) {
+            return &from_index_[index];
+        }
+        return nullptr; // Out of range
+    }
+
+    // State queries
+    bool contains(const T& value) const {
+        return to_index_.count(value) > 0;
+    }
+
+    size_type size() const {
+        return from_index_.size();
+    }
+
+    bool empty() const {
+        return from_index_.empty();
+    }
+
+    void clear() {
+        if (sealed_) {
+            throw std::logic_error("Map is sealed, cannot clear.");
+        }
+        to_index_.clear();
+        from_index_.clear();
+        // Note: clearing does not unseal the map.
+        // If unsealing is desired, `sealed_` should be set to false here.
+        // Current behavior: a sealed map, if clearable (e.g. by relaxing the check), would remain sealed but empty.
+        // As implemented, a sealed map cannot be cleared.
+    }
+
+    // Seal functionality
+    void seal() {
+        sealed_ = true;
+    }
+
+    bool is_sealed() const {
+        return sealed_;
+    }
+
+    // Erase functionality
+    // Returns true if an element was erased, false otherwise.
+    // Note on index stability: Erasing an element causes the element previously
+    // at the end of the map to move into the erased element's slot. The index of
+    // this moved element changes. Indices of other elements remain stable.
+    bool erase(const T& value) {
+        if (sealed_) {
+            throw std::logic_error("Map is sealed, cannot erase values.");
+        }
+        auto it = to_index_.find(value);
+        if (it == to_index_.end()) {
+            return false; // Value not found
+        }
+        size_type index_to_erase = it->second;
+        return erase_at_index(index_to_erase); // Call helper
+    }
+
+    bool erase_at_index(size_type index) {
+        if (sealed_) {
+            throw std::logic_error("Map is sealed, cannot erase values.");
+        }
+        if (index >= from_index_.size()) {
+            // Or throw std::out_of_range("Index out of bounds for erase_at_index");
+            return false; // Index out of bounds
+        }
+
+        // Value to be removed from to_index_
+        // Important: get a copy or reference BEFORE it's potentially overwritten in from_index_
+        T value_to_remove = from_index_[index];
+
+        if (index < from_index_.size() - 1) {
+            // Not the last element, so swap with the last element
+            T& last_value = from_index_.back(); // Reference to the last element
+            from_index_[index] = std::move(last_value); // Move last element to the erased slot
+            to_index_[from_index_[index]] = index; // Update index for the moved element
+                                                 // (use from_index_[index] as key in case T is complex)
+        }
+        // Whether it was the last element or not, now pop the last one
+        from_index_.pop_back();
+
+        // Remove the original value (that was targeted for erasure) from to_index_
+        size_t num_erased_from_map = to_index_.erase(value_to_remove);
+
+        // num_erased_from_map should be 1 if logic is correct and value_to_remove was indeed in to_index_
+        // If value_to_remove was somehow not in to_index_ but its index was valid,
+        // that would indicate an inconsistent state. For robustness, one might assert(num_erased_from_map > 0).
+        return num_erased_from_map > 0; // Or simply return true if we reached here successfully.
+    }
+
+
+    // Iterator Support
+    // All iterators are const_iterators to prevent modification of values
+    // in from_index_ which are used as keys in to_index_.
+    using const_iterator = typename std::vector<T>::const_iterator;
+
+    const_iterator begin() const {
+        return from_index_.cbegin();
+    }
+
+    const_iterator end() const {
+        return from_index_.cend();
+    }
+
+    const_iterator cbegin() const {
+        return from_index_.cbegin();
+    }
+
+    const_iterator cend() const {
+        return from_index_.cend();
+    }
+
+private:
+    std::unordered_map<T, size_type, Hash, KeyEqual> to_index_;
+    std::vector<T> from_index_;
+    bool sealed_ = false;
+};
+
+#endif // VALUE_INDEX_MAP_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         TopNByRatioSelectorLib
         IdPoolLib            # Added for id_pool_test
         FlatMapLib           # Added for flat_map_test
+        ValueIndexMapLib     # Added for value_index_map_test
     )
 
     # Specific configurations for certain tests

--- a/tests/value_index_map_test.cpp
+++ b/tests/value_index_map_test.cpp
@@ -1,0 +1,399 @@
+#include "../include/value_index_map.h"
+#include "gtest/gtest.h" // Google Test header
+#include <string>
+#include <vector>
+#include <optional>
+#include <stdexcept> // For std::logic_error etc.
+
+// Test fixture for ValueIndexMap tests, if needed for setup/teardown
+class ValueIndexMapTest : public ::testing::Test {
+protected:
+    // Per-test-suite set-up.
+    // Called before the first test in this test suite.
+    // Can be static if shared resources are static.
+    static void SetUpTestSuite() {}
+
+    // Per-test-suite tear-down.
+    // Called after the last test in this test suite.
+    // Can be static if shared resources are static.
+    static void TearDownTestSuite() {}
+
+    // You can define per-test set-up and tear-down logic as usual.
+    void SetUp() override {
+        // Code here will be called immediately after the constructor (right
+        // before each test).
+    }
+
+    void TearDown() override {
+        // Code here will be called immediately after each test (right
+        // before the destructor).
+    }
+};
+
+TEST_F(ValueIndexMapTest, BasicOperationsInt) {
+    ValueIndexMap<int> map;
+    ASSERT_EQ(map.size(), 0);
+    ASSERT_TRUE(map.empty());
+
+    size_t idx1 = map.insert(100);
+    ASSERT_EQ(idx1, 0);
+    ASSERT_EQ(map.size(), 1);
+    ASSERT_FALSE(map.empty());
+    ASSERT_TRUE(map.contains(100));
+    ASSERT_FALSE(map.contains(200));
+    ASSERT_EQ(map.index_of(100).value_or(-1), idx1);
+    ASSERT_NE(map.value_at(idx1), nullptr);
+    ASSERT_EQ(*map.value_at(idx1), 100);
+
+    size_t idx2 = map.insert(200);
+    ASSERT_EQ(idx2, 1);
+    ASSERT_EQ(map.size(), 2);
+    ASSERT_TRUE(map.contains(200));
+    ASSERT_EQ(map.index_of(200).value_or(-1), idx2);
+    ASSERT_NE(map.value_at(idx2), nullptr);
+    ASSERT_EQ(*map.value_at(idx2), 200);
+
+    // Idempotency
+    size_t idx1_again = map.insert(100);
+    ASSERT_EQ(idx1_again, idx1);
+    ASSERT_EQ(map.size(), 2); // Size should not change
+
+    // value_at out of bounds
+    ASSERT_EQ(map.value_at(map.size()), nullptr);
+    ASSERT_EQ(map.value_at(99), nullptr);
+
+    // index_of non-existent
+    ASSERT_FALSE(map.index_of(300).has_value());
+}
+
+TEST_F(ValueIndexMapTest, BasicOperationsString) {
+    ValueIndexMap<std::string> map;
+    ASSERT_EQ(map.size(), 0);
+
+    size_t idx_apple = map.insert("apple");
+    ASSERT_EQ(idx_apple, 0);
+    ASSERT_EQ(map.size(), 1);
+    ASSERT_TRUE(map.contains("apple"));
+    ASSERT_EQ(map.index_of("apple").value_or(-1), idx_apple);
+    ASSERT_NE(map.value_at(idx_apple), nullptr);
+    ASSERT_EQ(*map.value_at(idx_apple), "apple");
+
+    size_t idx_banana = map.insert("banana");
+    ASSERT_EQ(idx_banana, 1);
+    ASSERT_EQ(map.size(), 2);
+
+    // Move semantics for insert
+    std::string orange_str = "orange";
+    size_t idx_orange = map.insert(std::move(orange_str));
+    ASSERT_EQ(idx_orange, 2);
+    ASSERT_EQ(map.size(), 3);
+    ASSERT_TRUE(map.contains("orange"));
+    ASSERT_NE(map.value_at(idx_orange), nullptr);
+    ASSERT_EQ(*map.value_at(idx_orange), "orange");
+    // orange_str is in a valid but unspecified state (likely empty)
+    // EXPECT_TRUE(orange_str.empty()); // This behavior depends on std::string move
+}
+
+TEST_F(ValueIndexMapTest, Clear) {
+    ValueIndexMap<int> map;
+    map.insert(10);
+    map.insert(20);
+    ASSERT_EQ(map.size(), 2);
+    map.clear();
+    ASSERT_EQ(map.size(), 0);
+    ASSERT_TRUE(map.empty());
+    ASSERT_FALSE(map.contains(10));
+    ASSERT_FALSE(map.index_of(10).has_value());
+    ASSERT_EQ(map.value_at(0), nullptr);
+
+    // Insert after clear
+    size_t idx = map.insert(30);
+    ASSERT_EQ(idx, 0);
+    ASSERT_EQ(map.size(), 1);
+    ASSERT_TRUE(map.contains(30));
+}
+
+TEST_F(ValueIndexMapTest, Seal) {
+    ValueIndexMap<int> map;
+    map.insert(1);
+    map.seal();
+    ASSERT_TRUE(map.is_sealed());
+
+    ASSERT_THROW(map.insert(2), std::logic_error);
+    ASSERT_EQ(map.size(), 1); // Size should not change
+
+    ASSERT_THROW(map.clear(), std::logic_error);
+    ASSERT_EQ(map.size(), 1); // Size should not change
+
+    // Reads should still work
+    ASSERT_TRUE(map.contains(1));
+    ASSERT_EQ(map.index_of(1).value_or(-1), 0);
+    ASSERT_NE(map.value_at(0), nullptr);
+    ASSERT_EQ(*map.value_at(0), 1);
+}
+
+TEST_F(ValueIndexMapTest, Iterators) {
+    ValueIndexMap<std::string> map;
+    map.insert("first");
+    map.insert("second");
+    map.insert("third");
+
+    std::vector<std::string> expected_values = {"first", "second", "third"};
+    size_t i = 0;
+    for (const auto& val : map) { // Uses map.begin(), map.end()
+        ASSERT_LT(i, expected_values.size());
+        ASSERT_EQ(val, expected_values[i]);
+        i++;
+    }
+    ASSERT_EQ(i, expected_values.size());
+
+    // Test cbegin/cend
+    i = 0;
+    for (auto it = map.cbegin(); it != map.cend(); ++it) {
+        ASSERT_LT(i, expected_values.size());
+        ASSERT_EQ(*it, expected_values[i]);
+        i++;
+    }
+    ASSERT_EQ(i, expected_values.size());
+
+    ValueIndexMap<int> empty_map;
+    int count = 0;
+    for (const auto& val : empty_map) {
+        count++;
+    }
+    ASSERT_EQ(count, 0);
+    ASSERT_TRUE(std::begin(empty_map) == std::end(empty_map));
+}
+
+TEST_F(ValueIndexMapTest, SerializationDeserialization) {
+    ValueIndexMap<std::string> original_map;
+    original_map.insert("one");
+    original_map.insert("two");
+    original_map.insert("three");
+
+    const std::vector<std::string>& serialized_data = original_map.get_values_for_serialization();
+    ASSERT_EQ(serialized_data.size(), 3);
+
+    // Deserialize using copy constructor
+    ValueIndexMap<std::string> map_from_copy(serialized_data);
+    ASSERT_EQ(map_from_copy.size(), 3);
+    ASSERT_EQ(map_from_copy.index_of("one").value_or(-1), 0);
+    ASSERT_EQ(map_from_copy.index_of("two").value_or(-1), 1);
+    ASSERT_EQ(map_from_copy.index_of("three").value_or(-1), 2);
+    ASSERT_NE(map_from_copy.value_at(1), nullptr);
+    ASSERT_EQ(*map_from_copy.value_at(1), "two");
+
+    // Deserialize using move constructor
+    std::vector<std::string> data_to_move = {"alpha", "beta", "gamma"};
+    ValueIndexMap<std::string> map_from_move(std::move(data_to_move));
+    // data_to_move is in a valid but unspecified state (likely empty)
+    ASSERT_TRUE(data_to_move.empty() || data_to_move.capacity() == 0);
+    ASSERT_EQ(map_from_move.size(), 3);
+    ASSERT_EQ(map_from_move.index_of("alpha").value_or(-1), 0);
+    ASSERT_EQ(map_from_move.index_of("beta").value_or(-1), 1);
+    ASSERT_EQ(map_from_move.index_of("gamma").value_or(-1), 2);
+
+    // Test deserialization with duplicates in input (should throw)
+    std::vector<std::string> duplicate_data = {"x", "y", "x"};
+    ASSERT_THROW(ValueIndexMap<std::string> map_dup(duplicate_data), std::invalid_argument);
+
+    std::vector<std::string> duplicate_data_to_move = {"x", "y", "x"};
+    ASSERT_THROW(ValueIndexMap<std::string> map_dup_move(std::move(duplicate_data_to_move)), std::invalid_argument);
+}
+
+TEST_F(ValueIndexMapTest, Erase) {
+    ValueIndexMap<std::string> map;
+    map.insert("a"); // 0
+    map.insert("b"); // 1
+    map.insert("c"); // 2
+    map.insert("d"); // 3
+    map.insert("e"); // 4
+    ASSERT_EQ(map.size(), 5);
+
+    // Erase by value (middle)
+    ASSERT_TRUE(map.erase("c")); // "c" at index 2. "e" (last) moves to index 2.
+    ASSERT_EQ(map.size(), 4);
+    ASSERT_FALSE(map.contains("c"));
+    ASSERT_FALSE(map.index_of("c").has_value());
+    ASSERT_TRUE(map.contains("e"));
+    ASSERT_EQ(map.index_of("e").value_or(-1), 2); // "e" moved from index 4 to 2
+    ASSERT_NE(map.value_at(2), nullptr);
+    ASSERT_EQ(*map.value_at(2), "e");
+    ASSERT_EQ(map.index_of("d").value_or(-1), 3); // "d" should be unaffected
+
+    // Erase by value (actual last element)
+    // Current state: a(0), b(1), e(2), d(3)
+    ASSERT_TRUE(map.erase("d")); // "d" at index 3 (last)
+    ASSERT_EQ(map.size(), 3);
+    ASSERT_FALSE(map.contains("d"));
+    ASSERT_EQ(map.index_of("e").value_or(-1), 2); // "e" unaffected
+
+    // Erase by value (first element)
+    // Current state: a(0), b(1), e(2)
+    ASSERT_TRUE(map.erase("a")); // "a" at index 0. "e" (last) moves to index 0
+    ASSERT_EQ(map.size(), 2);
+    ASSERT_FALSE(map.contains("a"));
+    ASSERT_TRUE(map.contains("e"));
+    ASSERT_EQ(map.index_of("e").value_or(-1), 0); // "e" moved from index 2 to 0
+    ASSERT_NE(map.value_at(0), nullptr);
+    ASSERT_EQ(*map.value_at(0), "e");
+    ASSERT_EQ(map.index_of("b").value_or(-1), 1); // "b" unaffected
+
+    // Erase non-existent value
+    ASSERT_FALSE(map.erase("z"));
+    ASSERT_EQ(map.size(), 2);
+
+    // Erase by index
+    // Current state: e(0), b(1)
+    ASSERT_TRUE(map.erase_at_index(0)); // Erase "e". "b" (last) moves to index 0
+    ASSERT_EQ(map.size(), 1);
+    ASSERT_FALSE(map.contains("e"));
+    ASSERT_TRUE(map.contains("b"));
+    ASSERT_EQ(map.index_of("b").value_or(-1), 0);
+    ASSERT_NE(map.value_at(0), nullptr);
+    ASSERT_EQ(*map.value_at(0), "b");
+
+    // Erase last remaining element by index
+    ASSERT_TRUE(map.erase_at_index(0));
+    ASSERT_EQ(map.size(), 0);
+    ASSERT_TRUE(map.empty());
+
+    // Erase from empty map
+    ASSERT_FALSE(map.erase("any"));
+    ASSERT_FALSE(map.erase_at_index(0));
+
+    // Seal and erase
+    map.insert("final");
+    map.seal();
+    ASSERT_THROW(map.erase("final"), std::logic_error);
+    ASSERT_THROW(map.erase_at_index(0), std::logic_error);
+    ASSERT_EQ(map.size(), 1);
+}
+
+// Custom struct for testing custom hash/equality
+struct CustomType {
+    int id;
+    std::string data;
+
+    bool operator==(const CustomType& other) const {
+        return id == other.id && data == other.data;
+    }
+};
+
+// Custom hash for CustomType
+struct CustomTypeHash {
+    std::size_t operator()(const CustomType& ct) const {
+        // Simple hash combination
+        return std::hash<int>()(ct.id) ^ (std::hash<std::string>()(ct.data) << 1);
+    }
+};
+
+TEST_F(ValueIndexMapTest, CustomHashEquality) {
+    ValueIndexMap<CustomType, CustomTypeHash> map;
+
+    CustomType val1 = {1, "hello"};
+    CustomType val2 = {2, "world"};
+    CustomType val1_again = {1, "hello"}; // Same as val1
+
+    size_t idx1 = map.insert(val1);
+    ASSERT_EQ(idx1, 0);
+    ASSERT_EQ(map.size(), 1);
+    ASSERT_TRUE(map.contains(val1));
+    ASSERT_TRUE(map.index_of(val1).has_value());
+    ASSERT_EQ(map.index_of(val1).value(), idx1);
+    ASSERT_NE(map.value_at(idx1), nullptr);
+    EXPECT_EQ(map.value_at(idx1)->id, 1);
+    EXPECT_EQ(map.value_at(idx1)->data, "hello");
+
+
+    size_t idx2 = map.insert(val2);
+    ASSERT_EQ(idx2, 1);
+    ASSERT_EQ(map.size(), 2);
+
+    size_t idx1_check = map.insert(val1_again); // Should be idempotent
+    ASSERT_EQ(idx1_check, idx1);
+    ASSERT_EQ(map.size(), 2);
+
+    ASSERT_TRUE(map.contains({1, "hello"}));
+    ASSERT_FALSE(map.contains({3, "test"}));
+}
+
+TEST_F(ValueIndexMapTest, CopyMoveSemantics) {
+    ValueIndexMap<std::string> map1;
+    map1.insert("one");
+    map1.insert("two");
+
+    // Copy constructor
+    ValueIndexMap<std::string> map2 = map1;
+    ASSERT_EQ(map2.size(), 2);
+    EXPECT_TRUE(map2.contains("one") && map2.contains("two"));
+    ASSERT_EQ(map1.size(), 2); // map1 unchanged
+
+    // Copy assignment
+    ValueIndexMap<std::string> map3;
+    map3.insert("temp");
+    map3 = map1;
+    ASSERT_EQ(map3.size(), 2);
+    EXPECT_TRUE(map3.contains("one") && map3.contains("two"));
+    ASSERT_EQ(map1.size(), 2); // map1 unchanged
+
+    // Move constructor
+    ValueIndexMap<std::string> map4 = std::move(map1);
+    ASSERT_EQ(map4.size(), 2);
+    EXPECT_TRUE(map4.contains("one") && map4.contains("two"));
+    // map1 is in a valid but unspecified state (likely empty)
+    EXPECT_TRUE(map1.empty() || map1.size()==0);
+
+    // Re-initialize map1 for move assignment test
+    map1.insert("three"); // map1 might be empty or already cleared by move. This ensures it has content.
+    map1.insert("four");
+    ASSERT_EQ(map1.size(), 2);
+
+    // Move assignment
+    ValueIndexMap<std::string> map5;
+    map5.insert("another temp");
+    map5 = std::move(map1);
+    ASSERT_EQ(map5.size(), 2);
+    EXPECT_TRUE(map5.contains("three") && map5.contains("four"));
+    EXPECT_TRUE(map1.empty() || map1.size()==0);
+
+    // Test sealed status with copy/move
+    ValueIndexMap<int> sealed_orig;
+    sealed_orig.insert(100);
+    sealed_orig.seal();
+    ASSERT_TRUE(sealed_orig.is_sealed());
+
+    ValueIndexMap<int> sealed_copy_ctor = sealed_orig;
+    EXPECT_TRUE(sealed_copy_ctor.is_sealed());
+    ASSERT_EQ(sealed_copy_ctor.size(), 1);
+    ASSERT_THROW(sealed_copy_ctor.insert(200), std::logic_error);
+
+    ValueIndexMap<int> sealed_assign;
+    sealed_assign = sealed_orig; // Assign from sealed_orig
+    EXPECT_TRUE(sealed_assign.is_sealed());
+    ASSERT_EQ(sealed_assign.size(), 1);
+    ASSERT_THROW(sealed_assign.insert(200), std::logic_error);
+
+    ValueIndexMap<int> sealed_move_ctor = std::move(sealed_copy_ctor); // move from a sealed copy
+    EXPECT_TRUE(sealed_move_ctor.is_sealed());
+    ASSERT_EQ(sealed_move_ctor.size(), 1);
+    ASSERT_THROW(sealed_move_ctor.insert(300), std::logic_error);
+    // sealed_copy_ctor should be empty and not sealed
+    EXPECT_FALSE(sealed_copy_ctor.is_sealed());
+    EXPECT_TRUE(sealed_copy_ctor.empty());
+
+
+    ValueIndexMap<int> sealed_move_assign;
+    sealed_move_assign = std::move(sealed_assign); // move from another sealed copy
+    EXPECT_TRUE(sealed_move_assign.is_sealed());
+    ASSERT_EQ(sealed_move_assign.size(), 1);
+    ASSERT_THROW(sealed_move_assign.insert(300), std::logic_error);
+    // sealed_assign should be empty and not sealed
+    EXPECT_FALSE(sealed_assign.is_sealed());
+    EXPECT_TRUE(sealed_assign.empty());
+}
+
+// It's good practice to have a main function in one of your test files,
+// or link with gtest_main. CMake setup in tests/CMakeLists.txt handles this
+// by linking with GTest::gtest_main.
+// So, no main() function is needed here.


### PR DESCRIPTION
Implements a bijective value-to-index mapping utility `ValueIndexMap<T>`.

Features:
- Efficient O(1) lookup for value -> index and index -> value.
- Stable indexing (indices don't change, except for the moved element during erase).
- Idempotent `insert()`.
- `seal()` method to make the map immutable.
- Serialization (`get_values_for_serialization()`) and deserialization (constructors from `std::vector<T>`).
- Iterator support (const_iterators over values in insertion order).
- `erase(const T&)` and `erase_at_index(size_type)` using swap-and-pop.
- Support for custom hash and equality comparators for type T.
- Header-only (`include/value_index_map.h`).
- C++17 compatible.

Includes:
- Comprehensive unit tests in `tests/value_index_map_test.cpp` using Google Test.
- Example usage in `examples/value_index_map_example.cpp`.
- Updates to CMakeLists.txt to integrate the new library, example, and tests.