### PR TITLE
Disable InstrumentedRingBufferTest.PeakSizeTracking

### DIFF
--- a/tests/instrumented_ring_buffer_test.cpp
+++ b/tests/instrumented_ring_buffer_test.cpp
@@ -389,7 +389,7 @@ TEST_F(InstrumentedRingBufferTest, MultiProducerMultiConsumer_Minimal) { // Rena
     EXPECT_LE(buffer.get_peak_size(), buffer.capacity());
 }
 
-TEST_F(InstrumentedRingBufferTest, PeakSizeTracking) {
+TEST_F(InstrumentedRingBufferTest, DISABLED_PeakSizeTracking) {
     InstrumentedRingBuffer<int> buffer(5);
     EXPECT_EQ(buffer.get_peak_size(), 0);
 


### PR DESCRIPTION
The test InstrumentedRingBufferTest.PeakSizeTracking was reported as stuck. After careful review, no obvious logical errors were found in the test itself or in the peak size tracking mechanism of the InstrumentedRingBuffer class for single-threaded scenarios.

As per instructions, the test has been disabled by renaming it to DISABLED_PeakSizeTracking.