### PR TITLE
feat: Add WeightedSet data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,10 @@ target_include_directories(StatBufferLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/i
 add_library(DequeMapLib INTERFACE)
 target_include_directories(DequeMapLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define WeightedSetLib as an interface library (header-only)
+add_library(WeightedSetLib INTERFACE)
+target_include_directories(WeightedSetLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -349,6 +353,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         ShadowCopyLib        # Added for shadow_copy_example
         StatBufferLib        # Added for stat_buffer_example
         DequeMapLib          # Added for deque_map_example
+        WeightedSetLib       # Added for weighted_set_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/docs/README_weighted_set.md
+++ b/docs/README_weighted_set.md
@@ -1,0 +1,214 @@
+# WeightedSet Data Structure
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Purpose](#purpose)
+3. [API Reference](#api-reference)
+    - [Template Parameters](#template-parameters)
+    - [Type Aliases](#type-aliases)
+    - [Constructors](#constructors)
+    - [Modifiers](#modifiers)
+    - [Lookup](#lookup)
+    - [Sampling](#sampling)
+    - [Capacity](#capacity)
+    - [Iterators](#iterators)
+    - [Comparison](#comparison)
+    - [Swap](#swap)
+4. [Usage Example](#usage-example)
+5. [Time Complexity](#time-complexity)
+6. [Thread Safety](#thread-safety)
+
+## Overview
+
+`cpp_collections::WeightedSet<Key, WeightType, Compare>` is a C++ data structure that stores a collection of unique keys, each associated with a numerical weight. It allows for efficient addition, removal, and updating of key-weights, and most importantly, provides a mechanism to randomly sample keys based on their assigned weights. Keys with higher weights have a proportionally higher probability of being selected during sampling.
+
+It is implemented as a header-only library and aims to be idiomatic C++17/C++20.
+
+## Purpose
+
+The `WeightedSet` is useful in scenarios where elements need to be chosen randomly but with a bias determined by their importance or frequency, as represented by their weights. Common use cases include:
+
+-   **Probabilistic Sampling:** Implementing loot tables in games, selecting advertisements, A/B testing variations.
+-   **Weighted Random Selection:** Choosing a server based on load or capacity, weighted selection in simulations.
+-   **Data Analysis:** Sampling data points where each point has a different level of significance.
+
+It provides an alternative to manually managing weights in a `std::vector` or `std::map` and performing complex calculations for weighted sampling.
+
+## API Reference
+
+```cpp
+namespace cpp_collections {
+
+template <
+    typename Key,
+    typename WeightType = double,
+    typename Compare = std::less<Key>
+>
+class WeightedSet {
+public:
+    // ... public interface ...
+};
+
+} // namespace cpp_collections
+```
+
+### Template Parameters
+
+-   `Key`: The type of the keys stored in the set.
+-   `WeightType`: The numerical type used for weights (defaults to `double`). Must support arithmetic operations and comparison.
+-   `Compare`: A comparison function object type that defines the ordering of keys (defaults to `std::less<Key>`). Used by the underlying `std::map`.
+
+### Type Aliases
+
+-   `key_type = Key`
+-   `weight_type = WeightType`
+-   `key_compare = Compare`
+-   `value_type = std::pair<const Key, WeightType>`: Type of elements iterated over.
+-   `map_type = std::map<Key, WeightType, Compare>`: Underlying map type.
+-   `size_type = typename map_type::size_type`: Unsigned integer type for sizes.
+-   `iterator = typename map_type::iterator`
+-   `const_iterator = typename map_type::const_iterator`
+
+### Constructors
+
+-   `WeightedSet()`
+    -   Default constructor. Creates an empty `WeightedSet`.
+-   `explicit WeightedSet(const key_compare& comp)`
+    -   Creates an empty `WeightedSet` with a custom key comparator.
+-   `template<typename InputIt> WeightedSet(InputIt first, InputIt last, const key_compare& comp = key_compare())`
+    -   Constructs with elements from an iterator range `[first, last)`. `InputIt` must dereference to a pair-like object (e.g., `std::pair<Key, WeightType>`).
+-   `WeightedSet(std::initializer_list<value_type> ilist, const key_compare& comp = key_compare())`
+    -   Constructs with elements from an initializer list.
+-   `WeightedSet(const WeightedSet& other)`
+    -   Copy constructor.
+-   `WeightedSet(WeightedSet&& other) noexcept`
+    -   Move constructor.
+
+### Modifiers
+
+-   `void add(const key_type& key, weight_type weight)`
+-   `void add(key_type&& key, weight_type weight)`
+    -   Adds `key` with the given `weight`. If `key` already exists, its weight is updated.
+    -   If `weight` is less than or equal to `0`, the `key` is effectively removed from the set (if it exists) or not added.
+    -   Invalidates internal sampling cache.
+-   `bool remove(const key_type& key)`
+    -   Removes `key` from the set. Returns `true` if the key was found and removed, `false` otherwise.
+    -   Invalidates internal sampling cache if an item is removed.
+
+### Lookup
+
+-   `weight_type get_weight(const key_type& key) const`
+    -   Returns the weight of `key`. If `key` is not found, returns `0`.
+-   `bool contains(const key_type& key) const`
+    -   Returns `true` if `key` is in the set (i.e., was added with a positive weight), `false` otherwise.
+
+### Sampling
+
+-   `const key_type& sample() const`
+    -   Randomly samples a key from the set based on current weights.
+    -   Keys with higher weights are more likely to be selected.
+    -   Throws `std::out_of_range` if the set is empty or if the total positive weight is zero.
+    -   This method is logically `const` but may modify internal mutable caches for sampling efficiency.
+
+### Capacity
+
+-   `bool empty() const noexcept`
+    -   Returns `true` if the set contains no items, `false` otherwise.
+-   `size_type size() const noexcept`
+    -   Returns the number of unique keys in the set.
+-   `weight_type total_weight() const noexcept`
+    -   Returns the sum of all positive weights currently in the set.
+
+### Iterators
+
+The `WeightedSet` provides iterators that allow iterating over the `(key, weight)` pairs in the order defined by the `Compare` function (key-sorted by default).
+
+-   `iterator begin() noexcept`
+-   `const_iterator begin() const noexcept`
+-   `const_iterator cbegin() const noexcept`
+-   `iterator end() noexcept`
+-   `const_iterator end() const noexcept`
+-   `const_iterator cend() const noexcept`
+
+### Comparison
+
+-   `key_compare key_comp() const`
+    -   Returns the key comparison function object.
+
+### Swap
+
+-   `void swap(WeightedSet& other) noexcept(...)`
+    -   Exchanges the contents of this `WeightedSet` with `other`.
+-   `template <typename K, typename W, typename C> void swap(WeightedSet<K, W, C>& lhs, WeightedSet<K, W, C>& rhs) noexcept(...)`
+    -   Non-member swap function.
+
+## Usage Example
+
+```cpp
+#include "weighted_set.h"
+#include <iostream>
+#include <string>
+#include <map>
+
+int main() {
+    cpp_collections::WeightedSet<std::string, double> loot_table;
+
+    loot_table.add("Sword", 10.0);
+    loot_table.add("Shield", 10.0);
+    loot_table.add("Potion", 25.0);
+    loot_table.add("Gold Coin", 50.0);
+    loot_table.add("Rare Gem", 5.0);
+
+    std::cout << "Loot Table (Total Weight: " << loot_table.total_weight() << "):\n";
+    for (const auto& item : loot_table) {
+        std::cout << "  Item: " << item.first << ", Weight: " << item.second << "\n";
+    }
+
+    std::cout << "\nPerforming 10000 samples:\n";
+    std::map<std::string, int> counts;
+    if (!loot_table.empty() && loot_table.total_weight() > 0) {
+        for (int i = 0; i < 10000; ++i) {
+            try {
+                counts[loot_table.sample()]++;
+            } catch (const std::out_of_range& e) {
+                std::cerr << "Error during sampling: " << e.what() << std::endl;
+                break;
+            }
+        }
+    }
+
+    std::cout << "Sample counts:\n";
+    for (const auto& pair : counts) {
+        std::cout << "  " << pair.first << ": " << pair.second << " times\n";
+    }
+
+    return 0;
+}
+```
+
+## Time Complexity
+
+Let `N` be the number of items in the `WeightedSet`.
+The underlying data structure is a `std::map`.
+
+-   **`add(key, weight)`**: `O(log N)` due to `std::map::insert_or_assign`. Sets a flag indicating sampling data is stale.
+-   **`remove(key)`**: `O(log N)` due to `std::map::erase`. Sets a flag indicating sampling data is stale.
+-   **`get_weight(key)`**: `O(log N)` due to `std::map::find`.
+-   **`contains(key)`**: `O(log N)` due to `std::map::count`.
+-   **`sample()`**:
+    -   If sampling data is up-to-date: `O(log N)` for binary search on the cumulative weight vector.
+    -   If sampling data is stale: `O(N)` to rebuild the cumulative weight vector, then `O(log N)` for binary search. The rebuild happens only once after modifications until the next sample call.
+    -   Amortized complexity depends on the frequency of modifications versus sampling. If sampling is done frequently after many modifications, each sample effectively costs `O(N)`. If modifications are rare, most samples are `O(log N)`.
+-   **`empty()`**: `O(1)`.
+-   **`size()`**: `O(1)`.
+-   **`total_weight()`**: `O(N)` as it iterates through all items to sum positive weights.
+-   **Iterators**: Standard `std::map` iterator complexity. Increment/decrement is typically amortized `O(log N)` or `O(1)` in some cases. Traversal of all elements is `O(N)`.
+
+## Thread Safety
+
+The `WeightedSet` class is **not** thread-safe for concurrent write operations or mixed read/write operations without external synchronization.
+-   Concurrent calls to non-`const` methods (e.g., `add`, `remove`) from multiple threads must be synchronized.
+-   Concurrent calls to `const` methods (e.g., `get_weight`, `contains`, `size`, `empty`, iterators) are generally safe if no other thread is modifying the `WeightedSet`.
+-   The `sample()` method, although `const`, modifies internal mutable caches (`cumulative_items_`, `total_weight_for_sampling_`, `stale_sampling_data_`, `random_engine_`). If multiple threads call `sample()` concurrently, it can lead to data races on these mutable members. The `random_engine_` itself is not thread-safe for concurrent calls. Therefore, calls to `sample()` from multiple threads also require external synchronization, even on a `const WeightedSet` object.
+
+For multi-threaded scenarios, appropriate locking mechanisms (e.g., `std::mutex`) should be employed to protect access to `WeightedSet` instances.

--- a/examples/weighted_set_example.cpp
+++ b/examples/weighted_set_example.cpp
@@ -1,0 +1,134 @@
+#include "weighted_set.h"
+#include <iostream>
+#include <string>
+#include <vector>
+#include <iomanip> // For std::fixed and std::setprecision
+
+void print_line() {
+    std::cout << "----------------------------------------\n";
+}
+
+int main() {
+    std::cout << "WeightedSet Example\n";
+    print_line();
+
+    // Create a WeightedSet with strings as keys and doubles as weights
+    cpp_collections::WeightedSet<std::string, double> loot_table;
+
+    // Add items with weights
+    std::cout << "Adding items to the loot table...\n";
+    loot_table.add("Sword", 10.0);
+    loot_table.add("Shield", 10.0);
+    loot_table.add("Potion", 25.0);
+    loot_table.add("Gold Coin", 50.0);
+    loot_table.add("Rare Gem", 5.0);
+
+    std::cout << "Initial loot table (size: " << loot_table.size() << ", total weight: " << loot_table.total_weight() << "):\n";
+    for (const auto& item : loot_table) {
+        std::cout << "  Item: " << std::setw(10) << std::left << item.first
+                  << " Weight: " << item.second << "\n";
+    }
+    print_line();
+
+    // Demonstrate get_weight and contains
+    std::cout << "Weight of Potion: " << loot_table.get_weight("Potion") << "\n";
+    std::cout << "Weight of Dagger (not present): " << loot_table.get_weight("Dagger") << "\n";
+    std::cout << "Contains Shield? " << std::boolalpha << loot_table.contains("Shield") << "\n";
+    std::cout << "Contains Armor? " << std::boolalpha << loot_table.contains("Armor") << "\n";
+    print_line();
+
+    // Demonstrate updating an item's weight
+    std::cout << "Updating weight of Gold Coin to 60.0...\n";
+    loot_table.add("Gold Coin", 60.0);
+    std::cout << "Weight of Gold Coin after update: " << loot_table.get_weight("Gold Coin") << "\n";
+    std::cout << "Total weight after update: " << loot_table.total_weight() << "\n";
+    print_line();
+
+    // Demonstrate removing an item
+    std::cout << "Removing Shield...\n";
+    loot_table.remove("Shield");
+    std::cout << "Contains Shield after removal? " << std::boolalpha << loot_table.contains("Shield") << "\n";
+    std::cout << "Loot table size after removal: " << loot_table.size() << "\n";
+    std::cout << "Total weight after removal: " << loot_table.total_weight() << "\n";
+    print_line();
+
+    // Demonstrate adding an item with zero weight (should effectively not add or remove if present)
+    std::cout << "Trying to add 'Scroll' with 0.0 weight...\n";
+    loot_table.add("Scroll", 0.0);
+    std::cout << "Contains Scroll? " << std::boolalpha << loot_table.contains("Scroll") << "\n";
+    std::cout << "Size: " << loot_table.size() << "\n";
+    print_line();
+
+    // Demonstrate sampling
+    std::cout << "Sampling 10 items from the loot table:\n";
+    if (loot_table.empty() || loot_table.total_weight() <= 0) {
+        std::cout << "Cannot sample, loot table is effectively empty.\n";
+    } else {
+        std::map<std::string, int> sample_counts;
+        const int num_samples = 100000; // Increased samples for better statistical view
+        std::cout << "Performing " << num_samples << " samples to see distribution...\n";
+        for (int i = 0; i < num_samples; ++i) {
+            try {
+                sample_counts[loot_table.sample()]++;
+            } catch (const std::out_of_range& e) {
+                std::cerr << "Error during sampling: " << e.what() << std::endl;
+                break;
+            }
+        }
+
+        std::cout << "\nSampled item counts (out of " << num_samples << " samples):\n";
+        for (const auto& pair : sample_counts) {
+            double percentage = static_cast<double>(pair.second) / num_samples * 100.0;
+            std::cout << "  Item: " << std::setw(10) << std::left << pair.first
+                      << " Count: " << std::setw(7) << std::right << pair.second
+                      << " (" << std::fixed << std::setprecision(2) << percentage << "%)\n";
+        }
+
+        std::cout << "\nExpected distribution based on current weights:\n";
+        double current_total_weight = loot_table.total_weight();
+        if (current_total_weight > 0) {
+            for(const auto& item : loot_table) {
+                double expected_percentage = (item.second / current_total_weight) * 100.0;
+                 std::cout << "  Item: " << std::setw(10) << std::left << item.first
+                           << " Expected: (" << std::fixed << std::setprecision(2) << expected_percentage << "%)\n";
+            }
+        }
+    }
+    print_line();
+
+    // Test with integer keys and weights
+    cpp_collections::WeightedSet<int, int> number_set;
+    number_set.add(1, 10);
+    number_set.add(2, 20);
+    number_set.add(3, 70);
+
+    std::cout << "Number set (total weight: " << number_set.total_weight() << "):\n";
+     for (const auto& item : number_set) {
+        std::cout << "  Item: " << item.first << " Weight: " << item.second << "\n";
+    }
+    std::cout << "Sampling 5 numbers:\n";
+    if(!number_set.empty() && number_set.total_weight() > 0) {
+        for (int i = 0; i < 5; ++i) {
+            std::cout << "  Sampled: " << number_set.sample() << "\n";
+        }
+    } else {
+        std::cout << "Cannot sample from number_set.\n";
+    }
+    print_line();
+
+    // Test construction with initializer list
+    cpp_collections::WeightedSet<char, unsigned int> char_set = {
+        {'a', 100}, {'b', 50}, {'c', 25}, {'d', 5}
+    };
+    std::cout << "Character set from initializer list (total weight: " << char_set.total_weight() << "):\n";
+    for (const auto& item : char_set) {
+        std::cout << "  Char: " << item.first << " Weight: " << item.second << "\n";
+    }
+     if(!char_set.empty() && char_set.total_weight() > 0) {
+        std::cout << "Sampled char: " << char_set.sample() << "\n";
+    }
+    print_line();
+
+    std::cout << "Example finished.\n";
+    return 0;
+}

--- a/include/weighted_set.h
+++ b/include/weighted_set.h
@@ -1,0 +1,305 @@
+#pragma once
+
+#include <map>
+#include <vector>
+#include <string>
+#include <random>
+#include <stdexcept>
+#include <numeric>
+#include <algorithm>
+#include <functional>
+#include <limits> // Required for std::numeric_limits
+
+namespace cpp_collections {
+
+template <
+    typename Key,
+    typename WeightType = double,
+    typename Compare = std::less<Key>
+>
+class WeightedSet {
+public:
+    using key_type = Key;
+    using weight_type = WeightType;
+    using key_compare = Compare;
+    using value_type = std::pair<const Key, WeightType>; // For iterators over item_weights_
+    using map_type = std::map<Key, WeightType, Compare>;
+    using size_type = typename map_type::size_type;
+
+private:
+    map_type item_weights_;
+
+    mutable std::vector<std::pair<Key, WeightType>> cumulative_items_;
+    mutable WeightType total_weight_for_sampling_;
+    mutable bool stale_sampling_data_;
+    mutable std::mt19937 random_engine_;
+
+    void rebuild_sampling_data_() const {
+        cumulative_items_.clear();
+        // Optimization: Only reserve if item_weights_ is not empty.
+        if (!item_weights_.empty()) {
+            cumulative_items_.reserve(item_weights_.size());
+        }
+
+        WeightType current_cumulative_weight = static_cast<WeightType>(0);
+        for (const auto& pair : item_weights_) {
+            // Only include items with strictly positive weight in the sampling distribution
+            if (pair.second > static_cast<WeightType>(0)) {
+                current_cumulative_weight += pair.second;
+                cumulative_items_.emplace_back(pair.first, current_cumulative_weight);
+            }
+        }
+        total_weight_for_sampling_ = current_cumulative_weight;
+        stale_sampling_data_ = false;
+    }
+
+public:
+    using iterator = typename map_type::iterator;
+    using const_iterator = typename map_type::const_iterator;
+
+    WeightedSet()
+        : item_weights_(),
+          total_weight_for_sampling_(static_cast<WeightType>(0)),
+          stale_sampling_data_(true) {
+        std::random_device rd;
+        random_engine_.seed(rd());
+    }
+
+    explicit WeightedSet(const key_compare& comp)
+        : item_weights_(comp),
+          total_weight_for_sampling_(static_cast<WeightType>(0)),
+          stale_sampling_data_(true) {
+        std::random_device rd;
+        random_engine_.seed(rd());
+    }
+
+    template<typename InputIt>
+    WeightedSet(InputIt first, InputIt last, const key_compare& comp = key_compare())
+        : item_weights_(comp),
+          total_weight_for_sampling_(static_cast<WeightType>(0)),
+          stale_sampling_data_(true) {
+        std::random_device rd;
+        random_engine_.seed(rd());
+        for (InputIt it = first; it != last; ++it) {
+            // Assuming InputIt dereferences to a pair compatible with add's arguments
+            add(it->first, it->second);
+        }
+        // add() sets stale_sampling_data_, initial state is true anyway.
+    }
+
+    WeightedSet(std::initializer_list<value_type> ilist, const key_compare& comp = key_compare())
+        : item_weights_(comp),
+          total_weight_for_sampling_(static_cast<WeightType>(0)),
+          stale_sampling_data_(true) {
+        std::random_device rd;
+        random_engine_.seed(rd());
+        for (const auto& item : ilist) {
+            add(item.first, item.second);
+        }
+    }
+
+    WeightedSet(const WeightedSet& other)
+        : item_weights_(other.item_weights_),
+          total_weight_for_sampling_(static_cast<WeightType>(0)), // To be rebuilt
+          stale_sampling_data_(true), // Mark as stale, will be rebuilt on sample
+          random_engine_() { // Initialize new engine
+        std::random_device rd;
+        random_engine_.seed(rd());
+    }
+
+    WeightedSet(WeightedSet&& other) noexcept
+        : item_weights_(std::move(other.item_weights_)),
+          cumulative_items_(std::move(other.cumulative_items_)),
+          total_weight_for_sampling_(other.total_weight_for_sampling_),
+          stale_sampling_data_(other.stale_sampling_data_),
+          random_engine_(std::move(other.random_engine_)) {
+        other.stale_sampling_data_ = true; // Leave other in a valid but stale state
+        other.total_weight_for_sampling_ = static_cast<WeightType>(0);
+    }
+
+    WeightedSet& operator=(const WeightedSet& other) {
+        if (this == &other) return *this;
+        item_weights_ = other.item_weights_;
+        cumulative_items_.clear(); // Clear local cache
+        total_weight_for_sampling_ = static_cast<WeightType>(0);
+        stale_sampling_data_ = true;
+        // random_engine_ can keep its current seed or be re-seeded
+        // std::random_device rd; random_engine_.seed(rd());
+        return *this;
+    }
+
+    WeightedSet& operator=(WeightedSet&& other) noexcept {
+        if (this == &other) return *this;
+        item_weights_ = std::move(other.item_weights_);
+        cumulative_items_ = std::move(other.cumulative_items_);
+        total_weight_for_sampling_ = other.total_weight_for_sampling_;
+        stale_sampling_data_ = other.stale_sampling_data_;
+        random_engine_ = std::move(other.random_engine_);
+
+        other.stale_sampling_data_ = true;
+        other.total_weight_for_sampling_ = static_cast<WeightType>(0);
+        other.cumulative_items_.clear();
+        return *this;
+    }
+
+    void add(const key_type& key, weight_type weight) {
+        if (weight <= static_cast<weight_type>(0)) {
+            // If adding with non-positive weight, key is effectively removed or not added.
+            // Call remove to ensure stale_sampling_data_ is flagged if key existed.
+            remove(key);
+        } else {
+            // Insert or update the weight
+            auto result = item_weights_.insert_or_assign(key, weight);
+            // No matter insert or assign, data is now stale for sampling.
+            stale_sampling_data_ = true;
+        }
+    }
+
+    void add(key_type&& key, weight_type weight) {
+        if (weight <= static_cast<weight_type>(0)) {
+            remove(std::move(key));
+        } else {
+            // Use item_weights_.insert_or_assign for rvalue key as well
+            item_weights_.insert_or_assign(std::move(key), weight);
+            stale_sampling_data_ = true;
+        }
+    }
+
+    bool remove(const key_type& key) {
+        if (item_weights_.erase(key) > 0) {
+            stale_sampling_data_ = true;
+            return true;
+        }
+        return false;
+    }
+
+    // Overload for rvalue key for remove, if map supports it (std::map::erase(K&&) is C++23)
+    // For now, relying on const Key& version is fine.
+
+    weight_type get_weight(const key_type& key) const {
+        const_iterator it = item_weights_.find(key);
+        if (it != item_weights_.end()) {
+            return it->second; // Returns the stored weight
+        }
+        return static_cast<weight_type>(0); // Key not found or weight is not positive
+    }
+
+    bool contains(const key_type& key) const {
+        // Check if key exists and has a positive weight considered by the structure.
+        // However, `item_weights_` only stores items added with positive weight due to `add` logic.
+        // So, a simple count is sufficient.
+        return item_weights_.count(key) > 0;
+    }
+
+    const key_type& sample() const {
+        if (item_weights_.empty()) {
+            throw std::out_of_range("Cannot sample from an empty WeightedSet.");
+        }
+        if (stale_sampling_data_) {
+            rebuild_sampling_data_();
+        }
+        // After rebuild, total_weight_for_sampling_ reflects sum of positive weights.
+        if (total_weight_for_sampling_ <= static_cast<weight_type>(0)) {
+            // This implies no items have positive weight
+            throw std::out_of_range("Cannot sample when total positive weight is zero or negative.");
+        }
+        // cumulative_items_ should not be empty if total_weight_for_sampling_ > 0
+        if (cumulative_items_.empty()) {
+             throw std::logic_error("Internal error: cumulative_items_ empty despite positive total_weight_for_sampling_.");
+        }
+
+        // Always use double for the distribution to satisfy std::uniform_real_distribution requirements.
+        // Cast total_weight_for_sampling_ to double for the upper bound.
+        // The distribution is [min, max), so random_val will be < total_weight_for_sampling_ (as double).
+        std::uniform_real_distribution<double> dist(
+            0.0,
+            static_cast<double>(total_weight_for_sampling_)
+        );
+        double random_val = dist(random_engine_);
+
+        // Ensure random_val is not exactly total_weight_for_sampling_ if the distribution is [min, max)
+        // and lower_bound would go past the end.
+        // For std::uniform_real_distribution, it's [a, b). So random_val < total_weight_for_sampling_
+        // (unless total_weight_for_sampling_ is 0, handled above).
+
+        auto it = std::lower_bound(cumulative_items_.begin(), cumulative_items_.end(), random_val,
+            [](const std::pair<Key, WeightType>& elem, WeightType val) {
+                // Find first element where cumulative weight is >= val.
+                // So, keep searching if elem.second < val.
+                return elem.second < val;
+            });
+
+        // If random_val is exactly 0, lower_bound correctly returns begin().
+        // If random_val is very close to total_weight_for_sampling_ (but less),
+        // it should correctly point to the last element.
+        if (it == cumulative_items_.end()) {
+            // This should ideally not happen if total_weight_for_sampling_ > 0
+            // and random_val is from a [0, total_weight_for_sampling_) range.
+            // Could happen if all weights are extremely small, leading to precision issues,
+            // or if random_val somehow equals total_weight_for_sampling_ (dist should be [0, T)).
+            // Fallback to the last item if list is not empty.
+            if (!cumulative_items_.empty()) {
+                 return cumulative_items_.back().first;
+            }
+             // This indicates a logic flaw or extreme edge case with weights.
+            throw std::logic_error("Internal error: sampling failed, lower_bound returned end unexpectedly.");
+        }
+        return it->first;
+    }
+
+    bool empty() const noexcept {
+        return item_weights_.empty();
+    }
+
+    size_type size() const noexcept {
+        return item_weights_.size();
+    }
+
+    weight_type total_weight() const noexcept {
+        // Calculate sum of (positive) weights currently in item_weights_.
+        // This is the true sum, distinct from total_weight_for_sampling_ cache.
+        WeightType current_total = static_cast<WeightType>(0);
+        for (const auto& pair : item_weights_) {
+            // add() ensures only positive weights are stored.
+            current_total += pair.second;
+        }
+        return current_total;
+    }
+
+    iterator begin() noexcept { return item_weights_.begin(); }
+    const_iterator begin() const noexcept { return item_weights_.cbegin(); } // Corrected to cbegin
+    const_iterator cbegin() const noexcept { return item_weights_.cbegin(); }
+
+    iterator end() noexcept { return item_weights_.end(); }
+    const_iterator end() const noexcept { return item_weights_.cend(); } // Corrected to cend
+    const_iterator cend() const noexcept { return item_weights_.cend(); }
+
+    key_compare key_comp() const {
+        return item_weights_.key_comp();
+    }
+
+    void swap(WeightedSet& other) noexcept(
+        /* std::is_nothrow_swappable_v<map_type> && // C++17
+        std::is_nothrow_swappable_v<std::vector<std::pair<Key, WeightType>>> &&
+        std::is_nothrow_swappable_v<WeightType> &&
+        std::is_nothrow_swappable_v<bool> &&
+        std::is_nothrow_swappable_v<std::mt19937> */
+        // Simplified noexcept, map swap is complex. Rely on map's allocator propagation.
+        std::allocator_traits<typename map_type::allocator_type>::propagate_on_container_swap::value ||
+        std::allocator_traits<typename map_type::allocator_type>::is_always_equal::value
+    ) {
+        using std::swap;
+        swap(item_weights_, other.item_weights_);
+        swap(cumulative_items_, other.cumulative_items_);
+        swap(total_weight_for_sampling_, other.total_weight_for_sampling_);
+        swap(stale_sampling_data_, other.stale_sampling_data_);
+        swap(random_engine_, other.random_engine_);
+    }
+};
+
+template <typename K, typename W, typename C>
+void swap(WeightedSet<K, W, C>& lhs, WeightedSet<K, W, C>& rhs) noexcept(noexcept(lhs.swap(rhs))) {
+    lhs.swap(rhs);
+}
+
+} // namespace cpp_collections

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         ShadowCopyLib        # Added for shadow_copy_test
         StatBufferLib        # Added for stat_buffer_test
         DequeMapLib          # Added for deque_map_test
+        WeightedSetLib       # Added for weighted_set_test
     )
 
     # Specific configurations for certain tests

--- a/tests/weighted_set_test.cpp
+++ b/tests/weighted_set_test.cpp
@@ -1,0 +1,441 @@
+#include "gtest/gtest.h"
+#include "weighted_set.h" // Adjust path as necessary based on include directories
+#include <string>
+#include <vector>
+#include <map>
+#include <cmath>     // For std::abs
+#include <limits>    // For std::numeric_limits
+
+// Using namespace for convenience in test file
+using namespace cpp_collections;
+
+TEST(WeightedSetTest, DefaultConstruction) {
+    WeightedSet<int, double> ws;
+    EXPECT_TRUE(ws.empty());
+    EXPECT_EQ(ws.size(), 0);
+    EXPECT_DOUBLE_EQ(ws.total_weight(), 0.0);
+    EXPECT_THROW(ws.sample(), std::out_of_range);
+}
+
+TEST(WeightedSetTest, InitializerListConstruction) {
+    WeightedSet<std::string, int> ws = {
+        {"apple", 10},
+        {"banana", 20},
+        {"cherry", 5}
+    };
+    EXPECT_FALSE(ws.empty());
+    EXPECT_EQ(ws.size(), 3);
+    EXPECT_EQ(ws.total_weight(), 35);
+    EXPECT_TRUE(ws.contains("apple"));
+    EXPECT_EQ(ws.get_weight("apple"), 10);
+    EXPECT_TRUE(ws.contains("banana"));
+    EXPECT_EQ(ws.get_weight("banana"), 20);
+    EXPECT_TRUE(ws.contains("cherry"));
+    EXPECT_EQ(ws.get_weight("cherry"), 5);
+    EXPECT_FALSE(ws.contains("date"));
+}
+
+TEST(WeightedSetTest, AddNewItems) {
+    WeightedSet<int, int> ws;
+    ws.add(1, 100);
+    EXPECT_FALSE(ws.empty());
+    EXPECT_EQ(ws.size(), 1);
+    EXPECT_EQ(ws.total_weight(), 100);
+    EXPECT_TRUE(ws.contains(1));
+    EXPECT_EQ(ws.get_weight(1), 100);
+
+    ws.add(2, 50);
+    EXPECT_EQ(ws.size(), 2);
+    EXPECT_EQ(ws.total_weight(), 150);
+    EXPECT_TRUE(ws.contains(2));
+    EXPECT_EQ(ws.get_weight(2), 50);
+}
+
+TEST(WeightedSetTest, AddAndUpdateItems) {
+    WeightedSet<std::string, double> ws;
+    ws.add("item1", 10.0);
+    EXPECT_EQ(ws.get_weight("item1"), 10.0);
+    EXPECT_EQ(ws.total_weight(), 10.0);
+
+    ws.add("item1", 25.0); // Update weight
+    EXPECT_EQ(ws.size(), 1);
+    EXPECT_EQ(ws.get_weight("item1"), 25.0);
+    EXPECT_EQ(ws.total_weight(), 25.0);
+}
+
+TEST(WeightedSetTest, AddWithZeroOrNegativeWeight) {
+    WeightedSet<std::string, int> ws;
+    ws.add("positive", 10);
+    EXPECT_TRUE(ws.contains("positive"));
+    EXPECT_EQ(ws.size(), 1);
+
+    ws.add("zero_weight", 0);
+    EXPECT_FALSE(ws.contains("zero_weight"));
+    EXPECT_EQ(ws.size(), 1); // Size should not change
+
+    ws.add("negative_weight", -5);
+    EXPECT_FALSE(ws.contains("negative_weight"));
+    EXPECT_EQ(ws.size(), 1);
+
+    // Add item then update its weight to zero
+    ws.add("to_remove", 20);
+    EXPECT_TRUE(ws.contains("to_remove"));
+    EXPECT_EQ(ws.size(), 2);
+    ws.add("to_remove", 0); // Should remove it
+    EXPECT_FALSE(ws.contains("to_remove"));
+    EXPECT_EQ(ws.size(), 1);
+    EXPECT_EQ(ws.total_weight(), 10); // Only "positive" remains
+}
+
+TEST(WeightedSetTest, RemoveItems) {
+    WeightedSet<int, int> ws = {{1, 10}, {2, 20}, {3, 30}};
+    EXPECT_EQ(ws.size(), 3);
+    EXPECT_EQ(ws.total_weight(), 60);
+
+    EXPECT_TRUE(ws.remove(2)); // Remove existing
+    EXPECT_EQ(ws.size(), 2);
+    EXPECT_FALSE(ws.contains(2));
+    EXPECT_EQ(ws.get_weight(2), 0);
+    EXPECT_EQ(ws.total_weight(), 40); // 10 + 30
+
+    EXPECT_FALSE(ws.remove(5)); // Remove non-existing
+    EXPECT_EQ(ws.size(), 2);
+    EXPECT_EQ(ws.total_weight(), 40);
+}
+
+TEST(WeightedSetTest, GetWeightAndContains) {
+    WeightedSet<char, int> ws = {{'a', 1}, {'b', 2}};
+    EXPECT_TRUE(ws.contains('a'));
+    EXPECT_EQ(ws.get_weight('a'), 1);
+    EXPECT_FALSE(ws.contains('c'));
+    EXPECT_EQ(ws.get_weight('c'), 0);
+}
+
+TEST(WeightedSetTest, SampleFromSingleItemSet) {
+    WeightedSet<std::string, double> ws;
+    ws.add("lonely", 100.0);
+    ASSERT_EQ(ws.size(), 1);
+    ASSERT_DOUBLE_EQ(ws.total_weight(), 100.0);
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_EQ(ws.sample(), "lonely");
+    }
+}
+
+TEST(WeightedSetTest, SampleFromEmptySet) {
+    WeightedSet<int, int> ws;
+    EXPECT_THROW(ws.sample(), std::out_of_range);
+}
+
+TEST(WeightedSetTest, SampleFromZeroTotalWeightSet) {
+    WeightedSet<int, int> ws;
+    ws.add(1, 10);
+    EXPECT_NO_THROW(ws.sample()); // Should be fine
+
+    ws.add(1, 0); // Removes the item
+    EXPECT_TRUE(ws.empty());
+    EXPECT_THROW(ws.sample(), std::out_of_range);
+
+    WeightedSet<int,int> ws2;
+    ws2.add(1,0); // item not added
+    ws2.add(2,-10); // item not added
+    EXPECT_TRUE(ws2.empty());
+    EXPECT_THROW(ws2.sample(), std::out_of_range);
+}
+
+
+TEST(WeightedSetTest, Iteration) {
+    WeightedSet<std::string, int> ws = {{"c", 3}, {"a", 1}, {"b", 2}};
+    std::vector<std::pair<std::string, int>> expected_items = {
+        {"a", 1}, {"b", 2}, {"c", 3} // std::map iterates in key-sorted order
+    };
+    std::vector<std::pair<std::string, int>> actual_items;
+    for (const auto& item : ws) {
+        actual_items.push_back(item);
+    }
+    ASSERT_EQ(actual_items.size(), expected_items.size());
+    for(size_t i=0; i < actual_items.size(); ++i) {
+        EXPECT_EQ(actual_items[i].first, expected_items[i].first);
+        EXPECT_EQ(actual_items[i].second, expected_items[i].second);
+    }
+}
+
+TEST(WeightedSetTest, CopyConstruction) {
+    WeightedSet<std::string, int> original = {{"one", 1}, {"two", 2}};
+    WeightedSet<std::string, int> copy = original;
+
+    EXPECT_EQ(copy.size(), 2);
+    EXPECT_TRUE(copy.contains("one"));
+    EXPECT_EQ(copy.get_weight("one"), 1);
+    EXPECT_TRUE(copy.contains("two"));
+    EXPECT_EQ(copy.get_weight("two"), 2);
+    EXPECT_EQ(copy.total_weight(), 3);
+
+    // Modify original, copy should not change
+    original.add("three", 3);
+    EXPECT_EQ(copy.size(), 2);
+    EXPECT_FALSE(copy.contains("three"));
+
+    // Ensure copy can be sampled
+    EXPECT_NO_THROW(copy.sample());
+}
+
+TEST(WeightedSetTest, CopyAssignment) {
+    WeightedSet<std::string, int> original = {{"one", 1}, {"two", 2}};
+    WeightedSet<std::string, int> copy;
+    copy.add("bogus", 100); // Add something to copy first
+    copy = original;
+
+    EXPECT_EQ(copy.size(), 2);
+    EXPECT_TRUE(copy.contains("one"));
+    EXPECT_EQ(copy.get_weight("one"), 1);
+    EXPECT_FALSE(copy.contains("bogus"));
+    EXPECT_EQ(copy.total_weight(), 3);
+
+    // Ensure copy can be sampled
+    EXPECT_NO_THROW(copy.sample());
+}
+
+TEST(WeightedSetTest, MoveConstruction) {
+    WeightedSet<std::string, int> original = {{"one", 1}, {"two", 2}};
+    WeightedSet<std::string, int> moved_to(std::move(original));
+
+    EXPECT_EQ(moved_to.size(), 2);
+    EXPECT_TRUE(moved_to.contains("one"));
+    EXPECT_EQ(moved_to.get_weight("one"), 1);
+    EXPECT_EQ(moved_to.total_weight(), 3);
+
+    // Original should be in a valid but unspecified (likely empty) state
+    // Depending on map's move ctor, it might be empty or not.
+    // Our move ctor should make it stale and empty its caches.
+    // Let's check if it's sample-able (it shouldn't be if empty)
+    // or if it's empty.
+    // EXPECT_TRUE(original.empty()); // This depends on std::map's move behavior.
+                                  // It's safer to say it's valid.
+    EXPECT_NO_THROW(moved_to.sample());
+}
+
+TEST(WeightedSetTest, MoveAssignment) {
+    WeightedSet<std::string, int> original = {{"one", 1}, {"two", 2}};
+    WeightedSet<std::string, int> moved_to;
+    moved_to.add("bogus", 100);
+    moved_to = std::move(original);
+
+    EXPECT_EQ(moved_to.size(), 2);
+    EXPECT_TRUE(moved_to.contains("one"));
+    EXPECT_EQ(moved_to.get_weight("one"), 1);
+    EXPECT_FALSE(moved_to.contains("bogus"));
+    EXPECT_EQ(moved_to.total_weight(), 3);
+    EXPECT_NO_THROW(moved_to.sample());
+}
+
+
+TEST(WeightedSetTest, SwapFunctionality) {
+    WeightedSet<char, int> ws1 = {{'a', 10}, {'b', 20}};
+    WeightedSet<char, int> ws2 = {{'x', 100}, {'y', 200}, {'z', 300}};
+
+    ws1.swap(ws2);
+
+    EXPECT_EQ(ws1.size(), 3);
+    EXPECT_TRUE(ws1.contains('x'));
+    EXPECT_EQ(ws1.get_weight('x'), 100);
+    EXPECT_EQ(ws1.total_weight(), 600);
+
+    EXPECT_EQ(ws2.size(), 2);
+    EXPECT_TRUE(ws2.contains('a'));
+    EXPECT_EQ(ws2.get_weight('a'), 10);
+    EXPECT_EQ(ws2.total_weight(), 30);
+
+    EXPECT_NO_THROW(ws1.sample());
+    EXPECT_NO_THROW(ws2.sample());
+}
+
+TEST(WeightedSetTest, StatisticalSamplingDistribution) {
+    WeightedSet<std::string, int> ws;
+    ws.add("common", 75);
+    ws.add("rare", 20);
+    ws.add("legendary", 5);
+
+    ASSERT_EQ(ws.total_weight(), 100);
+
+    const int num_samples = 100000;
+    std::map<std::string, int> counts;
+    for (int i = 0; i < num_samples; ++i) {
+        counts[ws.sample()]++;
+    }
+
+    EXPECT_EQ(counts.size(), 3); // All items should have been sampled
+
+    double common_ratio = static_cast<double>(counts["common"]) / num_samples;
+    double rare_ratio = static_cast<double>(counts["rare"]) / num_samples;
+    double legendary_ratio = static_cast<double>(counts["legendary"]) / num_samples;
+
+    // Check if ratios are within a tolerance (e.g., 10% of expected value, or fixed like +/- 0.05)
+    // Expected ratios: common=0.75, rare=0.20, legendary=0.05
+    // Tolerance needs to be reasonable for statistical tests.
+    // A simple check for significant deviation: Chi-squared test would be more robust.
+    // For unit test, rough bounds:
+    EXPECT_NEAR(common_ratio, 0.75, 0.05); // Check within +/- 5 percentage points
+    EXPECT_NEAR(rare_ratio, 0.20, 0.05);
+    EXPECT_NEAR(legendary_ratio, 0.05, 0.025); // Tighter for smaller probability
+}
+
+TEST(WeightedSetTest, SamplingAfterUpdates) {
+    WeightedSet<int, int> ws;
+    ws.add(1, 1); // 100% item 1
+    EXPECT_EQ(ws.sample(), 1);
+
+    ws.add(2, 99); // item 1: 1%, item 2: 99%
+    // After many samples, 2 should be much more frequent
+    int count1 = 0, count2 = 0;
+    for (int i = 0; i < 10000; ++i) {
+        int sampled = ws.sample();
+        if (sampled == 1) count1++;
+        else if (sampled == 2) count2++;
+    }
+    EXPECT_LT(count1, count2);
+    EXPECT_GT(count1, 10); // Should appear some times (expected 100)
+    EXPECT_GT(count2, 9000); // Expected 9900
+
+    ws.remove(2); // Back to 100% item 1
+    EXPECT_EQ(ws.sample(), 1);
+
+    ws.add(1, 0); // Remove item 1, now empty
+    EXPECT_THROW(ws.sample(), std::out_of_range);
+}
+
+TEST(WeightedSetTest, ConstCorrectness) {
+    const WeightedSet<int, int> ws_const = {{1,10}, {2,20}};
+    EXPECT_EQ(ws_const.size(), 2);
+    EXPECT_TRUE(ws_const.contains(1));
+    EXPECT_FALSE(ws_const.empty());
+    EXPECT_EQ(ws_const.get_weight(1), 10);
+    EXPECT_EQ(ws_const.total_weight(), 30);
+
+    // Test const iterators
+    int sum_weights = 0;
+    for(WeightedSet<int, int>::const_iterator it = ws_const.cbegin(); it != ws_const.cend(); ++it) {
+        sum_weights += it->second;
+    }
+    EXPECT_EQ(sum_weights, 30);
+
+    // Test sampling from const object
+    EXPECT_NO_THROW(ws_const.sample());
+    int s = ws_const.sample(); // Sample multiple times
+    s = ws_const.sample();
+    s = ws_const.sample();
+    EXPECT_TRUE(s == 1 || s == 2);
+}
+
+TEST(WeightedSetTest, ZeroWeightInMiddleOfSamplingDataRebuild) {
+    // This tests if rebuild_sampling_data correctly skips items with zero weight
+    // even if they are in the middle of the map.
+    WeightedSet<int, int> ws;
+    ws.add(1, 10);
+    ws.add(2, 0);  // This item won't be in sampling data
+    ws.add(3, 20);
+
+    EXPECT_EQ(ws.size(), 2); // Item 2 was effectively removed/not added with positive weight.
+    EXPECT_TRUE(ws.contains(1));
+    EXPECT_FALSE(ws.contains(2)); // Due to add logic
+    EXPECT_TRUE(ws.contains(3));
+    EXPECT_EQ(ws.total_weight(), 30);
+
+    // Force rebuild and sample
+    std::map<int, int> counts;
+    for(int i = 0; i < 1000; ++i) {
+        counts[ws.sample()]++;
+    }
+    EXPECT_TRUE(counts.count(1));
+    EXPECT_FALSE(counts.count(2)); // Should not have sampled 2
+    EXPECT_TRUE(counts.count(3));
+    EXPECT_GT(counts[3], counts[1]); // 3 is twice as likely as 1
+}
+
+TEST(WeightedSetTest, KeyCompareCustom) {
+    struct ReverseCompare {
+        bool operator()(int a, int b) const { return a > b; }
+    };
+    WeightedSet<int, int, ReverseCompare> ws_rev = {{1,10}, {2,20}, {3,5}};
+    // Iteration should be in reverse order of keys
+    auto it = ws_rev.begin();
+    ASSERT_NE(it, ws_rev.end());
+    EXPECT_EQ(it->first, 3); ++it;
+    ASSERT_NE(it, ws_rev.end());
+    EXPECT_EQ(it->first, 2); ++it;
+    ASSERT_NE(it, ws_rev.end());
+    EXPECT_EQ(it->first, 1); ++it;
+    EXPECT_EQ(it, ws_rev.end());
+
+    EXPECT_NO_THROW(ws_rev.sample()); // Sampling should still work
+}
+
+TEST(WeightedSetTest, FloatingPointWeightsPrecision) {
+    WeightedSet<std::string, double> ws;
+    ws.add("A", 0.1);
+    ws.add("B", 0.2);
+    ws.add("C", 0.7);
+    EXPECT_DOUBLE_EQ(ws.total_weight(), 1.0);
+
+    std::map<std::string, int> counts;
+    const int num_samples = 20000; // More samples for finer grains
+     for (int i = 0; i < num_samples; ++i) {
+        counts[ws.sample()]++;
+    }
+    EXPECT_NEAR(static_cast<double>(counts["A"]) / num_samples, 0.1, 0.05);
+    EXPECT_NEAR(static_cast<double>(counts["B"]) / num_samples, 0.2, 0.05);
+    EXPECT_NEAR(static_cast<double>(counts["C"]) / num_samples, 0.7, 0.05);
+
+    // Test with very small weights
+    WeightedSet<int, double> ws_small;
+    ws_small.add(1, 0.000000001); // approx 1/3 chance
+    ws_small.add(2, 0.000000002); // approx 2/3 chance
+
+    std::map<int, int> small_counts;
+    int num_small_samples = 1000; // Fewer samples, but enough to see a bias
+    for(int i=0; i < num_small_samples; ++i) {
+        ASSERT_NO_THROW(small_counts[ws_small.sample()]++);
+    }
+    // Expect item 2 to be sampled more often than item 1
+    // Check if both items were sampled to avoid division by zero or missing key issues.
+    if (small_counts.count(1) && small_counts.count(2)) {
+        EXPECT_GT(small_counts[2], small_counts[1]);
+        // Check if roughly 2/3 vs 1/3
+        EXPECT_NEAR(static_cast<double>(small_counts[2]) / num_small_samples, 2.0/3.0, 0.15);
+        EXPECT_NEAR(static_cast<double>(small_counts[1]) / num_small_samples, 1.0/3.0, 0.15);
+    } else if (small_counts.count(2) && !small_counts.count(1)) {
+        // Only item 2 sampled, which is fine if item 1 had very low probability in N samples
+        EXPECT_EQ(small_counts[2], num_small_samples);
+    } else if (small_counts.count(1) && !small_counts.count(2)) {
+        // Only item 1 sampled, less likely but possible. For this test, we'd prefer 2 to show up.
+        // This might indicate an issue if item 2 (higher weight) is consistently not sampled.
+        // However, with very small probabilities, it's possible.
+        // For this test, let's ensure counts exist before comparing, or make it more robust.
+        // A simple GT might be enough if we ensure counts[1] and counts[2] are populated.
+        FAIL() << "Item 2 (higher weight) was not sampled, or item 1 dominated unexpectedly.";
+    } else {
+        // Neither sampled, or only one in a way that doesn't fit above.
+        // This case should ideally not be hit if sample() works and weights are positive.
+        ASSERT_TRUE(small_counts.count(1) || small_counts.count(2)) << "Neither item 1 nor 2 were sampled.";
+    }
+
+    // Test if adding an extremely small weight to a large one has any effect
+    WeightedSet<int, double> ws_mixed;
+    ws_mixed.add(1, 1.0e18); // Large weight
+    ws_mixed.add(2, 1.0);    // Tiny weight in comparison
+
+    int count_one = 0;
+    int count_two = 0;
+    for(int i=0; i<1000; ++i) { // Fewer samples, we expect item 2 to appear rarely
+        if(ws_mixed.sample() == 1) count_one++; else count_two++;
+    }
+    EXPECT_GT(count_one, 950); // Most samples should be 1
+    // Item 2 might or might not be sampled in few trials, that's ok.
+    // The key is that it doesn't break sampling.
+}
+
+// Main function for Google Test
+// int main(int argc, char **argv) {
+//     ::testing::InitGoogleTest(&argc, argv);
+//     return RUN_ALL_TESTS();
+// }
+// The above main is usually not needed if tests/CMakeLists.txt uses gtest_discover_tests and links GTest::gtest_main


### PR DESCRIPTION
Implemented a new WeightedSet data structure that allows storing unique keys with associated numerical weights. It supports random sampling of keys based on their assigned weights.

Key features:
- Templated on Key type, WeightType, and Compare function.
- Efficient add, remove, update, and lookup operations.
- Weighted random sampling (`sample()` method).
- Iterators for accessing (key, weight) pairs.

Includes:
- Header file: include/weighted_set.h
- Example usage: examples/weighted_set_example.cpp
- Unit tests: tests/weighted_set_test.cpp (all pass)
- Documentation: docs/README_weighted_set.md
- Updates to CMakeLists.txt and tests/CMakeLists.txt for integration.