### PR TITLE
Add TaggedPtr utility for pointer+tag encoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,10 @@ target_include_directories(TaggedUnionLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/
 add_library(ChronoRingLib INTERFACE)
 target_include_directories(ChronoRingLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define TaggedPtrLib as an interface library (header-only)
+add_library(TaggedPtrLib INTERFACE)
+target_include_directories(TaggedPtrLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -325,6 +329,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         OneOfLib             # Added for one_of_example
         ChronoRingLib        # Added for chrono_ring_example
         AsyncValueLib
+        TaggedPtrLib         # Added for tagged_ptr_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/examples/tagged_ptr_example.cpp
+++ b/examples/tagged_ptr_example.cpp
@@ -1,0 +1,174 @@
+#include "../include/tagged_ptr.h"
+#include <iostream>
+#include <vector> // For managing node memory in this example
+#include <cstdlib> // For exit()
+
+// Minimal assert for example, real tests are in test file.
+#define ASSERT_TRUE(condition, message) \
+    if (!(condition)) { \
+        std::cerr << "Assertion failed in example: (" #condition ") is not true - " << (message) << std::endl; \
+        exit(1); \
+    }
+
+// Define Color enum for the Red-Black Tree node
+enum class Color : uint8_t {
+    RED = 0,
+    BLACK = 1
+    // In a real RB tree, we might only need 1 bit, so BLACK could be 0, RED could be 1.
+    // Or vice-versa. Let's use 1 bit.
+};
+
+// Simplified Node structure for demonstration
+// Ensure Node is aligned enough for 1 tag bit (2^1 = 2 bytes)
+// Most non-empty structs will be aligned to at least 4 or 8 bytes by default.
+struct alignas(2) RBNode {
+    int key;
+    // TaggedPtr will store RBNode* and Color (1 bit)
+    TaggedPtr<RBNode, 1> left;
+    TaggedPtr<RBNode, 1> right;
+    // Parent pointer could also be a TaggedPtr if it needed a tag
+    RBNode* parent;
+
+    RBNode(int k) : key(k), parent(nullptr) {
+        // Children are initially null, color doesn't matter for null / can be default
+        left.set(nullptr, static_cast<uint8_t>(Color::BLACK));
+        right.set(nullptr, static_cast<uint8_t>(Color::BLACK));
+    }
+
+    void set_left_child(RBNode* node, Color color) {
+        left.set(node, static_cast<uint8_t>(color));
+        if (node) node->parent = this;
+    }
+
+    void set_right_child(RBNode* node, Color color) {
+        right.set(node, static_cast<uint8_t>(color));
+        if (node) node->parent = this;
+    }
+
+    RBNode* get_left_child() const {
+        return left.get_ptr();
+    }
+
+    Color get_left_color() const {
+        return static_cast<Color>(left.get_tag());
+    }
+
+    RBNode* get_right_child() const {
+        return right.get_ptr();
+    }
+
+    Color get_right_color() const {
+        return static_cast<Color>(right.get_tag());
+    }
+
+    // Helper to print color
+    static const char* color_to_string(Color c) {
+        return c == Color::RED ? "RED" : "BLACK";
+    }
+};
+
+// A very simple "tree" manager for demonstration purposes
+class SimpleTree {
+public:
+    RBNode* root_ = nullptr;
+    std::vector<RBNode*> all_nodes_; // To manage memory easily for the example
+
+    ~SimpleTree() {
+        for (RBNode* node : all_nodes_) {
+            delete node;
+        }
+    }
+
+    RBNode* add_node(int key) {
+        RBNode* new_node = new RBNode(key);
+        all_nodes_.push_back(new_node);
+        if (!root_) {
+            root_ = new_node;
+        }
+        // This is not a real RB tree insertion, just adding nodes for demo
+        return new_node;
+    }
+
+    void print_node_info(const RBNode* node) {
+        if (!node) {
+            std::cout << "Node: null" << std::endl;
+            return;
+        }
+        std::cout << "Node Key: " << node->key << std::endl;
+
+        RBNode* left_child = node->get_left_child();
+        Color left_color = node->get_left_color();
+        std::cout << "  Left Child: " << (left_child ? std::to_string(left_child->key) : "null");
+        std::cout << ", Color: " << RBNode::color_to_string(left_color) << std::endl;
+
+        RBNode* right_child = node->get_right_child();
+        Color right_color = node->get_right_color();
+        std::cout << "  Right Child: " << (right_child ? std::to_string(right_child->key) : "null");
+        std::cout << ", Color: " << RBNode::color_to_string(right_color) << std::endl;
+    }
+};
+
+
+int main() {
+    std::cout << "TaggedPtr Example: Simplified Red-Black Tree Node" << std::endl;
+    std::cout << "Max tag value for 1 bit: " << TaggedPtr<RBNode, 1>::max_tag() << std::endl;
+    // Test alignment requirement (compile time)
+    // TaggedPtr<RBNode, 3> tp_compile_fail; // RBNode alignof is likely >=2 but <8. This should fail.
+
+    SimpleTree tree;
+
+    RBNode* n10 = tree.add_node(10); // Root
+    RBNode* n5  = tree.add_node(5);
+    RBNode* n15 = tree.add_node(15);
+    RBNode* n3  = tree.add_node(3);
+    RBNode* n7  = tree.add_node(7);
+
+    // Manually construct a small tree structure using TaggedPtr for color
+    // Root is typically BLACK in an RB tree (after balancing)
+    // Let's imagine n10 is root and black.
+    // Children of a RED node must be BLACK.
+    // For this demo, we'll just set some arbitrary colors.
+
+    if (tree.root_ == n10) { // n10 is root
+        // Let's say n5 is its RED left child
+        n10->set_left_child(n5, Color::RED);
+        // And n15 is its BLACK right child
+        n10->set_right_child(n15, Color::BLACK);
+    }
+
+    // n5 (RED) must have BLACK children
+    n5->set_left_child(n3, Color::BLACK);
+    n5->set_right_child(n7, Color::BLACK);
+
+    // n15 (BLACK) can have RED or BLACK children
+    // Let's leave its children as null (implicitly BLACK from constructor)
+
+    std::cout << "\n--- Tree Structure ---" << std::endl;
+    tree.print_node_info(n10);
+    tree.print_node_info(n5);
+    tree.print_node_info(n15);
+    tree.print_node_info(n3);
+    tree.print_node_info(n7);
+
+    std::cout << "\n--- Modifying a tag ---" << std::endl;
+    std::cout << "n10's left child (" << n5->key << ") current color: "
+              << RBNode::color_to_string(n10->get_left_color()) << std::endl;
+
+    n10->left.set_tag(static_cast<uint8_t>(Color::BLACK)); // Change n5's color via n10's TaggedPtr
+
+    std::cout << "n10's left child (" << n5->key << ") new color: "
+              << RBNode::color_to_string(n10->get_left_color()) << std::endl;
+    ASSERT_TRUE(n10->get_left_color() == Color::BLACK, "Color change verification");
+
+
+    std::cout << "\nExample finished." << std::endl;
+
+    return 0;
+}
+
+// #undef ASSERT_TRUE // No longer needed here as it's defined at the top
+// #define ASSERT_TRUE(condition, message) \ // No longer needed here
+//     if (!(condition)) { \
+//         std::cerr << "Assertion failed in example: (" #condition ") is not true - " << (message) << std::endl; \
+//         exit(1); \
+//     }

--- a/include/tagged_ptr.h
+++ b/include/tagged_ptr.h
@@ -1,0 +1,94 @@
+#ifndef TAGGED_PTR_H
+#define TAGGED_PTR_H
+
+#include <cstdint>
+#include <cstddef> // For size_t, uintptr_t
+#include <type_traits> // For std::is_pointer, std::remove_pointer
+
+template <typename T, unsigned TagBits>
+class TaggedPtr {
+public:
+    static_assert(TagBits < sizeof(uintptr_t) * 8, "TagBits must be less than the number of bits in a pointer.");
+    // The alignment check for T will be done in constructors or methods where T is expected to be complete.
+
+    // Mask to extract the tag
+    static constexpr uintptr_t TAG_MASK = (static_cast<uintptr_t>(1) << TagBits) - 1;
+    // Mask to extract the pointer
+    static constexpr uintptr_t POINTER_MASK = ~TAG_MASK;
+
+private:
+    // Helper to perform the alignment check.
+    // This can be called from constructors or methods once T is complete.
+    static constexpr void check_alignment() {
+        static_assert(alignof(T) >= (static_cast<std::size_t>(1) << TagBits),
+                      "Insufficient pointer alignment for the requested number of tag bits. "
+                      "alignof(T) must be >= 2^TagBits.");
+    }
+
+public:
+    TaggedPtr() : data_(0) {
+        // Check alignment when a TaggedPtr object is created.
+        // This ensures T is complete at this point for non-global/static objects.
+        if constexpr (TagBits > 0) { // Avoid check if no bits are used for tag.
+            check_alignment();
+        }
+    }
+
+    TaggedPtr(T* ptr, uint8_t tag) : data_(0) {
+        if constexpr (TagBits > 0) { check_alignment(); }
+        set(ptr, tag);
+    }
+
+    void set(T* ptr, uint8_t tag) {
+        // Optional: runtime check for actual pointer alignment if desired, e.g., assert((reinterpret_cast<uintptr_t>(ptr) & TAG_MASK) == 0);
+        uintptr_t ptr_val = reinterpret_cast<uintptr_t>(ptr);
+        data_ = (ptr_val & POINTER_MASK) | (static_cast<uintptr_t>(tag) & TAG_MASK);
+    }
+
+    void set_ptr(T* ptr) {
+        // Optional: runtime check for actual pointer alignment
+        uintptr_t ptr_val = reinterpret_cast<uintptr_t>(ptr);
+        data_ = (ptr_val & POINTER_MASK) | (data_ & TAG_MASK);
+    }
+
+    void set_tag(uint8_t tag) {
+        data_ = (data_ & POINTER_MASK) | (static_cast<uintptr_t>(tag) & TAG_MASK);
+    }
+
+    T* get_ptr() const {
+        return reinterpret_cast<T*>(data_ & POINTER_MASK);
+    }
+
+    uint8_t get_tag() const {
+        return static_cast<uint8_t>(data_ & TAG_MASK);
+    }
+
+    uintptr_t as_uintptr_t() const {
+        return data_;
+    }
+
+    static TaggedPtr from_raw(uintptr_t raw) {
+        // Check alignment when from_raw is called, as T should be known and complete here.
+        if constexpr (TagBits > 0) { check_alignment(); }
+        TaggedPtr p;
+        p.data_ = raw;
+        return p;
+    }
+
+    bool operator==(const TaggedPtr& other) const {
+        return data_ == other.data_;
+    }
+
+    bool operator!=(const TaggedPtr& other) const {
+        return data_ != other.data_;
+    }
+
+    static constexpr size_t max_tag() {
+        return (static_cast<size_t>(1) << TagBits) - 1;
+    }
+
+private:
+    uintptr_t data_;
+};
+
+#endif // TAGGED_PTR_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         InvertedIndexLib     # Added for inverted_index_test
         OneOfLib             # Added for one_of_test
         ChronoRingLib        # Added for chrono_ring_test
+        TaggedPtrLib         # Added for tagged_ptr_test
     )
 
     # Specific configurations for certain tests

--- a/tests/tagged_ptr_test.cpp
+++ b/tests/tagged_ptr_test.cpp
@@ -1,0 +1,205 @@
+#include "gtest/gtest.h"
+#include "../include/tagged_ptr.h" // Adjust path as necessary based on include directories
+#include <cstdint> // For uintptr_t, uint8_t
+#include <cstddef> // For size_t
+
+// Define some test structures with specific alignments
+struct alignas(8) AlignedStruct8 {
+    int data;
+    char c;
+    bool operator==(const AlignedStruct8& other) const {
+        return data == other.data && c == other.c;
+    }
+};
+
+struct alignas(16) AlignedStruct16 {
+    long long data;
+    char c;
+     bool operator==(const AlignedStruct16& other) const {
+        return data == other.data && c == other.c;
+    }
+};
+
+// This struct is intentionally misaligned for some tests if TagBits > 2
+struct alignas(4) AlignedStruct4 {
+    int data;
+     bool operator==(const AlignedStruct4& other) const {
+        return data == other.data;
+    }
+};
+
+// Test fixture for TaggedPtr tests
+class TaggedPtrTest : public ::testing::Test {
+protected:
+    AlignedStruct8 obj8_1, obj8_2;
+    AlignedStruct16 obj16_1, obj16_2;
+    // AlignedStruct4 obj4_1; // Used for compile-time tests manually
+};
+
+TEST_F(TaggedPtrTest, BasicEncodingDecoding) {
+    TaggedPtr<AlignedStruct8, 3> tp; // 3 bits for tag, alignof(AlignedStruct8) == 8
+
+    tp.set(&obj8_1, 0);
+    EXPECT_EQ(tp.get_ptr(), &obj8_1);
+    EXPECT_EQ(tp.get_tag(), 0);
+
+    tp.set(&obj8_2, 5); // 5 is 101 in binary
+    EXPECT_EQ(tp.get_ptr(), &obj8_2);
+    EXPECT_EQ(tp.get_tag(), 5);
+}
+
+TEST_F(TaggedPtrTest, ConstructorInitialization) {
+    TaggedPtr<AlignedStruct8, 3> tp(&obj8_1, 7);
+    EXPECT_EQ(tp.get_ptr(), &obj8_1);
+    EXPECT_EQ(tp.get_tag(), 7);
+}
+
+TEST_F(TaggedPtrTest, NullPtrHandling) {
+    TaggedPtr<AlignedStruct16, 4> tp;
+
+    tp.set(nullptr, 3);
+    EXPECT_EQ(tp.get_ptr(), nullptr);
+    EXPECT_EQ(tp.get_tag(), 3);
+
+    tp.set_ptr(nullptr); // Should preserve tag
+    EXPECT_EQ(tp.get_ptr(), nullptr);
+    EXPECT_EQ(tp.get_tag(), 3);
+
+    TaggedPtr<AlignedStruct16, 4> tp_with_null_constructor(nullptr, 10);
+    EXPECT_EQ(tp_with_null_constructor.get_ptr(), nullptr);
+    EXPECT_EQ(tp_with_null_constructor.get_tag(), 10);
+}
+
+TEST_F(TaggedPtrTest, TagOperations) {
+    TaggedPtr<AlignedStruct16, 4> tp(&obj16_1, 1); // 4 bits for tag
+
+    EXPECT_EQ(tp.get_ptr(), &obj16_1);
+    EXPECT_EQ(tp.get_tag(), 1);
+
+    tp.set_tag(10); // Max tag is 15 (2^4 - 1)
+    EXPECT_EQ(tp.get_ptr(), &obj16_1); // Pointer preserved
+    EXPECT_EQ(tp.get_tag(), 10);
+
+    tp.set_tag(15); // Max tag
+    EXPECT_EQ(tp.get_tag(), 15);
+
+    // Test tag truncation (current implementation truncates)
+    // TagBits = 4, so max_tag = 15. 16 (10000) should be truncated to 0 (0000).
+    tp.set_tag(16);
+    EXPECT_EQ(tp.get_tag(), 0);
+
+    tp.set_tag(TaggedPtr<AlignedStruct16, 4>::max_tag());
+    EXPECT_EQ(tp.get_tag(), (TaggedPtr<AlignedStruct16, 4>::max_tag()));
+    EXPECT_EQ(tp.get_tag(), 15);
+}
+
+TEST_F(TaggedPtrTest, PointerOperations) {
+    TaggedPtr<AlignedStruct8, 2> tp(&obj8_1, 3); // 2 bits for tag
+
+    EXPECT_EQ(tp.get_ptr(), &obj8_1);
+    EXPECT_EQ(tp.get_tag(), 3);
+
+    tp.set_ptr(&obj8_2);
+    EXPECT_EQ(tp.get_ptr(), &obj8_2); // Pointer updated
+    EXPECT_EQ(tp.get_tag(), 3);       // Tag preserved
+}
+
+TEST_F(TaggedPtrTest, RawValueConversion) {
+    TaggedPtr<AlignedStruct16, 3> tp1(&obj16_1, 5);
+    uintptr_t raw_val = tp1.as_uintptr_t();
+
+    TaggedPtr<AlignedStruct16, 3> tp2 = TaggedPtr<AlignedStruct16, 3>::from_raw(raw_val);
+    EXPECT_EQ(tp1.get_ptr(), tp2.get_ptr());
+    EXPECT_EQ(tp1.get_tag(), tp2.get_tag());
+    EXPECT_EQ(tp1, tp2); // Uses operator==
+
+    // Check with nullptr
+    tp1.set(nullptr, 2);
+    raw_val = tp1.as_uintptr_t();
+    tp2 = TaggedPtr<AlignedStruct16, 3>::from_raw(raw_val);
+    EXPECT_EQ(tp2.get_ptr(), nullptr);
+    EXPECT_EQ(tp2.get_tag(), 2);
+    EXPECT_EQ(tp1, tp2);
+}
+
+TEST_F(TaggedPtrTest, ComparisonOperators) {
+    TaggedPtr<AlignedStruct8, 1> tp1(&obj8_1, 0);
+    TaggedPtr<AlignedStruct8, 1> tp2(&obj8_1, 0); // Same as tp1
+    TaggedPtr<AlignedStruct8, 1> tp3(&obj8_1, 1); // Same ptr, different tag
+    TaggedPtr<AlignedStruct8, 1> tp4(&obj8_2, 0); // Different ptr, same tag
+    TaggedPtr<AlignedStruct8, 1> tp_null1(nullptr, 0);
+    TaggedPtr<AlignedStruct8, 1> tp_null2(nullptr, 0); // Same as tp_null1
+    TaggedPtr<AlignedStruct8, 1> tp_null_tag(nullptr, 1); // Nullptr, different tag
+
+    EXPECT_TRUE(tp1 == tp2);
+    EXPECT_FALSE(tp1 != tp2);
+
+    EXPECT_TRUE(tp1 != tp3);
+    EXPECT_FALSE(tp1 == tp3);
+
+    EXPECT_TRUE(tp1 != tp4);
+    EXPECT_FALSE(tp1 == tp4);
+
+    EXPECT_TRUE(tp_null1 == tp_null2);
+    EXPECT_FALSE(tp_null1 != tp_null2);
+
+    EXPECT_TRUE(tp_null1 != tp_null_tag);
+    EXPECT_FALSE(tp_null1 == tp_null_tag);
+}
+
+TEST_F(TaggedPtrTest, MaxTagValue) {
+    EXPECT_EQ((TaggedPtr<AlignedStruct8, 1>::max_tag()), 1);  // 2^1 - 1
+    EXPECT_EQ((TaggedPtr<AlignedStruct8, 2>::max_tag()), 3);  // 2^2 - 1
+    EXPECT_EQ((TaggedPtr<AlignedStruct8, 3>::max_tag()), 7);  // 2^3 - 1
+    EXPECT_EQ((TaggedPtr<AlignedStruct16, 4>::max_tag()), 15); // 2^4 - 1
+}
+
+// Test for alignment static_assert.
+// This test doesn't run; its purpose is to fail compilation if static_assert works.
+// To verify:
+// 1. Uncomment the line inside the function.
+// 2. Try to compile. It should fail with a static_assert message.
+// 3. Comment it back to allow other tests to compile and run.
+/*
+TEST_F(TaggedPtrTest, CompileTimeAlignmentCheck) {
+    // AlignedStruct4 has alignof(4). Requesting 3 tag bits requires 2^3 = 8 byte alignment.
+    // This line should cause a static_assert to trigger during compilation.
+    // TaggedPtr<AlignedStruct4, 3> tp_compile_fail;
+    // (void)tp_compile_fail; // Suppress unused variable warning if it were to compile
+}
+*/
+
+// It might also be useful to test with void* if the TaggedPtr is intended for such use.
+// For example, TaggedPtr<void, 3> could point to any type of data.
+// The current static_assert relies on alignof(T), which is problematic for T=void.
+// A specialization or SFINAE might be needed for TaggedPtr<void, TagBits>.
+// For now, assuming T is a concrete, alignable type.
+
+TEST_F(TaggedPtrTest, ZeroTagBits) {
+    // What happens if TagBits is 0?
+    // static_assert(TagBits < sizeof(uintptr_t) * 8, ...) - passes
+    // static_assert(alignof(T) >= (1 << TagBits), ...) -> alignof(T) >= (1 << 0) -> alignof(T) >= 1. This is always true.
+    // TAG_MASK = (1 << 0) - 1 = 1 - 1 = 0
+    // POINTER_MASK = ~0 = all 1s.
+    TaggedPtr<AlignedStruct8, 0> tp(&obj8_1, 123); // Tag should be ignored/masked to 0
+
+    EXPECT_EQ(tp.get_ptr(), &obj8_1);
+    EXPECT_EQ(tp.get_tag(), 0); // Tag is masked out
+    EXPECT_EQ((TaggedPtr<AlignedStruct8, 0>::max_tag()), 0);
+
+    tp.set_tag(42); // Should have no effect on the tag, it remains 0
+    EXPECT_EQ(tp.get_tag(), 0);
+
+    uintptr_t raw = tp.as_uintptr_t();
+    EXPECT_EQ(raw, reinterpret_cast<uintptr_t>(&obj8_1)); // Raw value is just the pointer
+
+    TaggedPtr<AlignedStruct8, 0> tp2 = TaggedPtr<AlignedStruct8, 0>::from_raw(reinterpret_cast<uintptr_t>(&obj8_2));
+    EXPECT_EQ(tp2.get_ptr(), &obj8_2);
+    EXPECT_EQ(tp2.get_tag(), 0);
+}
+
+// Main function for Google Test is usually not needed here if linked with GTest::gtest_main
+// int main(int argc, char **argv) {
+//     ::testing::InitGoogleTest(&argc, argv);
+//     return RUN_ALL_TESTS();
+// }


### PR DESCRIPTION
This commit introduces TaggedPtr<T, TagBits>, a header-only C++17 utility that allows storing a pointer and a small integer tag within a single machine word. This is achieved by utilizing the lower unused bits of aligned pointers.

Key features:
- `set(T* ptr, uint8_t tag)`: Sets pointer and tag.
- `get_ptr()`, `get_tag()`: Retrieve pointer and tag.
- `set_ptr(T*)`, `set_tag(uint8_t)`: Modify pointer or tag individually.
- `as_uintptr_t()`, `from_raw(uintptr_t)`: Convert to/from raw integer.
- `operator==/!=`: Compare TaggedPtr instances.
- `static constexpr size_t max_tag()`: Get maximum storable tag.
- Compile-time `static_assert` to ensure `alignof(T)` is sufficient for the requested `TagBits`.

Includes:
- Implementation in `include/tagged_ptr.h`.
- Unit tests in `tests/tagged_ptr_test.cpp` using Google Test.
- An example in `examples/tagged_ptr_example.cpp` demonstrating usage with a simplified Red-Black Tree node.
- Updates to CMakeLists.txt to integrate the new library, example, and tests.