### PR TITLE
Fix compilation errors in FrozenList tests and CTAD

### DIFF
--- a/include/FrozenList.h
+++ b/include/FrozenList.h
@@ -266,9 +266,12 @@ FrozenList(std::initializer_list<T>, Alloc = Alloc())
     -> FrozenList<T, Alloc>;
 
 // Deduction guide for (size_type, const T&, Allocator)
-template<typename T, typename Alloc = std::allocator<T>>
-FrozenList(typename FrozenList<T, Alloc>::size_type, const T&, Alloc = Alloc())
-    -> FrozenList<T, Alloc>;
+// Changed to be more explicit about the first argument's type to avoid ambiguity with iterator constructor.
+template<typename T_elem, typename Alloc = std::allocator<T_elem>>
+FrozenList(std::size_t /*count*/,
+           const T_elem& /*value*/,
+           Alloc /*alloc*/ = Alloc())
+    -> FrozenList<T_elem, Alloc>;
 
 } // namespace cpp_collections
 

--- a/tests/frozen_list_test.cpp
+++ b/tests/frozen_list_test.cpp
@@ -526,17 +526,18 @@ TEST_F(FrozenListTest, DeductionGuides) {
     require_list_equals_vector(fl_from_fill, v_string);
 
     // With explicit allocator
-    std::allocator<long> myAlloc;
-    cpp_collections::FrozenList fl_from_iter_alloc(v_int.begin(), v_int.end(), myAlloc);
-    EXPECT_TRUE((std::is_same_v<decltype(fl_from_iter_alloc), cpp_collections::FrozenList<int, std::allocator<long>>>));
+    std::allocator<int> myAllocInt;
+    cpp_collections::FrozenList fl_from_iter_alloc(v_int.begin(), v_int.end(), myAllocInt);
+    EXPECT_TRUE((std::is_same_v<decltype(fl_from_iter_alloc), cpp_collections::FrozenList<int, std::allocator<int>>>));
     require_list_equals_vector(fl_from_iter_alloc, v_int);
-    EXPECT_EQ(fl_from_iter_alloc.get_allocator(), myAlloc);
+    EXPECT_EQ(fl_from_iter_alloc.get_allocator(), myAllocInt);
 
-    cpp_collections::FrozenList fl_from_init_alloc({1L, 2L, 3L}, myAlloc); // Deduce FrozenList<long, std::allocator<long>>
+    std::allocator<long> myAllocLong;
+    cpp_collections::FrozenList fl_from_init_alloc({1L, 2L, 3L}, myAllocLong); // Deduce FrozenList<long, std::allocator<long>>
     EXPECT_TRUE((std::is_same_v<decltype(fl_from_init_alloc), cpp_collections::FrozenList<long, std::allocator<long>>>));
     std::vector<long> v_long = {1L, 2L, 3L};
     require_list_equals_vector(fl_from_init_alloc, v_long);
-    EXPECT_EQ(fl_from_init_alloc.get_allocator(), myAlloc);
+    EXPECT_EQ(fl_from_init_alloc.get_allocator(), myAllocLong);
 }
 #endif
 


### PR DESCRIPTION
- Modified tests/frozen_list_test.cpp to use the correct std::allocator<int> when FrozenList is initialized with iterators pointing to int values. This resolves a static_assert failure within std::vector due to mismatched allocator value_type.

- Updated include/FrozenList.h to refine a class template argument deduction (CTAD) guide. The guide for the constructor taking (size_type, const T&, Allocator) was made more explicit by using std::size_t for the first parameter. This prevents ambiguity with the iterator-pair constructor and resolves an issue where T was incorrectly deduced as an iterator type, leading to a similar std::vector static_assert failure.