### PR TITLE
feat: Implement InvertedIndex container

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,9 @@ target_include_directories(FlatMapLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/incl
 add_library(ValueIndexMapLib INTERFACE)
 target_include_directories(ValueIndexMapLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define InvertedIndexLib as an interface library (header-only)
+add_library(InvertedIndexLib INTERFACE)
+target_include_directories(InvertedIndexLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Define OneOfLib as an interface library (header-only)
 add_library(OneOfLib INTERFACE)
@@ -314,6 +317,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         IdPoolLib            # Added for id_pool_example
         FlatMapLib           # Added for flat_map_example
         ValueIndexMapLib     # Added for value_index_map_example
+        InvertedIndexLib     # Added for inverted_index_example
         OneOfLib             # Added for one_of_example
         ChronoRingLib        # Added for chrono_ring_example
     )

--- a/docs/README_inverted_index.md
+++ b/docs/README_inverted_index.md
@@ -1,0 +1,236 @@
+# `InvertedIndex<Key, Value, HashKey, EqualKey, HashValue, EqualValue>`
+
+## Overview
+
+`InvertedIndex` is a header-only C++17 utility that provides a bi-directional, reverse multi-mapping container. It allows efficient management and querying of many-to-many relationships between keys and values.
+
+Essentially, it maintains two internal maps:
+1.  **Forward Map**: `Key → Set<Value>` (e.g., a document maps to a set of tags)
+2.  **Reverse Map**: `Value → Set<Key>` (e.g., a tag maps to a set of documents that have it)
+
+This structure enables quick lookups in both directions: finding all values associated with a key, and finding all keys associated with a value.
+
+## Motivation
+
+In many systems, managing relationships where an entity can be associated with multiple other entities (and vice-versa) is common. Examples include:
+*   Documents and tags
+*   Users and groups
+*   Products and categories/features
+*   Nodes in a graph and their neighbors (for undirected edges)
+
+While `std::unordered_multimap` can handle one-to-many mappings, it doesn't inherently provide an efficient reverse lookup. `InvertedIndex` addresses this by explicitly storing and maintaining both forward and reverse mappings, ensuring that operations like finding "all documents for a tag" are as efficient as finding "all tags for a document."
+
+## Use Cases
+
+*   **Search Engines**: Mapping words to document IDs containing them.
+*   **Tagging Systems**: Associating items (documents, images, posts) with multiple descriptive tags.
+*   **Classification Systems**: Mapping labels to object IDs that fall under that label.
+*   **Recommendation Engines**: Linking users to items they've interacted with, and items to users who've interacted with them.
+*   **Graph-like Structures**: Representing bi-directional relationships between nodes.
+*   **Entity-Attribute Systems**: Finding all entities that possess a certain attribute.
+
+## Features
+
+*   **Bi-directional Mapping**: Efficiently query `Key → Set<Value>` and `Value → Set<Key>`.
+*   **Header-Only**: Easy to integrate by just including `inverted_index.h`.
+*   **C++17**: Utilizes modern C++ features.
+*   **Customizable Hashing/Equality**: Supports custom hash functions and equality predicates for both `Key` and `Value` types via template parameters.
+*   **Value Semantics**: Supports copy and move construction/assignment.
+*   **Efficient Operations**: Most operations (add, remove, lookup) are amortized O(1) on average, thanks to the underlying `std::unordered_map` and `std::unordered_set`.
+
+## API
+
+```cpp
+template <
+    typename Key,
+    typename Value,
+    typename HashKey = std::hash<Key>,
+    typename EqualKey = std::equal_to<Key>,
+    typename HashValue = std::hash<Value>,
+    typename EqualValue = std::equal_to<Value>
+>
+class InvertedIndex {
+public:
+    // --- Type Aliases ---
+    using KeySet = std::unordered_set<Key, HashKey, EqualKey>;
+    using ValueSet = std::unordered_set<Value, HashValue, EqualValue>;
+
+    // --- Constructors ---
+    InvertedIndex(); // Default constructor
+
+    // Copy semantics
+    InvertedIndex(const InvertedIndex& other);
+    InvertedIndex& operator=(const InvertedIndex& other);
+
+    // Move semantics
+    InvertedIndex(InvertedIndex&& other) noexcept;
+    InvertedIndex& operator=(InvertedIndex&& other) noexcept;
+
+    // --- Core Methods ---
+
+    // Adds a mapping between key and value.
+    // Updates both forward (key -> {value, ...}) and reverse (value -> {key, ...}) maps.
+    // Idempotent: adding an existing mapping has no effect.
+    void add(const Key& key, const Value& value);
+
+    // Removes a specific mapping between key and value.
+    // If this causes a key to have no more values, the key is removed from the forward map.
+    // If this causes a value to have no more keys, the value is removed from the reverse map.
+    void remove(const Key& key, const Value& value);
+
+    // Removes a key and all its associated value mappings.
+    // For each value previously mapped to this key, the key is removed from that value's reverse mapping.
+    // If any such value then has no more associated keys, it is removed from the reverse map.
+    void remove_key(const Key& key);
+
+    // Removes a value and all its associated key mappings.
+    // For each key previously mapped to this value, the value is removed from that key's forward mapping.
+    // If any such key then has no more associated values, it is removed from the forward map.
+    void remove_value(const Value& value);
+
+    // Returns a const reference to the set of values associated with the given key.
+    // If the key does not exist, returns a const reference to a static empty ValueSet.
+    const ValueSet& values_for(const Key& key) const;
+
+    // Returns a const reference to the set of keys associated with the given value.
+    // If the value does not exist, returns a const reference to a static empty KeySet.
+    const KeySet& keys_for(const Value& value) const;
+
+    // Checks if a specific mapping between key and value exists.
+    // Returns true if key is mapped to value, false otherwise.
+    bool contains(const Key& key, const Value& value) const;
+
+    // Checks if the InvertedIndex contains any mappings.
+    // Returns true if empty, false otherwise.
+    bool empty() const;
+
+    // Removes all keys, values, and mappings from the InvertedIndex.
+    void clear();
+
+    // --- Iteration ---
+    // Provides const iterators to traverse the forward_map_ (Key -> ValueSet).
+    typename std::unordered_map<Key, ValueSet, HashKey, EqualKey>::const_iterator begin() const;
+    typename std::unordered_map<Key, ValueSet, HashKey, EqualKey>::const_iterator end() const;
+
+    // --- Size Information ---
+    // Returns the number of unique keys in the index.
+    size_t key_count() const;
+
+public: // Note: These are public for testing, typically would be private.
+    static const KeySet EMPTY_KEY_SET;
+    static const ValueSet EMPTY_VALUE_SET;
+};
+```
+
+### Template Parameters
+
+*   `Key`: The type of the keys.
+*   `Value`: The type of the values.
+*   `HashKey`: Hash function for `Key`. Defaults to `std::hash<Key>`.
+*   `EqualKey`: Equality comparison for `Key`. Defaults to `std::equal_to<Key>`.
+*   `HashValue`: Hash function for `Value`. Defaults to `std::hash<Value>`.
+*   `EqualValue`: Equality comparison for `Value`. Defaults to `std::equal_to<Value>`.
+
+You only need to specify custom hash/equality functors if the default `std::hash` or `std::equal_to` are not suitable for your `Key` or `Value` types (e.g., for custom structs without `std::hash` specializations).
+
+## Internal Structure
+
+The `InvertedIndex` internally uses two primary data structures:
+
+*   `forward_map_`: An `std::unordered_map<Key, ValueSet, HashKey, EqualKey>`
+    *   Maps each `Key` to an `std::unordered_set<Value, HashValue, EqualValue>` of its associated values.
+*   `reverse_map_`: An `std::unordered_map<Value, KeySet, HashValue, EqualValue>`
+    *   Maps each `Value` to an `std::unordered_set<Key, HashKey, EqualKey>` of its associated keys.
+
+```mermaid
+graph TD
+    subgraph InvertedIndex
+        direction LR
+        subgraph ForwardMap ["forward_map_ (Key -> Set<Value>)"]
+            direction LR
+            K1["Key1"] --> VS1["{ValA, ValB}"]
+            K2["Key2"] --> VS2["{ValB, ValC}"]
+        end
+        subgraph ReverseMap ["reverse_map_ (Value -> Set<Key>)"]
+            direction LR
+            VA["ValA"] --> KS_A["{Key1}"]
+            VB["ValB"] --> KS_B["{Key1, Key2}"]
+            VC["ValC"] --> KS_C["{Key2}"]
+        end
+    end
+
+    style ForwardMap fill:#f9f,stroke:#333,stroke-width:2px
+    style ReverseMap fill:#ccf,stroke:#333,stroke-width:2px
+```
+
+When an operation like `add(Key1, ValA)` is performed:
+1.  `ValA` is added to the `ValueSet` associated with `Key1` in `forward_map_`.
+2.  `Key1` is added to the `KeySet` associated with `ValA` in `reverse_map_`.
+
+Similarly, `remove` operations update both maps to maintain consistency.
+
+## Example Usage
+
+```cpp
+#include "inverted_index.h"
+#include <iostream>
+#include <string>
+
+// Helper to print sets
+template<typename S>
+void print_set(const S& set, const std::string& name) {
+    std::cout << name << ": { ";
+    for (const auto& item : set) std::cout << item << " ";
+    std::cout << "}" << std::endl;
+}
+
+int main() {
+    InvertedIndex<std::string, std::string> article_tags;
+
+    // Add articles and their tags
+    article_tags.add("ArticleA", "C++");
+    article_tags.add("ArticleA", "Programming");
+    article_tags.add("ArticleB", "Python");
+    article_tags.add("ArticleB", "AI");
+    article_tags.add("ArticleC", "C++");
+    article_tags.add("ArticleC", "Performance");
+
+    // What tags does ArticleA have?
+    const auto& tags_A = article_tags.values_for("ArticleA");
+    print_set(tags_A, "ArticleA tags"); // Output: ArticleA tags: { C++ Programming } (order may vary)
+
+    // Which articles are tagged "C++"?
+    const auto& articles_cpp = article_tags.keys_for("C++");
+    print_set(articles_cpp, "C++ articles"); // Output: C++ articles: { ArticleA ArticleC } (order may vary)
+
+    // Check if ArticleB is tagged "Performance"
+    bool has_perf = article_tags.contains("ArticleB", "Performance");
+    std::cout << "ArticleB tagged 'Performance': " << (has_perf ? "Yes" : "No") << std::endl; // Output: No
+
+    // Remove "C++" tag from ArticleA
+    article_tags.remove("ArticleA", "C++");
+    print_set(article_tags.values_for("ArticleA"), "ArticleA tags (updated)"); // Output: { Programming }
+    print_set(article_tags.keys_for("C++"), "C++ articles (updated)"); // Output: { ArticleC }
+
+    return 0;
+}
+```
+
+## Design Constraints & Considerations
+
+*   **C++17**: Leverages features from C++17.
+*   **Header-Only**: Simplifies integration.
+*   **`std::unordered_map` + `std::unordered_set`**: These are the core internal data structures, providing good average-case performance for hash-based operations.
+*   **Value Semantics**: Copyable and movable. Deep copies are performed.
+*   **Efficiency**:
+    *   `add`, `remove(key,value)`, `contains`, `values_for`, `keys_for`: Amortized O(1) on average, assuming good hash function performance. Worst case can be O(N) for the set/map operations if hash collisions are pathologically bad, or O(size of set) for some internal set operations.
+    *   `remove_key`: Proportional to the number of values associated with the key.
+    *   `remove_value`: Proportional to the number of keys associated with the value.
+    *   `clear`: Proportional to the total number of elements.
+*   **Thread Safety**: The `InvertedIndex` class itself is **not** thread-safe for concurrent writes. If thread safety is required, external synchronization mechanisms (like `std::mutex`) must be used, or a dedicated thread-safe wrapper would need to be implemented.
+
+## Future Enhancements (Not Implemented)
+
+*   **Thread-safe wrapper**: A `ConcurrentInvertedIndex` for safe multi-threaded access.
+*   **Size-limited (bounded) variant**: An index that evicts entries based on some policy (e.g., LRU) when a size limit is reached.
+*   **More complex iterators**: E.g., iterating over all `(Key, Value)` pairs directly.

--- a/examples/inverted_index_example.cpp
+++ b/examples/inverted_index_example.cpp
@@ -1,0 +1,119 @@
+#include "inverted_index.h"
+#include <iostream>
+#include <string>
+#include <vector>
+
+// Helper function to print a set of items
+template<typename T>
+void print_set(const T& set, const std::string& label) {
+    std::cout << label << ": {";
+    bool first = true;
+    for (const auto& item : set) {
+        if (!first) {
+            std::cout << ", ";
+        }
+        std::cout << item;
+        first = false;
+    }
+    std::cout << "}" << std::endl;
+}
+
+int main() {
+    // Using strings for document IDs and tags for simplicity
+    InvertedIndex<std::string, std::string> doc_tag_index;
+
+    std::cout << "--- Initializing Document Tagging System ---" << std::endl;
+
+    // Add some documents and their tags
+    doc_tag_index.add("doc1", "c++");
+    doc_tag_index.add("doc1", "programming");
+    doc_tag_index.add("doc1", "performance");
+
+    doc_tag_index.add("doc2", "python");
+    doc_tag_index.add("doc2", "scripting");
+    doc_tag_index.add("doc2", "data science");
+
+    doc_tag_index.add("doc3", "c++");
+    doc_tag_index.add("doc3", "game development");
+    doc_tag_index.add("doc3", "graphics");
+
+    doc_tag_index.add("doc4", "python");
+    doc_tag_index.add("doc4", "web development");
+    doc_tag_index.add("doc4", "programming"); // "programming" tag also in doc1
+
+    std::cout << "\n--- Current State ---" << std::endl;
+    if (doc_tag_index.empty()) {
+        std::cout << "Index is empty." << std::endl;
+    } else {
+        std::cout << "Index has " << doc_tag_index.key_count() << " documents." << std::endl;
+    }
+
+    // Querying: What tags does doc1 have?
+    std::cout << "\n--- Querying Tags for Documents ---" << std::endl;
+    const auto& tags_for_doc1 = doc_tag_index.values_for("doc1");
+    print_set(tags_for_doc1, "Tags for doc1");
+
+    const auto& tags_for_doc2 = doc_tag_index.values_for("doc2");
+    print_set(tags_for_doc2, "Tags for doc2");
+
+    const auto& tags_for_doc_non_existent = doc_tag_index.values_for("doc_X");
+    print_set(tags_for_doc_non_existent, "Tags for doc_X (non-existent)");
+
+
+    // Querying: Which documents have the tag "c++"?
+    std::cout << "\n--- Querying Documents for Tags ---" << std::endl;
+    const auto& docs_with_cpp = doc_tag_index.keys_for("c++");
+    print_set(docs_with_cpp, "Documents with tag 'c++'");
+
+    const auto& docs_with_programming = doc_tag_index.keys_for("programming");
+    print_set(docs_with_programming, "Documents with tag 'programming'");
+
+    const auto& docs_with_java = doc_tag_index.keys_for("java"); // This tag was not added
+    print_set(docs_with_java, "Documents with tag 'java' (non-existent tag)");
+
+    // Checking for specific mappings
+    std::cout << "\n--- Checking Specific Mappings ---" << std::endl;
+    std::cout << "doc1 has tag 'performance': " << (doc_tag_index.contains("doc1", "performance") ? "Yes" : "No") << std::endl;
+    std::cout << "doc2 has tag 'c++': " << (doc_tag_index.contains("doc2", "c++") ? "Yes" : "No") << std::endl;
+
+    // Removing a specific tag from a document
+    std::cout << "\n--- Modifying Mappings ---" << std::endl;
+    std::cout << "Removing tag 'performance' from 'doc1'..." << std::endl;
+    doc_tag_index.remove("doc1", "performance");
+    print_set(doc_tag_index.values_for("doc1"), "Tags for doc1 (after removing 'performance')");
+    print_set(doc_tag_index.keys_for("performance"), "Documents with tag 'performance' (after removing from doc1)");
+
+    // Removing a document entirely
+    std::cout << "\nRemoving 'doc2' entirely..." << std::endl;
+    doc_tag_index.remove_key("doc2");
+    std::cout << "doc2 has tag 'python': " << (doc_tag_index.contains("doc2", "python") ? "Yes" : "No") << std::endl;
+    print_set(doc_tag_index.values_for("doc2"), "Tags for doc2 (after removing doc2)");
+    print_set(doc_tag_index.keys_for("python"), "Documents with tag 'python' (after removing doc2)");
+    print_set(doc_tag_index.keys_for("scripting"), "Documents with tag 'scripting' (after removing doc2)");
+
+
+    // Removing a tag from all documents that have it
+    std::cout << "\nRemoving tag 'programming' from all documents..." << std::endl;
+    doc_tag_index.remove_value("programming");
+    print_set(doc_tag_index.values_for("doc1"), "Tags for doc1 (after removing 'programming' globally)");
+    print_set(doc_tag_index.values_for("doc4"), "Tags for doc4 (after removing 'programming' globally)");
+    print_set(doc_tag_index.keys_for("programming"), "Documents with tag 'programming' (after global removal)");
+
+
+    std::cout << "\n--- Final State ---" << std::endl;
+    std::cout << "Iterating through remaining documents and their tags:" << std::endl;
+    for (const auto& pair : doc_tag_index) { // Using the iterator
+        print_set(pair.second, "Tags for " + pair.first);
+    }
+
+    if (doc_tag_index.empty()) {
+        std::cout << "Index is now empty." << std::endl;
+    } else {
+        std::cout << "Index now has " << doc_tag_index.key_count() << " documents." << std::endl;
+    }
+
+    doc_tag_index.clear();
+    std::cout << "\nCleared the index. Is it empty? " << (doc_tag_index.empty() ? "Yes" : "No") << std::endl;
+
+    return 0;
+}

--- a/include/inverted_index.h
+++ b/include/inverted_index.h
@@ -1,0 +1,188 @@
+#ifndef INVERTED_INDEX_H
+#define INVERTED_INDEX_H
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector> // For potential future use or examples, not strictly required by current API
+#include <string> // For potential future use or examples
+#include <algorithm> // For std::remove_if if needed, or other algorithms
+#include <utility> // For std::move
+
+// Forward declaration for the iterators
+// Not strictly necessary if iterators just wrap underlying map iterators directly
+// but good practice if we want more complex iterator logic later.
+
+template <
+    typename Key,
+    typename Value,
+    typename HashKey = std::hash<Key>,
+    typename EqualKey = std::equal_to<Key>,
+    typename HashValue = std::hash<Value>,
+    typename EqualValue = std::equal_to<Value>
+>
+class InvertedIndex {
+public:
+    // Types
+    using KeySet = std::unordered_set<Key, HashKey, EqualKey>;
+    using ValueSet = std::unordered_set<Value, HashValue, EqualValue>;
+
+private:
+    using ForwardMapType = std::unordered_map<Key, ValueSet, HashKey, EqualKey>;
+    using ReverseMapType = std::unordered_map<Value, KeySet, HashValue, EqualValue>;
+
+    ForwardMapType forward_map_;
+    ReverseMapType reverse_map_;
+
+public: // Made public for testing EMPTY_SET references
+    // Static empty sets to return by reference for non-existent keys/values
+    // This avoids dangling references or the need to return by value.
+    static const KeySet EMPTY_KEY_SET;
+    static const ValueSet EMPTY_VALUE_SET;
+
+public:
+    // Constructors
+    InvertedIndex() = default;
+
+    // Copy semantics
+    InvertedIndex(const InvertedIndex& other)
+        : forward_map_(other.forward_map_), reverse_map_(other.reverse_map_) {}
+
+    InvertedIndex& operator=(const InvertedIndex& other) {
+        if (this == &other) {
+            return *this;
+        }
+        forward_map_ = other.forward_map_;
+        reverse_map_ = other.reverse_map_;
+        return *this;
+    }
+
+    // Move semantics
+    InvertedIndex(InvertedIndex&& other) noexcept
+        : forward_map_(std::move(other.forward_map_)), reverse_map_(std::move(other.reverse_map_)) {}
+
+    InvertedIndex& operator=(InvertedIndex&& other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+        forward_map_ = std::move(other.forward_map_);
+        reverse_map_ = std::move(other.reverse_map_);
+        return *this;
+    }
+
+    // Core methods
+    void add(const Key& key, const Value& value) {
+        forward_map_[key].insert(value);
+        reverse_map_[value].insert(key);
+    }
+
+    void remove(const Key& key, const Value& value) {
+        auto fwd_it = forward_map_.find(key);
+        if (fwd_it != forward_map_.end()) {
+            fwd_it->second.erase(value);
+            if (fwd_it->second.empty()) {
+                forward_map_.erase(fwd_it);
+            }
+        }
+
+        auto rev_it = reverse_map_.find(value);
+        if (rev_it != reverse_map_.end()) {
+            rev_it->second.erase(key);
+            if (rev_it->second.empty()) {
+                reverse_map_.erase(rev_it);
+            }
+        }
+    }
+
+    void remove_key(const Key& key) {
+        auto fwd_it = forward_map_.find(key);
+        if (fwd_it != forward_map_.end()) {
+            const ValueSet& values_to_remove = fwd_it->second;
+            for (const auto& value : values_to_remove) {
+                auto rev_it = reverse_map_.find(value);
+                if (rev_it != reverse_map_.end()) {
+                    rev_it->second.erase(key);
+                    if (rev_it->second.empty()) {
+                        reverse_map_.erase(rev_it);
+                    }
+                }
+            }
+            forward_map_.erase(fwd_it);
+        }
+    }
+
+    void remove_value(const Value& value) {
+        auto rev_it = reverse_map_.find(value);
+        if (rev_it != reverse_map_.end()) {
+            const KeySet& keys_to_remove = rev_it->second;
+            for (const auto& key : keys_to_remove) {
+                auto fwd_it = forward_map_.find(key);
+                if (fwd_it != forward_map_.end()) {
+                    fwd_it->second.erase(value);
+                    if (fwd_it->second.empty()) {
+                        forward_map_.erase(fwd_it);
+                    }
+                }
+            }
+            reverse_map_.erase(rev_it);
+        }
+    }
+
+    const ValueSet& values_for(const Key& key) const {
+        auto it = forward_map_.find(key);
+        if (it != forward_map_.end()) {
+            return it->second;
+        }
+        return EMPTY_VALUE_SET;
+    }
+
+    const KeySet& keys_for(const Value& value) const {
+        auto it = reverse_map_.find(value);
+        if (it != reverse_map_.end()) {
+            return it->second;
+        }
+        return EMPTY_KEY_SET;
+    }
+
+    bool contains(const Key& key, const Value& value) const {
+        auto it = forward_map_.find(key);
+        if (it != forward_map_.end()) {
+            const ValueSet& values = it->second;
+            return values.count(value) > 0;
+        }
+        return false;
+    }
+
+    bool empty() const {
+        return forward_map_.empty();
+    }
+
+    void clear() {
+        forward_map_.clear();
+        reverse_map_.clear();
+    }
+
+    // Iterator support (iterating over keys of the forward_map_)
+    typename ForwardMapType::const_iterator begin() const {
+        return forward_map_.begin();
+    }
+
+    typename ForwardMapType::const_iterator end() const {
+        return forward_map_.end();
+    }
+
+    // Size information (optional, but common)
+    size_t key_count() const { return forward_map_.size(); }
+    // size_t value_count() const { return reverse_map_.size(); } // Unique values
+    // size_t total_mappings() const; // Could be implemented if needed
+
+
+};
+
+// Initialize static empty sets
+template <typename Key, typename Value, typename HashKey, typename EqualKey, typename HashValue, typename EqualValue>
+const typename InvertedIndex<Key, Value, HashKey, EqualKey, HashValue, EqualValue>::KeySet InvertedIndex<Key, Value, HashKey, EqualKey, HashValue, EqualValue>::EMPTY_KEY_SET = {};
+
+template <typename Key, typename Value, typename HashKey, typename EqualKey, typename HashValue, typename EqualValue>
+const typename InvertedIndex<Key, Value, HashKey, EqualKey, HashValue, EqualValue>::ValueSet InvertedIndex<Key, Value, HashKey, EqualKey, HashValue, EqualValue>::EMPTY_VALUE_SET = {};
+
+#endif // INVERTED_INDEX_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         IdPoolLib            # Added for id_pool_test
         FlatMapLib           # Added for flat_map_test
         ValueIndexMapLib     # Added for value_index_map_test
+        InvertedIndexLib     # Added for inverted_index_test
         OneOfLib             # Added for one_of_test
         ChronoRingLib        # Added for chrono_ring_test
     )

--- a/tests/inverted_index_test.cpp
+++ b/tests/inverted_index_test.cpp
@@ -1,0 +1,635 @@
+#include "gtest/gtest.h"
+#include "inverted_index.h" // Adjust path as necessary based on include directories
+#include <string>
+#include <vector>
+#include <algorithm> // For std::sort for comparing vectors if needed
+
+// Basic test fixture
+class InvertedIndexTest : public ::testing::Test {
+protected:
+    InvertedIndex<std::string, int> index;
+    InvertedIndex<int, std::string> doc_tags_index; // For more semantic examples
+};
+
+TEST_F(InvertedIndexTest, InitialState) {
+    EXPECT_TRUE(index.empty());
+    EXPECT_TRUE(index.values_for("nonexistent_key").empty());
+    EXPECT_TRUE(index.keys_for(12345).empty());
+    EXPECT_FALSE(index.contains("key1", 1));
+}
+
+TEST_F(InvertedIndexTest, AddSingleEntry) {
+    index.add("key1", 100);
+    EXPECT_FALSE(index.empty());
+    EXPECT_TRUE(index.contains("key1", 100));
+    EXPECT_FALSE(index.contains("key1", 200));
+    EXPECT_FALSE(index.contains("key2", 100));
+
+    const auto& values = index.values_for("key1");
+    ASSERT_EQ(values.size(), 1);
+    EXPECT_NE(values.find(100), values.end());
+
+    const auto& keys = index.keys_for(100);
+    ASSERT_EQ(keys.size(), 1);
+    EXPECT_NE(keys.find("key1"), keys.end());
+}
+
+TEST_F(InvertedIndexTest, AddMultipleValuesForKey) {
+    index.add("doc1", 1); // tag 1
+    index.add("doc1", 2); // tag 2
+    index.add("doc1", 3); // tag 3
+
+    EXPECT_TRUE(index.contains("doc1", 1));
+    EXPECT_TRUE(index.contains("doc1", 2));
+    EXPECT_TRUE(index.contains("doc1", 3));
+    EXPECT_FALSE(index.contains("doc1", 4));
+
+    const auto& values = index.values_for("doc1");
+    ASSERT_EQ(values.size(), 3);
+    EXPECT_NE(values.find(1), values.end());
+    EXPECT_NE(values.find(2), values.end());
+    EXPECT_NE(values.find(3), values.end());
+
+    // Check reverse mapping
+    const auto& keys_for_tag1 = index.keys_for(1);
+    ASSERT_EQ(keys_for_tag1.size(), 1);
+    EXPECT_NE(keys_for_tag1.find("doc1"), keys_for_tag1.end());
+
+    const auto& keys_for_tag2 = index.keys_for(2);
+    ASSERT_EQ(keys_for_tag2.size(), 1);
+    EXPECT_NE(keys_for_tag2.find("doc1"), keys_for_tag2.end());
+}
+
+TEST_F(InvertedIndexTest, AddMultipleKeysForValue) {
+    index.add("doc1", 10);
+    index.add("doc2", 10);
+    index.add("doc3", 10);
+
+    EXPECT_TRUE(index.contains("doc1", 10));
+    EXPECT_TRUE(index.contains("doc2", 10));
+    EXPECT_TRUE(index.contains("doc3", 10));
+    EXPECT_FALSE(index.contains("doc4", 10));
+
+    const auto& keys = index.keys_for(10);
+    ASSERT_EQ(keys.size(), 3);
+    EXPECT_NE(keys.find("doc1"), keys.end());
+    EXPECT_NE(keys.find("doc2"), keys.end());
+    EXPECT_NE(keys.find("doc3"), keys.end());
+
+    // Check forward mapping
+    const auto& values_for_doc1 = index.values_for("doc1");
+    ASSERT_EQ(values_for_doc1.size(), 1);
+    EXPECT_NE(values_for_doc1.find(10), values_for_doc1.end());
+
+    const auto& values_for_doc2 = index.values_for("doc2");
+    ASSERT_EQ(values_for_doc2.size(), 1);
+    EXPECT_NE(values_for_doc2.find(10), values_for_doc2.end());
+}
+
+TEST_F(InvertedIndexTest, AddComplexScenario) {
+    // Document tagging example
+    // doc1: cpp, programming, high-performance
+    // doc2: cpp, search, library
+    // doc3: java, programming, enterprise
+    doc_tags_index.add(1, "cpp");
+    doc_tags_index.add(1, "programming");
+    doc_tags_index.add(1, "high-performance");
+
+    doc_tags_index.add(2, "cpp");
+    doc_tags_index.add(2, "search");
+    doc_tags_index.add(2, "library");
+
+    doc_tags_index.add(3, "java");
+    doc_tags_index.add(3, "programming");
+    doc_tags_index.add(3, "enterprise");
+
+    // --- Verification ---
+    // Values for doc1
+    const auto& tags_for_doc1 = doc_tags_index.values_for(1);
+    ASSERT_EQ(tags_for_doc1.size(), 3);
+    EXPECT_NE(tags_for_doc1.find("cpp"), tags_for_doc1.end());
+    EXPECT_NE(tags_for_doc1.find("programming"), tags_for_doc1.end());
+    EXPECT_NE(tags_for_doc1.find("high-performance"), tags_for_doc1.end());
+
+    // Values for doc2
+    const auto& tags_for_doc2 = doc_tags_index.values_for(2);
+    ASSERT_EQ(tags_for_doc2.size(), 3);
+    EXPECT_NE(tags_for_doc2.find("cpp"), tags_for_doc2.end());
+    EXPECT_NE(tags_for_doc2.find("search"), tags_for_doc2.end());
+    EXPECT_NE(tags_for_doc2.find("library"), tags_for_doc2.end());
+
+    // Keys for "cpp"
+    const auto& docs_for_cpp = doc_tags_index.keys_for("cpp");
+    ASSERT_EQ(docs_for_cpp.size(), 2);
+    EXPECT_NE(docs_for_cpp.find(1), docs_for_cpp.end());
+    EXPECT_NE(docs_for_cpp.find(2), docs_for_cpp.end());
+
+    // Keys for "programming"
+    const auto& docs_for_programming = doc_tags_index.keys_for("programming");
+    ASSERT_EQ(docs_for_programming.size(), 2);
+    EXPECT_NE(docs_for_programming.find(1), docs_for_programming.end());
+    EXPECT_NE(docs_for_programming.find(3), docs_for_programming.end());
+
+    // Keys for "library"
+    const auto& docs_for_library = doc_tags_index.keys_for("library");
+    ASSERT_EQ(docs_for_library.size(), 1);
+    EXPECT_NE(docs_for_library.find(2), docs_for_library.end());
+
+    // Contains checks
+    EXPECT_TRUE(doc_tags_index.contains(1, "cpp"));
+    EXPECT_TRUE(doc_tags_index.contains(2, "cpp"));
+    EXPECT_FALSE(doc_tags_index.contains(3, "cpp"));
+    EXPECT_TRUE(doc_tags_index.contains(1, "programming"));
+    EXPECT_FALSE(doc_tags_index.contains(2, "programming")); // doc2 does not have "programming" directly, it has "search", "library"
+    EXPECT_TRUE(doc_tags_index.contains(3, "programming"));
+
+    // Check a non-existent mapping
+    EXPECT_FALSE(doc_tags_index.contains(1, "nonexistent_tag"));
+    EXPECT_TRUE(doc_tags_index.values_for(999).empty()); // Non-existent doc
+    EXPECT_TRUE(doc_tags_index.keys_for("nonexistent_tag_key").empty()); // Non-existent tag
+}
+
+TEST_F(InvertedIndexTest, IdempotencyOfAdd) {
+    index.add("key1", 100);
+    index.add("key1", 100); // Add again
+    index.add("key1", 100); // And again
+
+    EXPECT_TRUE(index.contains("key1", 100));
+    const auto& values = index.values_for("key1");
+    ASSERT_EQ(values.size(), 1);
+    EXPECT_NE(values.find(100), values.end());
+
+    const auto& keys = index.keys_for(100);
+    ASSERT_EQ(keys.size(), 1);
+    EXPECT_NE(keys.find("key1"), keys.end());
+
+    index.add("key1", 200);
+    index.add("key1", 100); // Add original again after a new one
+
+    const auto& values_updated = index.values_for("key1");
+    ASSERT_EQ(values_updated.size(), 2);
+    EXPECT_NE(values_updated.find(100), values_updated.end());
+    EXPECT_NE(values_updated.find(200), values_updated.end());
+
+    const auto& keys_for_100_updated = index.keys_for(100);
+    ASSERT_EQ(keys_for_100_updated.size(), 1);
+    EXPECT_NE(keys_for_100_updated.find("key1"), keys_for_100_updated.end());
+
+    const auto& keys_for_200 = index.keys_for(200);
+    ASSERT_EQ(keys_for_200.size(), 1);
+    EXPECT_NE(keys_for_200.find("key1"), keys_for_200.end());
+}
+
+TEST_F(InvertedIndexTest, ValuesForNonExistentKey) {
+    const auto& values = index.values_for("phantom_key");
+    EXPECT_TRUE(values.empty());
+}
+
+TEST_F(InvertedIndexTest, KeysForNonExistentValue) {
+    const auto& keys = index.keys_for(99999);
+    EXPECT_TRUE(keys.empty());
+}
+
+// Test with custom hash and equality for Key and Value (using simple structs)
+struct CustomKey {
+    int id;
+    std::string name;
+
+    bool operator==(const CustomKey& other) const {
+        return id == other.id && name == other.name;
+    }
+};
+
+struct CustomKeyHash {
+    std::size_t operator()(const CustomKey& k) const {
+        return std::hash<int>()(k.id) ^ (std::hash<std::string>()(k.name) << 1);
+    }
+};
+
+struct CustomValue {
+    int value_id;
+
+    bool operator==(const CustomValue& other) const {
+        return value_id == other.value_id;
+    }
+};
+
+struct CustomValueHash {
+    std::size_t operator()(const CustomValue& v) const {
+        return std::hash<int>()(v.value_id);
+    }
+};
+
+
+TEST(InvertedIndexCustomTypeTest, AddAndRetrieveWithCustomTypes) {
+    InvertedIndex<CustomKey, CustomValue, CustomKeyHash, std::equal_to<CustomKey>, CustomValueHash, std::equal_to<CustomValue>> custom_index;
+
+    CustomKey k1 = {1, "one"};
+    CustomValue v1 = {101};
+    CustomKey k2 = {2, "two"};
+    CustomValue v2 = {102};
+
+    custom_index.add(k1, v1);
+    custom_index.add(k1, v2);
+    custom_index.add(k2, v1);
+
+    EXPECT_TRUE(custom_index.contains(k1, v1));
+    EXPECT_TRUE(custom_index.contains(k1, v2));
+    EXPECT_TRUE(custom_index.contains(k2, v1));
+    EXPECT_FALSE(custom_index.contains(k2, v2));
+
+    const auto& values_for_k1 = custom_index.values_for(k1);
+    ASSERT_EQ(values_for_k1.size(), 2);
+    EXPECT_NE(values_for_k1.find(v1), values_for_k1.end());
+    EXPECT_NE(values_for_k1.find(v2), values_for_k1.end());
+
+    const auto& keys_for_v1 = custom_index.keys_for(v1);
+    ASSERT_EQ(keys_for_v1.size(), 2);
+    EXPECT_NE(keys_for_v1.find(k1), keys_for_v1.end());
+    EXPECT_NE(keys_for_v1.find(k2), keys_for_v1.end());
+}
+
+// Test with default std::equal_to for custom types (if operator== is defined)
+struct SimpleKey {
+    int id;
+    bool operator==(const SimpleKey& other) const { return id == other.id; }
+};
+namespace std {
+    template <> struct hash<SimpleKey> {
+        size_t operator()(const SimpleKey& k) const { return hash<int>()(k.id); }
+    };
+}
+
+struct SimpleValue {
+    std::string data;
+    bool operator==(const SimpleValue& other) const { return data == other.data; }
+};
+namespace std {
+    template <> struct hash<SimpleValue> {
+        size_t operator()(const SimpleValue& v) const { return hash<std::string>()(v.data); }
+    };
+}
+
+TEST(InvertedIndexCustomTypeStdHashTest, AddAndRetrieveWithStdHashableCustomTypes) {
+    InvertedIndex<SimpleKey, SimpleValue> custom_index_std;
+
+    SimpleKey sk1 = {1};
+    SimpleValue sv1 = {"alpha"};
+    SimpleKey sk2 = {2};
+    SimpleValue sv2 = {"beta"};
+
+    custom_index_std.add(sk1, sv1);
+    custom_index_std.add(sk1, sv2);
+    custom_index_std.add(sk2, sv1);
+
+    EXPECT_TRUE(custom_index_std.contains(sk1, sv1));
+    EXPECT_TRUE(custom_index_std.contains(sk1, sv2));
+    EXPECT_TRUE(custom_index_std.contains(sk2, sv1));
+    EXPECT_FALSE(custom_index_std.contains(sk2, sv2));
+
+    const auto& values_for_sk1 = custom_index_std.values_for(sk1);
+    ASSERT_EQ(values_for_sk1.size(), 2);
+    EXPECT_NE(values_for_sk1.find(sv1), values_for_sk1.end());
+    EXPECT_NE(values_for_sk1.find(sv2), values_for_sk1.end());
+
+    const auto& keys_for_sv1 = custom_index_std.keys_for(sv1);
+    ASSERT_EQ(keys_for_sv1.size(), 2);
+    EXPECT_NE(keys_for_sv1.find(sk1), keys_for_sv1.end());
+    EXPECT_NE(keys_for_sv1.find(sk2), keys_for_sv1.end());
+}
+
+// --- Tests for Remove Operations ---
+
+TEST_F(InvertedIndexTest, RemoveSingleMapping) {
+    index.add("key1", 100);
+    index.add("key1", 200);
+    index.add("key2", 100);
+
+    ASSERT_TRUE(index.contains("key1", 100));
+    ASSERT_TRUE(index.contains("key1", 200));
+    ASSERT_TRUE(index.contains("key2", 100));
+    ASSERT_EQ(index.values_for("key1").size(), 2);
+    ASSERT_EQ(index.keys_for(100).size(), 2);
+
+    index.remove("key1", 100);
+
+    EXPECT_FALSE(index.contains("key1", 100));
+    EXPECT_TRUE(index.contains("key1", 200)); // Should still be there
+    EXPECT_TRUE(index.contains("key2", 100)); // Should still be there
+
+    const auto& values_for_key1 = index.values_for("key1");
+    ASSERT_EQ(values_for_key1.size(), 1);
+    EXPECT_NE(values_for_key1.find(200), values_for_key1.end());
+
+    const auto& keys_for_100 = index.keys_for(100);
+    ASSERT_EQ(keys_for_100.size(), 1);
+    EXPECT_NE(keys_for_100.find("key2"), keys_for_100.end());
+
+    // Remove last value for a key, key should be removed from forward_map
+    index.remove("key1", 200);
+    EXPECT_FALSE(index.contains("key1", 200));
+    EXPECT_TRUE(index.values_for("key1").empty());
+    EXPECT_FALSE(index.key_count() == 2); // key1 should be gone, only key2 remains
+    EXPECT_EQ(index.key_count(), 1);
+
+
+    // Remove last key for a value, value should be removed from reverse_map
+    index.add("key3", 300); // Add something new
+    index.remove("key2", 100); // key2 was the last key for value 100
+    EXPECT_FALSE(index.contains("key2", 100));
+    EXPECT_TRUE(index.keys_for(100).empty());
+}
+
+TEST_F(InvertedIndexTest, RemoveNonExistentMapping) {
+    index.add("key1", 100);
+    ASSERT_TRUE(index.contains("key1", 100));
+    ASSERT_EQ(index.values_for("key1").size(), 1);
+    ASSERT_EQ(index.keys_for(100).size(), 1);
+
+    // Try removing a value not mapped to key1
+    index.remove("key1", 999);
+    EXPECT_TRUE(index.contains("key1", 100)); // Original should still be there
+    EXPECT_EQ(index.values_for("key1").size(), 1);
+
+    // Try removing a key not in the index
+    index.remove("nonexistent_key", 100);
+    EXPECT_TRUE(index.contains("key1", 100));
+    EXPECT_EQ(index.keys_for(100).size(), 1);
+
+    // Try removing a value not in the index at all
+    index.remove("key1", 777);
+    EXPECT_TRUE(index.contains("key1", 100));
+}
+
+TEST_F(InvertedIndexTest, RemoveKey) {
+    doc_tags_index.add(1, "cpp");
+    doc_tags_index.add(1, "programming");
+    doc_tags_index.add(2, "cpp");
+    doc_tags_index.add(2, "search");
+    doc_tags_index.add(3, "java");
+
+    ASSERT_TRUE(doc_tags_index.contains(1, "cpp"));
+    ASSERT_TRUE(doc_tags_index.contains(1, "programming"));
+    ASSERT_TRUE(doc_tags_index.contains(2, "cpp"));
+    ASSERT_EQ(doc_tags_index.keys_for("cpp").size(), 2);
+    ASSERT_EQ(doc_tags_index.values_for(1).size(), 2);
+
+    doc_tags_index.remove_key(1); // Remove all tags for doc 1
+
+    EXPECT_FALSE(doc_tags_index.contains(1, "cpp"));
+    EXPECT_FALSE(doc_tags_index.contains(1, "programming"));
+    EXPECT_TRUE(doc_tags_index.values_for(1).empty()); // Doc 1 should have no tags
+
+    // Check reverse map updates
+    const auto& docs_for_cpp = doc_tags_index.keys_for("cpp");
+    ASSERT_EQ(docs_for_cpp.size(), 1);
+    EXPECT_NE(docs_for_cpp.find(2), docs_for_cpp.end()); // Only doc 2 should have "cpp"
+
+    const auto& docs_for_programming = doc_tags_index.keys_for("programming");
+    EXPECT_TRUE(docs_for_programming.empty()); // "programming" was only on doc 1
+
+    // Check other keys are unaffected
+    EXPECT_TRUE(doc_tags_index.contains(2, "cpp"));
+    EXPECT_TRUE(doc_tags_index.contains(3, "java"));
+
+    // Remove a key that doesn't exist
+    doc_tags_index.remove_key(999); // Should not crash or change state
+    EXPECT_TRUE(doc_tags_index.contains(2, "cpp"));
+    EXPECT_EQ(doc_tags_index.keys_for("cpp").size(), 1);
+}
+
+TEST_F(InvertedIndexTest, RemoveValue) {
+    doc_tags_index.add(1, "cpp");
+    doc_tags_index.add(1, "programming");
+    doc_tags_index.add(2, "cpp");
+    doc_tags_index.add(2, "search");
+    doc_tags_index.add(3, "cpp"); // Doc 3 also has "cpp"
+
+    ASSERT_TRUE(doc_tags_index.contains(1, "cpp"));
+    ASSERT_TRUE(doc_tags_index.contains(2, "cpp"));
+    ASSERT_TRUE(doc_tags_index.contains(3, "cpp"));
+    ASSERT_EQ(doc_tags_index.keys_for("cpp").size(), 3);
+    ASSERT_EQ(doc_tags_index.values_for(1).count("cpp"), 1);
+
+    doc_tags_index.remove_value("cpp"); // Remove "cpp" tag from all documents
+
+    EXPECT_FALSE(doc_tags_index.contains(1, "cpp"));
+    EXPECT_FALSE(doc_tags_index.contains(2, "cpp"));
+    EXPECT_FALSE(doc_tags_index.contains(3, "cpp"));
+    EXPECT_TRUE(doc_tags_index.keys_for("cpp").empty()); // No docs should have "cpp"
+
+    // Check forward map updates
+    EXPECT_FALSE(doc_tags_index.values_for(1).count("cpp"));
+    EXPECT_TRUE(doc_tags_index.values_for(1).count("programming")); // This should remain
+
+    EXPECT_FALSE(doc_tags_index.values_for(2).count("cpp"));
+    EXPECT_TRUE(doc_tags_index.values_for(2).count("search")); // This should remain
+
+    EXPECT_FALSE(doc_tags_index.values_for(3).count("cpp"));
+    EXPECT_TRUE(doc_tags_index.values_for(3).empty()); // Doc 3 only had "cpp"
+
+    // Remove a value that doesn't exist
+    doc_tags_index.remove_value("nonexistent_tag"); // Should not crash
+    EXPECT_TRUE(doc_tags_index.values_for(1).count("programming"));
+}
+
+// --- Tests for Clear and Empty ---
+TEST_F(InvertedIndexTest, ClearAndEmpty) {
+    EXPECT_TRUE(index.empty());
+    index.add("key1", 1);
+    index.add("key2", 2);
+    EXPECT_FALSE(index.empty());
+    ASSERT_EQ(index.key_count(), 2);
+
+    index.clear();
+    EXPECT_TRUE(index.empty());
+    EXPECT_EQ(index.key_count(), 0);
+    EXPECT_TRUE(index.values_for("key1").empty());
+    EXPECT_TRUE(index.keys_for(1).empty());
+    EXPECT_FALSE(index.contains("key1",1));
+
+    // Clear an already empty index
+    index.clear();
+    EXPECT_TRUE(index.empty());
+}
+
+// --- Tests for Copy and Move Semantics ---
+TEST_F(InvertedIndexTest, CopyConstructor) {
+    index.add("doc1", 10);
+    index.add("doc1", 20);
+    index.add("doc2", 10);
+
+    InvertedIndex<std::string, int> copied_index(index);
+
+    // Check copied state
+    EXPECT_FALSE(copied_index.empty());
+    EXPECT_EQ(copied_index.key_count(), 2);
+    EXPECT_TRUE(copied_index.contains("doc1", 10));
+    EXPECT_TRUE(copied_index.contains("doc1", 20));
+    EXPECT_TRUE(copied_index.contains("doc2", 10));
+    ASSERT_EQ(copied_index.values_for("doc1").size(), 2);
+    ASSERT_EQ(copied_index.keys_for(10).size(), 2);
+
+    // Modify original, copied should not change
+    index.add("doc3", 30);
+    EXPECT_TRUE(index.contains("doc3", 30));
+    EXPECT_FALSE(copied_index.contains("doc3", 30));
+    EXPECT_EQ(copied_index.key_count(), 2);
+
+
+    // Modify copied, original should not change
+    copied_index.remove("doc1", 10);
+    EXPECT_FALSE(copied_index.contains("doc1", 10));
+    EXPECT_TRUE(index.contains("doc1", 10)); // Original still has it
+}
+
+TEST_F(InvertedIndexTest, CopyAssignmentOperator) {
+    index.add("doc1", 10);
+    index.add("doc2", 20);
+
+    InvertedIndex<std::string, int> assigned_index;
+    assigned_index.add("temp", 99); // Add some initial data
+
+    assigned_index = index;
+
+    // Check assigned state
+    EXPECT_FALSE(assigned_index.empty());
+    EXPECT_EQ(assigned_index.key_count(), 2);
+    EXPECT_TRUE(assigned_index.contains("doc1", 10));
+    EXPECT_TRUE(assigned_index.contains("doc2", 20));
+    EXPECT_FALSE(assigned_index.contains("temp", 99)); // Original data gone
+
+    // Modify original, assigned should not change
+    index.add("doc3", 30);
+    EXPECT_FALSE(assigned_index.contains("doc3", 30));
+
+    // Self-assignment
+    assigned_index = assigned_index; // Should not crash or corrupt
+    EXPECT_TRUE(assigned_index.contains("doc1", 10));
+    EXPECT_EQ(assigned_index.key_count(), 2);
+}
+
+TEST_F(InvertedIndexTest, MoveConstructor) {
+    index.add("doc1", 10);
+    index.add("doc1", 20);
+    index.add("doc2", 10);
+
+    // Need to get data before move to verify
+    auto original_k1_values = index.values_for("doc1");
+    ASSERT_EQ(original_k1_values.size(), 2);
+
+    InvertedIndex<std::string, int> moved_index(std::move(index));
+
+    // Check moved state
+    EXPECT_FALSE(moved_index.empty());
+    EXPECT_EQ(moved_index.key_count(), 2);
+    EXPECT_TRUE(moved_index.contains("doc1", 10));
+    EXPECT_TRUE(moved_index.contains("doc1", 20));
+    EXPECT_TRUE(moved_index.contains("doc2", 10));
+    ASSERT_EQ(moved_index.values_for("doc1").size(), 2);
+    ASSERT_EQ(moved_index.keys_for(10).size(), 2);
+
+    // Check original (source) state - should be valid but empty or unspecified
+    // For std::unordered_map, moved-from state is valid but unspecified.
+    // We expect it to be empty as per typical move semantics for containers.
+    EXPECT_TRUE(index.empty()); // Assuming typical move leaves source empty
+    EXPECT_EQ(index.key_count(), 0);
+}
+
+TEST_F(InvertedIndexTest, MoveAssignmentOperator) {
+    index.add("doc1", 10);
+    index.add("doc2", 20);
+
+    InvertedIndex<std::string, int> moved_assigned_index;
+    moved_assigned_index.add("temp", 99); // Initial data
+
+    moved_assigned_index = std::move(index);
+
+    // Check assigned state
+    EXPECT_FALSE(moved_assigned_index.empty());
+    EXPECT_EQ(moved_assigned_index.key_count(), 2);
+    EXPECT_TRUE(moved_assigned_index.contains("doc1", 10));
+    EXPECT_TRUE(moved_assigned_index.contains("doc2", 20));
+    EXPECT_FALSE(moved_assigned_index.contains("temp", 99));
+
+    // Check original (source) state
+    EXPECT_TRUE(index.empty());
+    EXPECT_EQ(index.key_count(), 0);
+
+    // Self-move assignment
+    // Note: Self-move assignment behavior can be tricky.
+    // A robust implementation should handle it, typically resulting in the object remaining valid.
+    // The standard doesn't strictly guarantee the object is unchanged but it must be in a valid state.
+    // For our map-based implementation, moving members to themselves should be okay.
+    InvertedIndex<std::string, int> self_move_test;
+    self_move_test.add("self", 1);
+    self_move_test = std::move(self_move_test);
+    EXPECT_TRUE(self_move_test.contains("self", 1)); // Should ideally still be there or be validly empty
+    // Depending on how std::unordered_map handles self-move, it might be empty or unchanged.
+    // Let's assume it should remain valid. If it's empty, key_count would be 0.
+    // If it's unchanged, key_count would be 1.
+    // The important part is that it's in a valid state and doesn't crash.
+    // A common pattern is for self-move to be a no-op if guarded by `if (this != &other)`.
+}
+
+// Re-verify idempotency of add (already partially tested)
+TEST_F(InvertedIndexTest, AddIdempotencyStress) {
+    index.add("k1", 1);
+    index.add("k1", 1);
+    index.add("k1", 2);
+    index.add("k1", 2);
+    index.add("k2", 1);
+    index.add("k2", 1);
+
+    EXPECT_EQ(index.values_for("k1").size(), 2);
+    EXPECT_TRUE(index.values_for("k1").count(1));
+    EXPECT_TRUE(index.values_for("k1").count(2));
+
+    EXPECT_EQ(index.values_for("k2").size(), 1);
+    EXPECT_TRUE(index.values_for("k2").count(1));
+
+    EXPECT_EQ(index.keys_for(1).size(), 2);
+    EXPECT_TRUE(index.keys_for(1).count("k1"));
+    EXPECT_TRUE(index.keys_for(1).count("k2"));
+
+    EXPECT_EQ(index.keys_for(2).size(), 1);
+    EXPECT_TRUE(index.keys_for(2).count("k1"));
+}
+
+// Re-verify empty state queries (already partially tested in InitialState)
+TEST_F(InvertedIndexTest, EmptyStateQueriesComprehensive) {
+    EXPECT_TRUE(index.empty());
+    EXPECT_EQ(index.key_count(), 0);
+
+    const auto& vals = index.values_for("any");
+    EXPECT_TRUE(vals.empty());
+    // Test that the returned reference is to the static empty set
+    const auto& vals2 = index.values_for("another");
+    EXPECT_EQ(&vals, &index.EMPTY_VALUE_SET); // Check if it's THE static empty set
+    EXPECT_EQ(&vals2, &index.EMPTY_VALUE_SET);
+
+
+    const auto& keys = index.keys_for(0);
+    EXPECT_TRUE(keys.empty());
+    const auto& keys2 = index.keys_for(1);
+    EXPECT_EQ(&keys, &index.EMPTY_KEY_SET);
+    EXPECT_EQ(&keys2, &index.EMPTY_KEY_SET);
+
+
+    EXPECT_FALSE(index.contains("any", 0));
+
+    // Operations on empty should not fail
+    index.remove("any", 0);
+    index.remove_key("any");
+    index.remove_value(0);
+    EXPECT_TRUE(index.empty()); // Still empty
+
+    index.clear(); // Clear an empty index
+    EXPECT_TRUE(index.empty());
+}
+
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Implements a header-only C++17 InvertedIndex class for bi-directional multi-mapping (Key -> Set<Value> and Value -> Set<Key>).

Features:
- Add, remove, and query mappings.
- Remove all associations for a key or a value.
- Custom hash/equality support for Key and Value types.
- Copy and move semantics.
- Iteration support over keys.

Includes comprehensive unit tests using Google Test, a usage example (document tagging system), and detailed documentation.