### PR TITLE
feat: Implement SparseSet data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ target_include_directories(RetryUtil INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/inclu
 add_library(ScopedFlagLib INTERFACE)
 target_include_directories(ScopedFlagLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define SparseSetLib as an interface library (header-only)
+add_library(SparseSetLib INTERFACE)
+target_include_directories(SparseSetLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Define SplitView as an interface library (header-only)
 add_library(SplitView INTERFACE)
 target_include_directories(SplitView INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -371,7 +375,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         GenerationalArenaLib # Added for generational_arena_example
 
         FrozenListLib        # Added for frozen_list_example
-
+        SparseSetLib         # Added for sparse_set_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/docs/README_SparseSet.md
+++ b/docs/README_SparseSet.md
@@ -1,0 +1,121 @@
+# SparseSet
+
+## Overview
+
+`SparseSet<T, IndexT, AllocatorT, AllocatorIndexT>` is a C++ data structure that stores a set of items (typically non-negative integers like entity IDs or resource handles) from a potentially large universal set `[0, MaxValue)`. It is designed to provide O(1) average time complexity for add, remove, and contains operations, along with cache-friendly iteration over the elements currently present in the set.
+
+This structure is particularly useful in scenarios requiring efficient management of dynamic sets of IDs where the range of possible IDs is large, but the number of active IDs at any given time is relatively small. A common use case is in Entity-Component-System (ECS) architectures in game development or simulations.
+
+## Template Parameters
+
+-   `T`: The type of elements stored. This type must be usable as an array index (convertible to `IndexT` or `size_t`) and should typically represent non-negative integer values. Defaults to `uint32_t`.
+-   `IndexT`: The type used for indices within the internal dense array and for storing the count of elements. Defaults to `uint32_t`.
+-   `AllocatorT`: The allocator type for storing elements of type `T` in the dense array. Defaults to `std::allocator<T>`.
+-   `AllocatorIndexT`: The allocator type for storing indices of type `IndexT` in the sparse array. Defaults to `std::allocator_traits<AllocatorT>::template rebind_alloc<IndexT>`.
+
+## How it Works
+
+The `SparseSet` uses two internal arrays (typically `std::vector`):
+1.  `dense_`: A tightly packed array storing the actual elements that are currently in the set. Iteration happens over this array.
+2.  `sparse_`: An array indexed by the element values themselves. For an element `e`, `sparse_[e]` stores the index of `e` within the `dense_` array.
+
+A `count_` member variable tracks the number of valid elements currently stored in the `dense_` array.
+
+-   **`contains(value)`**: Checks `sparse_[value]`. If the index stored there is less than `count_`, and `dense_[sparse_[value]] == value`, then the element is present. This two-part check ensures validity even if `sparse_` contains stale data.
+-   **`insert(value)`**: If not already present and within `max_value_capacity`, `value` is added to the end of `dense_` (at `dense_[count_]`), and `sparse_[value]` is set to `count_`. `count_` is then incremented.
+-   **`erase(value)`**: If present, the element `value` at `dense_[idx]` (where `idx = sparse_[value]`) is removed by:
+    1.  Taking the last element from `dense_` (at `dense_[count_ - 1]`).
+    2.  Placing this last element into `dense_[idx]`.
+    3.  Updating the sparse array for this moved element: `sparse_[last_element] = idx`.
+    4.  Decrementing `count_`.
+    This swap-and-pop technique maintains the dense packing and O(1) complexity.
+
+## API
+
+### Construction
+-   `SparseSet(size_type max_value, size_type initial_dense_capacity = 0, const AllocatorT& alloc_t = AllocatorT(), const AllocatorIndexT& alloc_idx_t = AllocatorIndexT())`:
+    Constructs a `SparseSet`. `max_value` defines the exclusive upper limit for element values (i.e., elements `0` to `max_value - 1` can be stored). `sparse_` array is sized to `max_value`. `initial_dense_capacity` can be used to pre-reserve memory for the `dense_` array.
+
+### Modifiers
+-   `std::pair<iterator, bool> insert(const_reference value)`: Inserts `value`. Returns `true` and iterator to element if inserted, `false` and iterator if already present or out of range. O(1) average.
+-   `bool erase(const_reference value)`: Erases `value`. Returns `true` if erased, `false` otherwise. O(1).
+-   `void clear() noexcept`: Removes all elements. O(N) to clear dense vector, or O(1) if only count is reset (current implementation clears dense vector).
+-   `void swap(SparseSet& other) noexcept`: Swaps contents with another `SparseSet`.
+
+### Lookup
+-   `bool contains(const_reference value) const noexcept`: Checks if `value` is in the set. O(1).
+-   `iterator find(const_reference value)`: Returns iterator to `value` if found, else `end()`. O(1).
+-   `const_iterator find(const_reference value) const`: Const version of `find`. O(1).
+
+### Capacity
+-   `bool empty() const noexcept`: Returns `true` if size is 0. O(1).
+-   `size_type size() const noexcept`: Returns the number of elements. O(1).
+-   `size_type max_value_capacity() const noexcept`: Returns `max_value` set at construction (size of `sparse_` array).
+-   `size_type dense_capacity() const noexcept`: Returns current capacity of the `dense_` array.
+-   `void reserve_dense(size_type new_cap)`: Reserves memory for `dense_` array.
+
+### Iterators
+-   `iterator begin() noexcept`, `iterator end() noexcept`
+-   `const_iterator begin() const noexcept`, `const_iterator end() const noexcept`
+-   `const_iterator cbegin() const noexcept`, `const_iterator cend() const noexcept`
+    Iterators are random access and iterate over the elements in the `dense_` array. The order of elements is generally the insertion order mixed by erasures; it is *not* sorted by value.
+
+### Comparison
+-   `bool operator==(const SparseSet& other) const`: Checks for set equality (same elements, regardless of `max_value_capacity` or internal order).
+-   `bool operator!=(const SparseSet& other) const`: Inverse of `operator==`.
+
+## Time and Space Complexity
+
+-   **Time Complexity**:
+    -   `insert`, `erase`, `contains`, `find`: O(1) average.
+    -   `clear`: O(1) (resets count, `dense_.clear()` is O(N) where N is current size but often fast).
+    -   Iteration: O(N) where N is the number of elements currently in the set.
+-   **Space Complexity**: O(MaxValue + N), where `MaxValue` is the `max_value_capacity` given at construction (for the `sparse_` array) and N is the number of elements currently stored (for the `dense_` array).
+
+## Usage Example
+
+```cpp
+#include "sparse_set.h" // Adjust path as necessary
+#include <iostream>
+
+int main() {
+    // Create a SparseSet for entity IDs up to 999.
+    cpp_collections::SparseSet<uint32_t> active_entities(1000);
+
+    // Add some entities
+    active_entities.insert(10);
+    active_entities.insert(55);
+    active_entities.insert(120);
+
+    std::cout << "Number of active entities: " << active_entities.size() << std::endl;
+
+    // Check if an entity is active
+    if (active_entities.contains(55)) {
+        std::cout << "Entity 55 is active." << std::endl;
+    }
+
+    if (!active_entities.contains(100)) {
+        std::cout << "Entity 100 is not active." << std::endl;
+    }
+
+    // Iterate over active entities (order is not guaranteed to be sorted by ID)
+    std::cout << "Active entity IDs: ";
+    for (uint32_t id : active_entities) {
+        std::cout << id << " ";
+    }
+    std::cout << std::endl;
+
+    // Remove an entity
+    active_entities.erase(55);
+    std::cout << "Entity 55 removed. New size: " << active_entities.size() << std::endl;
+
+    // Clear all entities
+    active_entities.clear();
+    std::cout << "All entities cleared. Size: " << active_entities.size() << std::endl;
+
+    return 0;
+}
+
+```
+
+This documentation provides an overview of the `SparseSet`, its API, complexity, and a basic usage example.

--- a/examples/sparse_set_example.cpp
+++ b/examples/sparse_set_example.cpp
@@ -1,0 +1,140 @@
+#include "sparse_set.h" // Assuming this path is correct relative to include dir
+#include <iostream>
+#include <vector>
+#include <algorithm> // For std::shuffle
+#include <random>    // For std::mt19937, std::random_device
+#include <cassert>   // For assert
+
+int main() {
+    std::cout << "--- SparseSet Usage Example ---" << std::endl;
+
+    // Create a SparseSet that can hold elements up to 999 (i.e., max_value_capacity = 1000)
+    // Defaulting to uint32_t for element type and index type.
+    cpp_collections::SparseSet<> game_entities(1000);
+
+    // 1. Inserting elements (e.g., activating entities)
+    std::cout << "\n1. Inserting entities:" << std::endl;
+    game_entities.insert(10);
+    game_entities.insert(250);
+    game_entities.insert(5);
+    game_entities.insert(800);
+
+    std::cout << "Set size: " << game_entities.size() << std::endl; // Expected: 4
+
+    // Trying to insert an existing element
+    auto result = game_entities.insert(10);
+    if (!result.second) {
+        std::cout << "Entity " << *result.first << " was already present." << std::endl;
+    }
+
+    // 2. Checking for containment
+    std::cout << "\n2. Checking entity status:" << std::endl;
+    uint32_t entity_to_check = 250;
+    if (game_entities.contains(entity_to_check)) {
+        std::cout << "Entity " << entity_to_check << " is active." << std::endl;
+    } else {
+        std::cout << "Entity " << entity_to_check << " is NOT active." << std::endl;
+    }
+
+    entity_to_check = 100; // This entity was not inserted
+    if (game_entities.contains(entity_to_check)) {
+        std::cout << "Entity " << entity_to_check << " is active." << std::endl;
+    } else {
+        std::cout << "Entity " << entity_to_check << " is NOT active." << std::endl;
+    }
+
+    // Check out of range entity
+    entity_to_check = 2000; // max_value_capacity is 1000
+    if (game_entities.contains(entity_to_check)) {
+        std::cout << "Entity " << entity_to_check << " is active (ERROR: should be out of range)." << std::endl;
+    } else {
+        std::cout << "Entity " << entity_to_check << " is not active (correctly identified as out of range or not present)." << std::endl;
+    }
+
+
+    // 3. Iterating over active entities
+    // The order of iteration is the order in the dense array, not sorted by value.
+    std::cout << "\n3. Active entities (iteration order):" << std::endl;
+    for (uint32_t entity_id : game_entities) {
+        std::cout << entity_id << " ";
+    }
+    std::cout << std::endl;
+
+    // 4. Erasing elements (e.g., deactivating entities)
+    std::cout << "\n4. Deactivating entity 250:" << std::endl;
+    bool erased = game_entities.erase(250);
+    if (erased) {
+        std::cout << "Entity 250 deactivated." << std::endl;
+    }
+    std::cout << "Set size after erase: " << game_entities.size() << std::endl; // Expected: 3
+    if (!game_entities.contains(250)) {
+        std::cout << "Entity 250 is confirmed inactive." << std::endl;
+    }
+
+    // Try erasing a non-existent entity
+    erased = game_entities.erase(100); // Was never there
+    if (!erased) {
+        std::cout << "Entity 100 was not found to deactivate." << std::endl;
+    }
+
+    // 5. Find an element
+    std::cout << "\n5. Finding entity 5:" << std::endl;
+    auto it = game_entities.find(5);
+    if (it != game_entities.end()) {
+        std::cout << "Found entity " << *it << "." << std::endl;
+    } else {
+        std::cout << "Entity 5 not found." << std::endl;
+    }
+
+    it = game_entities.find(250); // Was erased
+    if (it == game_entities.end()) {
+        std::cout << "Entity 250 (erased) correctly not found." << std::endl;
+    }
+
+
+    // 6. Simulating many additions and removals
+    std::cout << "\n6. Simulating additions and removals:" << std::endl;
+    std::vector<uint32_t> entity_ids;
+    for (uint32_t i = 0; i < 500; ++i) { // Insert entities up to 499
+        if (i % 3 == 0) entity_ids.push_back(i);
+    }
+
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(entity_ids.begin(), entity_ids.end(), g);
+
+    cpp_collections::SparseSet<uint32_t> dynamic_set(600); // Max value 599
+    int ops = 0;
+    for (uint32_t id : entity_ids) {
+        dynamic_set.insert(id);
+        ops++;
+        if (ops % 10 == 0 && !dynamic_set.empty()) {
+            // Remove a random element from the ones currently in the set
+            // This is a bit tricky without direct access to dense array elements by index easily
+            // For demo, just remove the one we just added if it's not the only one
+            if (dynamic_set.size() > 1 && ops % 20 == 0) { // Remove some, not all
+                 dynamic_set.erase(id); // remove the one just added
+            }
+        }
+    }
+    std::cout << "After dynamic operations, set size: " << dynamic_set.size() << std::endl;
+    std::cout << "First 5 elements in dynamic_set (iteration order): ";
+    int print_count = 0;
+    for(uint32_t id : dynamic_set) {
+        std::cout << id << " ";
+        print_count++;
+        if (print_count >= 5) break;
+    }
+    std::cout << (print_count == 0 ? "(empty)" : "") << std::endl;
+
+
+    // 7. Clear the set
+    std::cout << "\n7. Clearing all entities:" << std::endl;
+    game_entities.clear();
+    std::cout << "Set size after clear: " << game_entities.size() << std::endl; // Expected: 0
+    assert(game_entities.empty());
+
+    std::cout << "\n--- SparseSet Example Finished ---" << std::endl;
+
+    return 0;
+}

--- a/include/sparse_set.h
+++ b/include/sparse_set.h
@@ -1,0 +1,320 @@
+#pragma once
+
+#include <vector>
+#include <memory> // For std::allocator
+#include <stdexcept> // For std::out_of_range, std::invalid_argument
+#include <limits>   // For std::numeric_limits
+#include <iterator> // For std::iterator tags
+#include <type_traits> // For std::is_signed_v
+
+namespace cpp_collections {
+
+// Forward declaration for iterator
+template <typename T, typename IndexT, typename AllocatorT, bool IsConst>
+class SparseSetIterator;
+
+template <
+    typename T_cls = uint32_t,
+    typename IndexT_cls = uint32_t,
+    typename AllocatorT_cls = std::allocator<T_cls>,
+    typename AllocatorIndexT_cls = typename std::allocator_traits<AllocatorT_cls>::template rebind_alloc<IndexT_cls>
+>
+class SparseSet {
+public:
+    using value_type = T_cls;
+    using allocator_type_T = AllocatorT_cls;
+    using allocator_type_IndexT = AllocatorIndexT_cls;
+    using size_type = IndexT_cls;
+    using difference_type = std::ptrdiff_t;
+    using reference = T_cls&;
+    using const_reference = const T_cls&;
+    using pointer = T_cls*;
+    using const_pointer = const T_cls*;
+
+    using iterator = SparseSetIterator<T_cls, IndexT_cls, AllocatorT_cls, false>;
+    using const_iterator = SparseSetIterator<T_cls, IndexT_cls, AllocatorT_cls, true>;
+
+    // --- Construction and Destruction ---
+
+    explicit SparseSet(
+        size_type max_value,
+        size_type initial_dense_capacity = 0,
+        const AllocatorT_cls& alloc_t = AllocatorT_cls(),
+        const AllocatorIndexT_cls& alloc_idx_t = AllocatorIndexT_cls()
+    );
+
+    SparseSet(const SparseSet& other) = default;
+    SparseSet(SparseSet&& other) noexcept = default;
+    SparseSet& operator=(const SparseSet& other) = default;
+    SparseSet& operator=(SparseSet&& other) noexcept = default;
+    ~SparseSet() = default;
+
+    std::pair<iterator, bool> insert(const_reference value);
+    bool erase(const_reference value);
+    void clear() noexcept;
+    void swap(SparseSet& other) noexcept;
+
+    bool contains(const_reference value) const noexcept;
+    iterator find(const_reference value);
+    const_iterator find(const_reference value) const;
+
+    bool empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_value_capacity() const noexcept;
+    size_type dense_capacity() const noexcept;
+    void reserve_dense(size_type new_cap);
+
+    iterator begin() noexcept;
+    iterator end() noexcept;
+    const_iterator begin() const noexcept;
+    const_iterator end() const noexcept;
+    const_iterator cbegin() const noexcept;
+    const_iterator cend() const noexcept;
+
+    bool operator==(const SparseSet& other) const;
+    bool operator!=(const SparseSet& other) const;
+
+private:
+    friend class SparseSetIterator<T_cls, IndexT_cls, AllocatorT_cls, false>;
+    friend class SparseSetIterator<T_cls, IndexT_cls, AllocatorT_cls, true>;
+
+    std::vector<T_cls, AllocatorT_cls> dense_;
+    std::vector<IndexT_cls, AllocatorIndexT_cls> sparse_;
+    size_type count_;
+};
+
+template <typename T, typename IndexT, typename AllocatorT_iter, bool IsConst> // Iterator uses AllocatorT_iter for consistency if needed
+class SparseSetIterator {
+public:
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = T; // T from SparseSet's T_cls
+    using difference_type = std::ptrdiff_t;
+    using pointer_type = std::conditional_t<IsConst, const T*, T*>;
+    using reference_type = std::conditional_t<IsConst, const T&, T&>;
+
+public:
+    pointer_type ptr_ = nullptr;
+
+public:
+    SparseSetIterator() = default;
+    explicit SparseSetIterator(pointer_type p) : ptr_(p) {}
+
+    template <bool OtherIsConst = IsConst, typename = std::enable_if_t<IsConst && !OtherIsConst>>
+    SparseSetIterator(const SparseSetIterator<T, IndexT, AllocatorT_iter, false>& other)
+        : ptr_(other.ptr_) {}
+
+    reference_type operator*() const { return *ptr_; }
+    pointer_type operator->() const { return ptr_; }
+    reference_type operator[](difference_type n) const { return ptr_[n]; }
+
+    SparseSetIterator& operator++() { ++ptr_; return *this; }
+    SparseSetIterator operator++(int) { SparseSetIterator tmp = *this; ++ptr_; return tmp; }
+    SparseSetIterator& operator--() { --ptr_; return *this; }
+    SparseSetIterator operator--(int) { SparseSetIterator tmp = *this; --ptr_; return tmp; }
+
+    SparseSetIterator& operator+=(difference_type n) { ptr_ += n; return *this; }
+    SparseSetIterator& operator-=(difference_type n) { ptr_ -= n; return *this; }
+
+    friend SparseSetIterator operator+(SparseSetIterator lhs, difference_type n) { lhs += n; return lhs; }
+    friend SparseSetIterator operator+(difference_type n, SparseSetIterator rhs) { rhs += n; return rhs; }
+    friend SparseSetIterator operator-(SparseSetIterator lhs, difference_type n) { lhs -= n; return lhs; }
+    friend difference_type operator-(const SparseSetIterator& lhs, const SparseSetIterator& rhs) { return lhs.ptr_ - rhs.ptr_; }
+
+    friend bool operator==(const SparseSetIterator& a, const SparseSetIterator& b) { return a.ptr_ == b.ptr_; }
+    friend bool operator!=(const SparseSetIterator& a, const SparseSetIterator& b) { return a.ptr_ != b.ptr_; }
+    friend bool operator<(const SparseSetIterator& a, const SparseSetIterator& b) { return a.ptr_ < b.ptr_; }
+    friend bool operator>(const SparseSetIterator& a, const SparseSetIterator& b) { return a.ptr_ > b.ptr_; }
+    friend bool operator<=(const SparseSetIterator& a, const SparseSetIterator& b) { return a.ptr_ <= b.ptr_; }
+    friend bool operator>=(const SparseSetIterator& a, const SparseSetIterator& b) { return a.ptr_ >= b.ptr_; }
+};
+
+// Method Definitions
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::SparseSet(
+    typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::size_type max_val_cap,
+    typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::size_type initial_dense_cap,
+    const AllocatorT_cls& alloc_t,
+    const AllocatorIndexT_cls& alloc_idx_t)
+    : dense_(alloc_t), sparse_(alloc_idx_t), count_(0) {
+    sparse_.resize(max_val_cap);
+    if (initial_dense_cap > 0) {
+        dense_.reserve(initial_dense_cap);
+    }
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+std::pair<typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::iterator, bool>
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::insert(const_reference value) {
+    size_type val_as_idx = static_cast<size_type>(value);
+
+    if (val_as_idx >= sparse_.size() || (std::is_signed_v<T_cls> && value < 0) ) {
+        return {end(), false};
+    }
+    IndexT_cls& sparse_slot_for_value = sparse_[val_as_idx];
+    if (sparse_slot_for_value < count_ && dense_[sparse_slot_for_value] == value) {
+        return {iterator(&dense_[sparse_slot_for_value]), false};
+    }
+    dense_.push_back(value);
+    sparse_slot_for_value = count_;
+    iterator it_to_inserted = iterator(&dense_[count_]);
+    count_++;
+    return {it_to_inserted, true};
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+bool SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::erase(const_reference value) {
+    size_type val_as_idx = static_cast<size_type>(value);
+    if (val_as_idx >= sparse_.size() || (std::is_signed_v<T_cls> && value < 0)) {
+        return false;
+    }
+    IndexT_cls& potential_idx_in_dense = sparse_[val_as_idx];
+    if (!(potential_idx_in_dense < count_ && dense_[potential_idx_in_dense] == value)) {
+        return false;
+    }
+    T_cls last_element_in_dense = dense_.back();
+    dense_[potential_idx_in_dense] = last_element_in_dense;
+    sparse_[static_cast<size_type>(last_element_in_dense)] = potential_idx_in_dense;
+    dense_.pop_back();
+    count_--;
+    return true;
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+void SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::clear() noexcept {
+    dense_.clear();
+    count_ = 0;
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+void SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::swap(SparseSet& other) noexcept {
+    using std::swap;
+    swap(dense_, other.dense_);
+    swap(sparse_, other.sparse_);
+    swap(count_, other.count_);
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+bool SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::contains(const_reference value) const noexcept {
+    size_type val_as_idx = static_cast<size_type>(value);
+    if (val_as_idx >= sparse_.size() || (std::is_signed_v<T_cls> && value < 0)) {
+        return false;
+    }
+    IndexT_cls index_in_dense = sparse_[val_as_idx];
+    return index_in_dense < count_ && dense_[index_in_dense] == value;
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::iterator
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::find(const_reference value) {
+    size_type val_as_idx = static_cast<size_type>(value);
+    if (val_as_idx < sparse_.size() && !(std::is_signed_v<T_cls> && value < 0)) {
+        IndexT_cls index_in_dense = sparse_[val_as_idx];
+        if (index_in_dense < count_ && dense_[index_in_dense] == value) {
+            return iterator(&dense_[index_in_dense]);
+        }
+    }
+    return end();
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::const_iterator
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::find(const_reference value) const {
+    size_type val_as_idx = static_cast<size_type>(value);
+     if (val_as_idx < sparse_.size() && !(std::is_signed_v<T_cls> && value < 0)) {
+        IndexT_cls index_in_dense = sparse_[val_as_idx];
+        if (index_in_dense < count_ && dense_[index_in_dense] == value) {
+            return const_iterator(&dense_[index_in_dense]);
+        }
+    }
+    return cend();
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+bool SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::empty() const noexcept {
+    return count_ == 0;
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::size_type
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::size() const noexcept {
+    return count_;
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::size_type
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::max_value_capacity() const noexcept {
+    return static_cast<size_type>(sparse_.size());
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::size_type
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::dense_capacity() const noexcept {
+    return static_cast<size_type>(dense_.capacity());
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+void SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::reserve_dense(size_type new_cap) {
+    dense_.reserve(new_cap);
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::iterator
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::begin() noexcept {
+    return iterator(dense_.data());
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::iterator
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::end() noexcept {
+    return iterator(dense_.data() + count_);
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::const_iterator
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::begin() const noexcept {
+    return const_iterator(dense_.data());
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::const_iterator
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::end() const noexcept {
+    return const_iterator(dense_.data() + count_);
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::const_iterator
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::cbegin() const noexcept {
+    return begin();
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+typename SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::const_iterator
+SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::cend() const noexcept {
+    return end();
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+bool SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::operator==(const SparseSet& other) const {
+    if (count_ != other.count_) {
+        return false;
+    }
+    for (const_iterator it = cbegin(); it != cend(); ++it) {
+        if (!other.contains(*it)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+bool SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>::operator!=(const SparseSet& other) const {
+    return !(*this == other);
+}
+
+template <typename T_cls, typename IndexT_cls, typename AllocatorT_cls, typename AllocatorIndexT_cls>
+void swap(SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>& lhs,
+          SparseSet<T_cls, IndexT_cls, AllocatorT_cls, AllocatorIndexT_cls>& rhs) noexcept {
+    lhs.swap(rhs);
+}
+
+} // namespace cpp_collections

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,7 +103,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         GenerationalArenaLib # Added for generational_arena_test
 
         FrozenListLib        # Added for frozen_list_test
-
+        SparseSetLib         # Added for sparse_set_test
     )
 
     # Specific configurations for certain tests

--- a/tests/sparse_set_test.cpp
+++ b/tests/sparse_set_test.cpp
@@ -1,0 +1,295 @@
+#include "sparse_set.h" // Assuming sparse_set.h is in include directory accessible here
+#include "gtest/gtest.h"
+#include <vector>
+#include <algorithm> // For std::sort, std::is_permutation
+#include <set>       // For comparing contents
+
+// Test fixture for SparseSet tests
+class SparseSetTest : public ::testing::Test {
+protected:
+    // Per-test set-up and tear-down can be done here if needed
+};
+
+TEST_F(SparseSetTest, ConstructorAndBasicProperties) {
+    cpp_collections::SparseSet<uint32_t, uint32_t> ss(100); // Max value 99
+    EXPECT_TRUE(ss.empty());
+    EXPECT_EQ(ss.size(), 0);
+    EXPECT_EQ(ss.max_value_capacity(), 100);
+    EXPECT_GE(ss.dense_capacity(), 0);
+
+    cpp_collections::SparseSet<int, size_t> ss_int(50, 10); // Max value 49, initial dense 10
+    EXPECT_TRUE(ss_int.empty());
+    EXPECT_EQ(ss_int.size(), 0);
+    EXPECT_EQ(ss_int.max_value_capacity(), 50);
+    EXPECT_GE(ss_int.dense_capacity(), 10);
+
+    cpp_collections::SparseSet<uint16_t> ss_zero_max(0);
+    EXPECT_TRUE(ss_zero_max.empty());
+    EXPECT_EQ(ss_zero_max.max_value_capacity(), 0);
+    auto insert_res_zero = ss_zero_max.insert(0);
+    EXPECT_FALSE(insert_res_zero.second);
+
+    cpp_collections::SparseSet<uint16_t> ss_one_max(1);
+    EXPECT_TRUE(ss_one_max.empty());
+    EXPECT_EQ(ss_one_max.max_value_capacity(), 1);
+    auto insert_res_one = ss_one_max.insert(0);
+    EXPECT_TRUE(insert_res_one.second);
+    EXPECT_EQ(ss_one_max.size(), 1);
+    EXPECT_TRUE(ss_one_max.contains(0));
+    auto insert_res_one_again = ss_one_max.insert(1);
+    EXPECT_FALSE(insert_res_one_again.second);
+}
+
+TEST_F(SparseSetTest, InsertAndContains) {
+    cpp_collections::SparseSet<uint32_t> ss(100);
+
+    auto res1 = ss.insert(10);
+    EXPECT_TRUE(res1.second);
+    EXPECT_EQ(*res1.first, 10);
+    EXPECT_TRUE(ss.contains(10));
+    EXPECT_EQ(ss.size(), 1);
+
+    auto res2 = ss.insert(20);
+    EXPECT_TRUE(res2.second);
+    EXPECT_EQ(*res2.first, 20);
+    EXPECT_TRUE(ss.contains(20));
+    EXPECT_EQ(ss.size(), 2);
+
+    auto res3 = ss.insert(10);
+    EXPECT_FALSE(res3.second);
+    EXPECT_EQ(*res3.first, 10);
+    EXPECT_TRUE(ss.contains(10));
+    EXPECT_EQ(ss.size(), 2);
+
+    auto res_boundary = ss.insert(99);
+    EXPECT_TRUE(res_boundary.second);
+    EXPECT_TRUE(ss.contains(99));
+    EXPECT_EQ(ss.size(), 3);
+
+    auto res_zero = ss.insert(0);
+    EXPECT_TRUE(res_zero.second);
+    EXPECT_TRUE(ss.contains(0));
+    EXPECT_EQ(ss.size(), 4);
+
+    EXPECT_FALSE(ss.contains(5));
+    EXPECT_FALSE(ss.contains(100));
+
+    auto res_oor = ss.insert(100);
+    EXPECT_FALSE(res_oor.second);
+    EXPECT_EQ(ss.size(), 4);
+}
+
+TEST_F(SparseSetTest, Erase) {
+    cpp_collections::SparseSet<uint32_t> ss(100);
+    ss.insert(10);
+    ss.insert(20);
+    ss.insert(30);
+    ss.insert(0);
+    ss.insert(99);
+    ASSERT_EQ(ss.size(), 5);
+
+    EXPECT_TRUE(ss.erase(20));
+    EXPECT_FALSE(ss.contains(20));
+    EXPECT_EQ(ss.size(), 4);
+
+    EXPECT_TRUE(ss.erase(0));
+    EXPECT_FALSE(ss.contains(0));
+    EXPECT_EQ(ss.size(), 3);
+
+    EXPECT_TRUE(ss.erase(99));
+    EXPECT_FALSE(ss.contains(99));
+    EXPECT_EQ(ss.size(), 2);
+
+    EXPECT_FALSE(ss.erase(50));
+    EXPECT_EQ(ss.size(), 2);
+
+    EXPECT_FALSE(ss.erase(20));
+    EXPECT_EQ(ss.size(), 2);
+
+    EXPECT_FALSE(ss.erase(100));
+    EXPECT_EQ(ss.size(), 2);
+
+    EXPECT_TRUE(ss.erase(10));
+    EXPECT_TRUE(ss.erase(30));
+    EXPECT_TRUE(ss.empty());
+    EXPECT_EQ(ss.size(), 0);
+
+    EXPECT_FALSE(ss.erase(10));
+
+    cpp_collections::SparseSet<uint32_t> ss2(20);
+    ss2.insert(1);
+    ss2.insert(5);
+    ss2.insert(3);
+    ASSERT_TRUE(ss2.erase(1));
+    EXPECT_EQ(ss2.size(), 2);
+    EXPECT_FALSE(ss2.contains(1));
+    EXPECT_TRUE(ss2.contains(3));
+    EXPECT_TRUE(ss2.contains(5));
+
+    std::set<uint32_t> expected_after_erase_1 = {3, 5};
+    std::set<uint32_t> actual_after_erase_1;
+    for(uint32_t val : ss2) actual_after_erase_1.insert(val);
+    EXPECT_EQ(actual_after_erase_1, expected_after_erase_1);
+}
+
+TEST_F(SparseSetTest, ClearAndSwap) {
+    cpp_collections::SparseSet<uint32_t> ss1(100);
+    ss1.insert(10);
+    ss1.insert(20);
+    ASSERT_EQ(ss1.size(), 2);
+
+    ss1.clear();
+    EXPECT_TRUE(ss1.empty());
+    EXPECT_EQ(ss1.size(), 0);
+    EXPECT_FALSE(ss1.contains(10));
+    EXPECT_EQ(ss1.max_value_capacity(), 100);
+
+    ss1.insert(5);
+    EXPECT_TRUE(ss1.contains(5));
+    EXPECT_EQ(ss1.size(), 1);
+
+    cpp_collections::SparseSet<uint32_t> ss2(50);
+    ss2.insert(30);
+    ss2.insert(40);
+
+    ss1.swap(ss2);
+
+    EXPECT_EQ(ss1.size(), 2);
+    EXPECT_TRUE(ss1.contains(30));
+    EXPECT_TRUE(ss1.contains(40));
+    EXPECT_FALSE(ss1.contains(5));
+    EXPECT_EQ(ss1.max_value_capacity(), 50);
+
+    EXPECT_EQ(ss2.size(), 1);
+    EXPECT_TRUE(ss2.contains(5));
+    EXPECT_FALSE(ss2.contains(30));
+    EXPECT_EQ(ss2.max_value_capacity(), 100);
+
+    cpp_collections::swap(ss1, ss2);
+
+    EXPECT_EQ(ss2.size(), 2);
+    EXPECT_TRUE(ss2.contains(30));
+    EXPECT_EQ(ss1.size(), 1);
+    EXPECT_TRUE(ss1.contains(5));
+}
+
+TEST_F(SparseSetTest, Iteration) {
+    cpp_collections::SparseSet<uint32_t> ss(100);
+
+    int count = 0;
+    for (uint32_t val : ss) {
+        (void)val;
+        count++;
+    }
+    EXPECT_EQ(count, 0);
+    EXPECT_EQ(ss.begin(), ss.end());
+
+    ss.insert(10);
+    ss.insert(1);
+    ss.insert(50);
+    ss.insert(5);
+
+    std::set<uint32_t> expected_elements = {1, 5, 10, 50};
+    std::set<uint32_t> actual_elements;
+    for (uint32_t val : ss) {
+        actual_elements.insert(val);
+    }
+    EXPECT_EQ(actual_elements, expected_elements);
+    EXPECT_EQ(ss.size(), expected_elements.size());
+
+    const auto& const_ss = ss;
+    actual_elements.clear();
+    for (uint32_t val : const_ss) {
+        actual_elements.insert(val);
+    }
+    EXPECT_EQ(actual_elements, expected_elements);
+    EXPECT_EQ(const_ss.cbegin(), const_ss.begin());
+    EXPECT_EQ(const_ss.cend(), const_ss.end());
+
+
+    std::vector<uint32_t> from_iter;
+    for (auto it = ss.begin(); it != ss.end(); ++it) {
+        from_iter.push_back(*it);
+    }
+    EXPECT_EQ(from_iter.size(), expected_elements.size());
+    for(uint32_t val : from_iter) {
+        EXPECT_TRUE(expected_elements.count(val));
+    }
+
+    auto it_found = ss.find(10);
+    ASSERT_NE(it_found, ss.end());
+    EXPECT_EQ(*it_found, 10);
+
+    auto it_not_found = ss.find(101);
+    EXPECT_EQ(it_not_found, ss.end());
+
+    const auto it_const_found = const_ss.find(5);
+    ASSERT_NE(it_const_found, const_ss.end());
+    EXPECT_EQ(*it_const_found, 5);
+}
+
+TEST_F(SparseSetTest, DenseReallocation) {
+    cpp_collections::SparseSet<uint32_t> ss(1000, 2);
+
+    EXPECT_GE(ss.dense_capacity(), 2);
+
+    ss.insert(10);
+    ss.insert(20);
+    size_t cap_before = ss.dense_capacity();
+    ASSERT_EQ(ss.size(), 2);
+
+    ss.insert(30);
+    EXPECT_EQ(ss.size(), 3);
+    EXPECT_TRUE(ss.contains(10));
+    EXPECT_TRUE(ss.contains(20));
+    EXPECT_TRUE(ss.contains(30));
+    if (cap_before <= 2 && cap_before > 0) { // Only check growth if initial capacity was small and binding
+      EXPECT_GT(ss.dense_capacity(), cap_before);
+    }
+
+
+    for (uint32_t i = 0; i < 50; ++i) {
+        ss.insert(i + 100);
+    }
+    EXPECT_EQ(ss.size(), 3 + 50);
+    EXPECT_TRUE(ss.contains(10));
+    EXPECT_TRUE(ss.contains(120));
+
+    cpp_collections::SparseSet<uint32_t> ss2(100);
+    ss2.reserve_dense(10);
+    EXPECT_GE(ss2.dense_capacity(), 10);
+    for(int i=0; i<10; ++i) ss2.insert(i);
+    EXPECT_EQ(ss2.size(),10);
+    size_t cap_after_fill = ss2.dense_capacity();
+    ss2.insert(10);
+    if (cap_after_fill <=10 ) { // Check growth only if capacity was binding
+        EXPECT_GT(ss2.dense_capacity(), cap_after_fill);
+    }
+}
+
+TEST_F(SparseSetTest, ComparisonOperators) {
+    cpp_collections::SparseSet<uint32_t> ss1(100), ss2(100), ss3(100), ss4(50);
+
+    ss1.insert(10); ss1.insert(20);
+    ss2.insert(20); ss2.insert(10);
+    ss3.insert(10); ss3.insert(30);
+    ss4.insert(10); ss4.insert(20);
+
+    EXPECT_EQ(ss1, ss2);
+    EXPECT_FALSE(ss1 != ss2);
+
+    EXPECT_NE(ss1, ss3);
+    EXPECT_FALSE(ss1 == ss3);
+
+    EXPECT_EQ(ss1, ss4);
+
+    ss2.clear();
+    EXPECT_NE(ss1, ss2);
+}
+
+// It's good practice to have a main if not linking with gtest_main,
+// but since tests/CMakeLists.txt links GTest::gtest_main, this is not needed.
+// int main(int argc, char **argv) {
+//     ::testing::InitGoogleTest(&argc, argv);
+//     return RUN_ALL_TESTS();
+// }


### PR DESCRIPTION
Adds a new data structure `cpp_collections::SparseSet<T, IndexT, AllocatorT, AllocatorIndexT>`.

Features:
- O(1) average time complexity for insert, erase, and contains.
- Cache-friendly iteration over contained elements.
- Suitable for managing sets of integer-like IDs from a large universal set where the number of active IDs is relatively small.

Includes:
- Header file `include/sparse_set.h` with the implementation.
- Unit tests `tests/sparse_set_test.cpp` using Google Test.
- Usage example `examples/sparse_set_example.cpp`.
- Documentation `docs/README_SparseSet.md`.
- Updates to CMakeLists.txt to integrate the new component.

All implemented unit tests for SparseSet pass when run directly.