### PR TITLE
feat: Implement GroupedSet data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,10 @@ target_include_directories(WeightedSetLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/
 add_library(GenerationalArenaLib INTERFACE)
 target_include_directories(GenerationalArenaLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define GroupedSetLib as an interface library (header-only)
+add_library(GroupedSetLib INTERFACE)
+target_include_directories(GroupedSetLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -373,6 +377,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         WeightedSetLib       # Added for weighted_set_example
 
         GenerationalArenaLib # Added for generational_arena_example
+        GroupedSetLib        # Added for GroupedSet_example
 
         FrozenListLib        # Added for frozen_list_example
         SparseSetLib         # Added for sparse_set_example

--- a/examples/GroupedSet_example.cpp
+++ b/examples/GroupedSet_example.cpp
@@ -1,0 +1,134 @@
+#include "GroupedSet.h" // Assuming GroupedSet.h is in the include path
+#include <iostream>
+#include <string>
+#include <vector>
+
+// Helper function to print a set
+template<typename T, typename Compare>
+void print_set(const std::set<T, Compare>& s, const std::string& label) {
+    std::cout << label << ": { ";
+    for (const auto& item : s) {
+        std::cout << item << " ";
+    }
+    std::cout << "}" << std::endl;
+}
+
+// Helper function to print a vector
+template<typename T>
+void print_vector(const std::vector<T>& v, const std::string& label) {
+    std::cout << label << ": [ ";
+    for (const auto& item : v) {
+        std::cout << item << " ";
+    }
+    std::cout << "]" << std::endl;
+}
+
+int main() {
+    // Create a GroupedSet with string items and string group IDs
+    cpp_collections::GroupedSet<std::string, std::string> asset_manager;
+
+    // Add items
+    asset_manager.add_item("Laptop01");
+    asset_manager.add_item("Laptop02");
+    asset_manager.add_item("Server01");
+    asset_manager.add_item("Server02");
+    asset_manager.add_item("Desktop01");
+    asset_manager.add_item("Switch01"); // Initially ungrouped
+
+    std::cout << "Initial state:" << std::endl;
+    print_set(asset_manager.get_all_items(), "All items");
+    std::cout << "Total items: " << asset_manager.size() << std::endl;
+    std::cout << "Is empty? " << (asset_manager.empty() ? "Yes" : "No") << std::endl;
+    std::cout << "Group count: " << asset_manager.group_count() << std::endl;
+    std::cout << std::endl;
+
+    // Add items to groups
+    std::cout << "Adding items to groups..." << std::endl;
+    asset_manager.add_item_to_group("Laptop01", "HR");
+    asset_manager.add_item_to_group("Laptop02", "Engineering");
+    asset_manager.add_item_to_group("Server01", "Engineering");
+    asset_manager.add_item_to_group("Server01", "DataCenterA"); // Server01 in two groups
+    asset_manager.add_item_to_group("Server02", "DataCenterB");
+    asset_manager.add_item_to_group("Desktop01", "HR");
+    asset_manager.add_item_to_group("Desktop01", "Finance"); // Desktop01 in two groups
+
+    // Check item existence
+    std::cout << "Item 'Laptop01' exists: " << (asset_manager.item_exists("Laptop01") ? "Yes" : "No") << std::endl;
+    std::cout << "Item 'Projector01' exists: " << (asset_manager.item_exists("Projector01") ? "Yes" : "No") << std::endl;
+
+    // Check group existence
+    std::cout << "Group 'HR' exists: " << (asset_manager.group_exists("HR") ? "Yes" : "No") << std::endl;
+    std::cout << "Group 'Marketing' exists: " << (asset_manager.group_exists("Marketing") ? "Yes" : "No") << std::endl;
+    std::cout << std::endl;
+
+    // Querying
+    std::cout << "Querying groups and items:" << std::endl;
+    print_vector(asset_manager.get_all_groups(), "All groups");
+    print_set(asset_manager.get_items_in_group("HR"), "Items in HR");
+    print_set(asset_manager.get_items_in_group("Engineering"), "Items in Engineering");
+    print_set(asset_manager.get_items_in_group("DataCenterA"), "Items in DataCenterA");
+    print_set(asset_manager.get_items_in_group("Marketing"), "Items in Marketing (non-existent)");
+
+    print_set(asset_manager.get_groups_for_item("Server01"), "Groups for Server01");
+    print_set(asset_manager.get_groups_for_item("Laptop02"), "Groups for Laptop02");
+    print_set(asset_manager.get_groups_for_item("Switch01"), "Groups for Switch01 (ungrouped)");
+
+    std::cout << "Is 'Laptop01' in 'HR'? " << (asset_manager.is_item_in_group("Laptop01", "HR") ? "Yes" : "No") << std::endl;
+    std::cout << "Is 'Laptop01' in 'Engineering'? " << (asset_manager.is_item_in_group("Laptop01", "Engineering") ? "Yes" : "No") << std::endl;
+    std::cout << std::endl;
+
+    // Counts
+    std::cout << "Counts:" << std::endl;
+    std::cout << "Total items: " << asset_manager.size() << std::endl;
+    std::cout << "Group count: " << asset_manager.group_count() << std::endl;
+    std::cout << "Items in 'HR' count: " << asset_manager.items_in_group_count("HR") << std::endl;
+    std::cout << "Groups for 'Server01' count: " << asset_manager.groups_for_item_count("Server01") << std::endl;
+    std::cout << std::endl;
+
+    // Advanced queries
+    std::cout << "Advanced queries:" << std::endl;
+    std::vector<std::string> eng_dc_groups = {"Engineering", "DataCenterA"};
+    print_set(asset_manager.get_items_in_all_groups(eng_dc_groups), "Items in ALL (Engineering, DataCenterA)");
+
+    std::vector<std::string> hr_fin_groups = {"HR", "Finance"};
+    print_set(asset_manager.get_items_in_all_groups(hr_fin_groups), "Items in ALL (HR, Finance)");
+
+    std::vector<std::string> any_hr_eng = {"HR", "Engineering"};
+    print_set(asset_manager.get_items_in_any_group(any_hr_eng), "Items in ANY (HR, Engineering)");
+
+    print_set(asset_manager.get_ungrouped_items(), "Ungrouped items");
+    std::cout << std::endl;
+
+    // Removals
+    std::cout << "Demonstrating removals:" << std::endl;
+    std::cout << "Removing 'Laptop01' from 'HR'..." << std::endl;
+    asset_manager.remove_item_from_group("Laptop01", "HR");
+    print_set(asset_manager.get_items_in_group("HR"), "Items in HR after removing Laptop01");
+    print_set(asset_manager.get_groups_for_item("Laptop01"), "Groups for Laptop01 after removing from HR");
+    print_set(asset_manager.get_ungrouped_items(), "Ungrouped items after Laptop01 removed from HR"); // Laptop01 should now be ungrouped
+    std::cout << std::endl;
+
+    std::cout << "Removing 'Server01' (item) completely..." << std::endl;
+    asset_manager.remove_item("Server01");
+    print_set(asset_manager.get_all_items(), "All items after removing Server01");
+    print_set(asset_manager.get_items_in_group("Engineering"), "Items in Engineering after removing Server01");
+    print_set(asset_manager.get_items_in_group("DataCenterA"), "Items in DataCenterA after removing Server01");
+    std::cout << "Item 'Server01' exists: " << (asset_manager.item_exists("Server01") ? "Yes" : "No") << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "Removing 'Finance' (group) completely..." << std::endl;
+    asset_manager.remove_group("Finance");
+    print_vector(asset_manager.get_all_groups(), "All groups after removing Finance");
+    print_set(asset_manager.get_groups_for_item("Desktop01"), "Groups for Desktop01 after removing Finance group");
+    std::cout << "Group 'Finance' exists: " << (asset_manager.group_exists("Finance") ? "Yes" : "No") << std::endl;
+    std::cout << std::endl;
+
+    // Clear everything
+    std::cout << "Clearing the GroupedSet..." << std::endl;
+    asset_manager.clear();
+    std::cout << "Total items after clear: " << asset_manager.size() << std::endl;
+    std::cout << "Is empty after clear? " << (asset_manager.empty() ? "Yes" : "No") << std::endl;
+    print_vector(asset_manager.get_all_groups(), "All groups after clear");
+
+    return 0;
+}

--- a/include/GroupedSet.h
+++ b/include/GroupedSet.h
@@ -1,0 +1,372 @@
+#pragma once
+
+#include <set>
+#include <map>
+#include <vector>
+#include <string> // Common type for T or G, good to include for users
+#include <functional> // For std::less
+#include <algorithm>  // For std::set_intersection, std::set_union
+#include <iterator>   // For std::inserter
+
+namespace cpp_collections {
+
+template <
+    typename T,
+    typename G,
+    typename ItemCompare = std::less<T>,
+    typename GroupCompare = std::less<G>
+>
+class GroupedSet {
+public:
+    // Type aliases
+    using item_type = T;
+    using group_type = G;
+    using item_set_type = std::set<T, ItemCompare>;
+    using group_set_type = std::set<G, GroupCompare>;
+
+private:
+    // Internal data structures
+    item_set_type all_items_;
+    std::map<G, item_set_type, GroupCompare> group_to_items_;
+    std::map<T, group_set_type, ItemCompare> item_to_groups_;
+
+    // Comparators (store instances if they might have state, though std::less doesn't)
+    ItemCompare item_comparator_;
+    GroupCompare group_comparator_;
+
+public:
+    // Constructor
+    GroupedSet(const ItemCompare& item_comp = ItemCompare(),
+               const GroupCompare& group_comp = GroupCompare())
+        : item_comparator_(item_comp), group_comparator_(group_comp) {}
+
+    // Default copy/move constructors and assignment operators should be fine
+    GroupedSet(const GroupedSet&) = default;
+    GroupedSet(GroupedSet&&) = default;
+    GroupedSet& operator=(const GroupedSet&) = default;
+    GroupedSet& operator=(GroupedSet&&) = default;
+    ~GroupedSet() = default;
+
+    // --- Modification methods ---
+
+    /**
+     * @brief Adds an item to the global set of items.
+     * The item will not belong to any group until explicitly added to one.
+     * @param item The item to add.
+     * @return True if the item was newly added, false if it already existed.
+     */
+    bool add_item(const T& item) {
+        return all_items_.insert(item).second;
+    }
+
+    /**
+     * @brief Adds an item to a specific group.
+     * If the item does not exist in the GroupedSet, it's added to the global set of items.
+     * If the group does not exist, it is created.
+     * @param item The item to add to the group.
+     * @param group The group to add the item to.
+     * @return True if the item was newly added to this specific group,
+     *         false if it was already in this group.
+     */
+    bool add_item_to_group(const T& item, const G& group) {
+        all_items_.insert(item); // Ensure item exists globally
+
+        // Add group to item's list of groups
+        item_to_groups_[item].insert(group);
+
+        // Add item to group's list of items
+        // The return value reflects whether the item was new to this group.
+        return group_to_items_[group].insert(item).second;
+    }
+
+    /**
+     * @brief Removes an item from a specific group.
+     * The item itself is not removed from the GroupedSet's global item list.
+     * If the group becomes empty after removing the item, the group itself is not automatically deleted.
+     * If the item no longer belongs to any group, its entry in item_to_groups_ is cleared but not removed.
+     * @param item The item to remove from the group.
+     * @param group The group from which to remove the item.
+     * @return True if the item was found in the group and removed, false otherwise.
+     */
+    bool remove_item_from_group(const T& item, const G& group) {
+        bool removed_from_group = false;
+        auto group_it = group_to_items_.find(group);
+        if (group_it != group_to_items_.end()) {
+            if (group_it->second.erase(item) > 0) {
+                removed_from_group = true;
+            }
+            // Design choice: Do not remove group if it becomes empty. User can call remove_group if desired.
+        }
+
+        auto item_it = item_to_groups_.find(item);
+        if (item_it != item_to_groups_.end()) {
+            item_it->second.erase(group);
+            // Design choice: Do not remove item's entry from item_to_groups_ if its group set becomes empty.
+            // It might still be in all_items_ and could be added to groups later.
+        }
+        return removed_from_group;
+    }
+
+    /**
+     * @brief Removes an item completely from the GroupedSet.
+     * This includes removing it from the global item list and from all groups it belonged to.
+     * @param item The item to remove.
+     * @return True if the item existed and was removed, false otherwise.
+     */
+    bool remove_item(const T& item) {
+        if (all_items_.erase(item) == 0) {
+            return false; // Item didn't exist in the global list
+        }
+
+        auto item_groups_it = item_to_groups_.find(item);
+        if (item_groups_it != item_to_groups_.end()) {
+            // Iterate over a copy of the groups, as we are modifying group_to_items_
+            group_set_type groups_item_belonged_to = item_groups_it->second;
+            for (const G& group_key : groups_item_belonged_to) {
+                auto group_items_it = group_to_items_.find(group_key);
+                if (group_items_it != group_to_items_.end()) {
+                    group_items_it->second.erase(item);
+                    // Optional: if (group_items_it->second.empty()) { group_to_items_.erase(group_items_it); }
+                }
+            }
+            item_to_groups_.erase(item_groups_it); // Remove the item's entry from reverse map
+        }
+        return true;
+    }
+
+    /**
+     * @brief Removes a group and dissociates all its items from it.
+     * Items that were in this group are not removed from the GroupedSet's
+     * global item list, nor are they removed from other groups they might belong to.
+     * @param group The group to remove.
+     * @return True if the group existed and was removed, false otherwise.
+     */
+    bool remove_group(const G& group) {
+        auto group_items_it = group_to_items_.find(group);
+        if (group_items_it == group_to_items_.end()) {
+            return false; // Group didn't exist
+        }
+
+        // Iterate over a copy of items in the group to avoid iterator invalidation issues
+        item_set_type items_in_group = group_items_it->second;
+        for (const T& item_key : items_in_group) {
+            auto item_groups_it = item_to_groups_.find(item_key);
+            if (item_groups_it != item_to_groups_.end()) {
+                item_groups_it->second.erase(group);
+                // Optional: if (item_groups_it->second.empty()) { item_to_groups_.erase(item_groups_it); }
+            }
+        }
+        group_to_items_.erase(group_items_it); // Remove the group itself
+        return true;
+    }
+
+    /**
+     * @brief Clears all items, groups, and memberships from the GroupedSet.
+     */
+    void clear() {
+        all_items_.clear();
+        group_to_items_.clear();
+        item_to_groups_.clear();
+    }
+
+    // --- Query methods ---
+
+    /**
+     * @brief Checks if an item exists in the GroupedSet (regardless of group membership).
+     * @param item The item to check.
+     * @return True if the item exists, false otherwise.
+     */
+    bool item_exists(const T& item) const {
+        return all_items_.count(item) > 0;
+    }
+
+    /**
+     * @brief Checks if a group exists (i.e., has been created, possibly empty).
+     * @param group The group to check.
+     * @return True if the group exists, false otherwise.
+     */
+    bool group_exists(const G& group) const {
+        return group_to_items_.count(group) > 0;
+    }
+
+    /**
+     * @brief Checks if a specific item belongs to a specific group.
+     * @param item The item to check.
+     * @param group The group to check.
+     * @return True if the item is in the group, false otherwise.
+     */
+    bool is_item_in_group(const T& item, const G& group) const {
+        auto it = group_to_items_.find(group);
+        if (it != group_to_items_.end()) {
+            return it->second.count(item) > 0;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Retrieves a set of items belonging to a specific group.
+     * @param group The group whose items are to be retrieved.
+     * @return A copy of the set of items in the group. Returns an empty set if the group doesn't exist.
+     */
+    item_set_type get_items_in_group(const G& group) const {
+        auto it = group_to_items_.find(group);
+        if (it != group_to_items_.end()) {
+            return it->second; // Returns a copy
+        }
+        return item_set_type(item_comparator_); // Return empty set with correct comparator
+    }
+
+    /**
+     * @brief Retrieves a set of groups that a specific item belongs to.
+     * @param item The item whose groups are to be retrieved.
+     * @return A copy of the set of groups the item belongs to. Returns an empty set if the item doesn't exist or isn't in any group.
+     */
+    group_set_type get_groups_for_item(const T& item) const {
+        auto it = item_to_groups_.find(item);
+        if (it != item_to_groups_.end()) {
+            return it->second; // Returns a copy
+        }
+        return group_set_type(group_comparator_); // Return empty set with correct comparator
+    }
+
+    /**
+     * @brief Retrieves all unique items stored in the GroupedSet, regardless of group membership.
+     * @return A const reference to the set of all items.
+     */
+    const item_set_type& get_all_items() const {
+        return all_items_;
+    }
+
+    /**
+     * @brief Retrieves a list of all unique group identifiers currently active.
+     * @return A vector containing all group keys.
+     */
+    std::vector<G> get_all_groups() const {
+        std::vector<G> group_keys;
+        group_keys.reserve(group_to_items_.size());
+        for (const auto& pair : group_to_items_) {
+            group_keys.push_back(pair.first);
+        }
+        // Optionally sort if a specific order is desired, but map keys are already somewhat ordered.
+        // For std::map, keys are already sorted by GroupCompare.
+        return group_keys;
+    }
+
+    /**
+     * @brief Retrieves items that are present in ALL of the specified groups.
+     * @param groups A vector of group identifiers.
+     * @return A set of items that are members of every group in the input vector.
+     *         Returns an empty set if the groups vector is empty or no items match.
+     */
+    item_set_type get_items_in_all_groups(const std::vector<G>& groups) const {
+        if (groups.empty()) {
+            return item_set_type(item_comparator_);
+        }
+
+        // Start with items from the first group (or an empty set if group doesn't exist)
+        item_set_type result_items = get_items_in_group(groups[0]);
+        if (result_items.empty() && groups.size() > 1) { // If first group is empty, intersection will be empty
+             return item_set_type(item_comparator_);
+        }
+
+
+        for (size_t i = 1; i < groups.size(); ++i) {
+            item_set_type current_group_items = get_items_in_group(groups[i]);
+            item_set_type intersection(item_comparator_);
+            std::set_intersection(result_items.begin(), result_items.end(),
+                                  current_group_items.begin(), current_group_items.end(),
+                                  std::inserter(intersection, intersection.begin()),
+                                  item_comparator_);
+            result_items = std::move(intersection);
+            if (result_items.empty()) { // Optimization: if intersection is empty, further work is futile
+                break;
+            }
+        }
+        return result_items;
+    }
+
+    /**
+     * @brief Retrieves items that are present in ANY of the specified groups.
+     * @param groups A vector of group identifiers.
+     * @return A set of items that are members of at least one group in the input vector.
+     */
+    item_set_type get_items_in_any_group(const std::vector<G>& groups) const {
+        item_set_type result_items(item_comparator_);
+        for (const G& group_key : groups) {
+            item_set_type current_group_items = get_items_in_group(group_key);
+            result_items.insert(current_group_items.begin(), current_group_items.end());
+        }
+        return result_items;
+    }
+
+    /**
+     * @brief Retrieves items that are in the GroupedSet but do not belong to any group.
+     * @return A set of items that are not associated with any group.
+     */
+    item_set_type get_ungrouped_items() const {
+        item_set_type ungrouped(item_comparator_);
+        for (const T& item : all_items_) {
+            auto it = item_to_groups_.find(item);
+            // Item is ungrouped if it's not in item_to_groups_ or its set of groups is empty.
+            if (it == item_to_groups_.end() || it->second.empty()) {
+                ungrouped.insert(item);
+            }
+        }
+        return ungrouped;
+    }
+
+    // --- Size/utility methods ---
+
+    /**
+     * @brief Returns the total number of unique items in the GroupedSet.
+     * @return The number of unique items.
+     */
+    size_t size() const {
+        return all_items_.size();
+    }
+
+    /**
+     * @brief Checks if the GroupedSet contains any items.
+     * @return True if there are no items, false otherwise.
+     */
+    bool empty() const {
+        return all_items_.empty();
+    }
+
+    /**
+     * @brief Returns the number of distinct groups that have at least one item or have been explicitly created.
+     * @return The number of groups.
+     */
+    size_t group_count() const {
+        return group_to_items_.size();
+    }
+
+    /**
+     * @brief Returns the number of items in a specific group.
+     * @param group The group identifier.
+     * @return The number of items in the group, or 0 if the group doesn't exist.
+     */
+    size_t items_in_group_count(const G& group) const {
+        auto it = group_to_items_.find(group);
+        if (it != group_to_items_.end()) {
+            return it->second.size();
+        }
+        return 0;
+    }
+
+    /**
+     * @brief Returns the number of groups a specific item belongs to.
+     * @param item The item identifier.
+     * @return The number of groups the item is a member of, or 0 if the item doesn't exist or isn't in any groups.
+     */
+    size_t groups_for_item_count(const T& item) const {
+        auto it = item_to_groups_.find(item);
+        if (it != item_to_groups_.end()) {
+            return it->second.size();
+        }
+        return 0;
+    }
+
+}; // class GroupedSet
+
+} // namespace cpp_collections

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         WeightedSetLib       # Added for weighted_set_test
 
         GenerationalArenaLib # Added for generational_arena_test
+        GroupedSetLib        # Added for test_GroupedSet
 
         FrozenListLib        # Added for frozen_list_test
         SparseSetLib         # Added for sparse_set_test

--- a/tests/test_GroupedSet.cpp
+++ b/tests/test_GroupedSet.cpp
@@ -1,0 +1,321 @@
+#include "gtest/gtest.h"
+#include "GroupedSet.h" // Adjust path as necessary
+#include <string>
+#include <vector>
+#include <set>
+#include <algorithm> // For std::sort for vector comparison
+
+// Define types for convenience in tests
+using Item = std::string;
+using Group = std::string;
+using TestGroupedSet = cpp_collections::GroupedSet<Item, Group>;
+using ItemSet = std::set<Item>;
+using GroupSet = std::set<Group>;
+
+// Helper to compare vectors by content regardless of order (after sorting)
+template<typename T>
+void EXPECT_VECTORS_EQ_UNORDERED(std::vector<T> vec1, std::vector<T> vec2) {
+    std::sort(vec1.begin(), vec1.end());
+    std::sort(vec2.begin(), vec2.end());
+    EXPECT_EQ(vec1, vec2);
+}
+
+TEST(GroupedSetTest, InitialState) {
+    TestGroupedSet gs;
+    EXPECT_TRUE(gs.empty());
+    EXPECT_EQ(gs.size(), 0);
+    EXPECT_EQ(gs.group_count(), 0);
+    EXPECT_TRUE(gs.get_all_items().empty());
+    EXPECT_TRUE(gs.get_all_groups().empty());
+    EXPECT_TRUE(gs.get_ungrouped_items().empty());
+}
+
+TEST(GroupedSetTest, AddItem) {
+    TestGroupedSet gs;
+    EXPECT_TRUE(gs.add_item("item1"));
+    EXPECT_FALSE(gs.empty());
+    EXPECT_EQ(gs.size(), 1);
+    EXPECT_TRUE(gs.item_exists("item1"));
+    EXPECT_FALSE(gs.item_exists("item2"));
+    EXPECT_FALSE(gs.add_item("item1")); // Already exists
+    EXPECT_EQ(gs.size(), 1);
+
+    ItemSet expected_all = {"item1"};
+    EXPECT_EQ(gs.get_all_items(), expected_all);
+    ItemSet expected_ungrouped = {"item1"};
+    EXPECT_EQ(gs.get_ungrouped_items(), expected_ungrouped);
+}
+
+TEST(GroupedSetTest, AddItemToGroup) {
+    TestGroupedSet gs;
+    EXPECT_TRUE(gs.add_item_to_group("item1", "groupA"));
+
+    EXPECT_TRUE(gs.item_exists("item1"));
+    EXPECT_TRUE(gs.group_exists("groupA"));
+    EXPECT_TRUE(gs.is_item_in_group("item1", "groupA"));
+    EXPECT_EQ(gs.size(), 1);
+    EXPECT_EQ(gs.group_count(), 1);
+    EXPECT_EQ(gs.items_in_group_count("groupA"), 1);
+    EXPECT_EQ(gs.groups_for_item_count("item1"), 1);
+
+    ItemSet expected_group_a = {"item1"};
+    EXPECT_EQ(gs.get_items_in_group("groupA"), expected_group_a);
+    GroupSet expected_item1_groups = {"groupA"};
+    EXPECT_EQ(gs.get_groups_for_item("item1"), expected_item1_groups);
+    EXPECT_TRUE(gs.get_ungrouped_items().empty()); // item1 is now grouped
+
+    // Add same item to another group
+    EXPECT_TRUE(gs.add_item_to_group("item1", "groupB"));
+    EXPECT_EQ(gs.groups_for_item_count("item1"), 2);
+    GroupSet expected_item1_groups_updated = {"groupA", "groupB"};
+    EXPECT_EQ(gs.get_groups_for_item("item1"), expected_item1_groups_updated);
+
+    // Add new item to existing group
+    EXPECT_TRUE(gs.add_item_to_group("item2", "groupA"));
+    EXPECT_EQ(gs.items_in_group_count("groupA"), 2);
+    ItemSet expected_group_a_updated = {"item1", "item2"};
+    EXPECT_EQ(gs.get_items_in_group("groupA"), expected_group_a_updated);
+
+    // Add item that was previously only in all_items_
+    gs.add_item("item3");
+    EXPECT_TRUE(gs.add_item_to_group("item3", "groupC"));
+    EXPECT_TRUE(gs.is_item_in_group("item3", "groupC"));
+    EXPECT_EQ(gs.groups_for_item_count("item3"), 1);
+
+    // Try adding item already in group
+    EXPECT_FALSE(gs.add_item_to_group("item1", "groupA"));
+}
+
+TEST(GroupedSetTest, RemoveItemFromGroup) {
+    TestGroupedSet gs;
+    gs.add_item_to_group("item1", "groupA");
+    gs.add_item_to_group("item1", "groupB");
+    gs.add_item_to_group("item2", "groupA");
+
+    EXPECT_TRUE(gs.remove_item_from_group("item1", "groupA"));
+    EXPECT_FALSE(gs.is_item_in_group("item1", "groupA"));
+    EXPECT_TRUE(gs.is_item_in_group("item1", "groupB")); // Still in groupB
+    EXPECT_EQ(gs.items_in_group_count("groupA"), 1);     // item2 still in groupA
+    EXPECT_EQ(gs.groups_for_item_count("item1"), 1);
+
+    // Item becomes ungrouped if removed from its only group
+    gs.add_item_to_group("item3", "groupC");
+    EXPECT_TRUE(gs.remove_item_from_group("item3", "groupC"));
+    EXPECT_EQ(gs.groups_for_item_count("item3"), 0);
+    ItemSet expected_ungrouped = {"item3"};
+    EXPECT_EQ(gs.get_ungrouped_items(), expected_ungrouped);
+
+
+    EXPECT_FALSE(gs.remove_item_from_group("item1", "groupNonExistent"));
+    EXPECT_FALSE(gs.remove_item_from_group("itemNonExistent", "groupA"));
+    EXPECT_FALSE(gs.remove_item_from_group("item2", "groupB")); // item2 not in groupB
+}
+
+TEST(GroupedSetTest, RemoveItem) {
+    TestGroupedSet gs;
+    gs.add_item_to_group("item1", "groupA");
+    gs.add_item_to_group("item1", "groupB");
+    gs.add_item_to_group("item2", "groupA");
+    gs.add_item("item3"); // Ungrouped item
+
+    EXPECT_TRUE(gs.remove_item("item1"));
+    EXPECT_FALSE(gs.item_exists("item1"));
+    EXPECT_FALSE(gs.is_item_in_group("item1", "groupA"));
+    EXPECT_FALSE(gs.is_item_in_group("item1", "groupB"));
+    EXPECT_EQ(gs.items_in_group_count("groupA"), 1); // item2 still there
+    EXPECT_EQ(gs.groups_for_item_count("item1"), 0);
+    EXPECT_EQ(gs.size(), 2); // item2 and item3 remain
+
+    EXPECT_TRUE(gs.remove_item("item3")); // Remove ungrouped item
+    EXPECT_FALSE(gs.item_exists("item3"));
+    EXPECT_EQ(gs.size(), 1);
+
+    EXPECT_FALSE(gs.remove_item("itemNonExistent"));
+}
+
+TEST(GroupedSetTest, RemoveGroup) {
+    TestGroupedSet gs;
+    gs.add_item_to_group("item1", "groupA");
+    gs.add_item_to_group("item1", "groupB"); // item1 in A and B
+    gs.add_item_to_group("item2", "groupA"); // item2 in A
+    gs.add_item_to_group("item3", "groupC"); // item3 in C
+
+    EXPECT_TRUE(gs.remove_group("groupA"));
+    EXPECT_FALSE(gs.group_exists("groupA"));
+    EXPECT_FALSE(gs.is_item_in_group("item1", "groupA"));
+    EXPECT_TRUE(gs.is_item_in_group("item1", "groupB")); // Still in groupB
+    EXPECT_EQ(gs.groups_for_item_count("item1"), 1);
+    EXPECT_FALSE(gs.is_item_in_group("item2", "groupA"));
+    EXPECT_EQ(gs.groups_for_item_count("item2"), 0); // item2 was only in groupA
+    EXPECT_EQ(gs.group_count(), 2); // groupB and groupC remain
+
+    ItemSet expected_ungrouped_after_A_removed = {"item2"}; // item2 becomes ungrouped
+    EXPECT_EQ(gs.get_ungrouped_items(), expected_ungrouped_after_A_removed);
+
+
+    EXPECT_FALSE(gs.remove_group("groupNonExistent"));
+}
+
+TEST(GroupedSetTest, Clear) {
+    TestGroupedSet gs;
+    gs.add_item_to_group("item1", "groupA");
+    gs.add_item_to_group("item2", "groupB");
+    gs.clear();
+
+    EXPECT_TRUE(gs.empty());
+    EXPECT_EQ(gs.size(), 0);
+    EXPECT_EQ(gs.group_count(), 0);
+    EXPECT_FALSE(gs.item_exists("item1"));
+    EXPECT_FALSE(gs.group_exists("groupA"));
+}
+
+TEST(GroupedSetTest, QueryMethods) {
+    TestGroupedSet gs;
+    gs.add_item_to_group("apple", "fruit");
+    gs.add_item_to_group("banana", "fruit");
+    gs.add_item_to_group("carrot", "vegetable");
+    gs.add_item_to_group("apple", "red");
+    gs.add_item_to_group("carrot", "orange");
+    gs.add_item("brocolli"); // Ungrouped
+
+    // get_all_items
+    ItemSet expected_all = {"apple", "banana", "carrot", "brocolli"};
+    EXPECT_EQ(gs.get_all_items(), expected_all);
+
+    // get_all_groups
+    std::vector<Group> expected_groups_vec = {"fruit", "vegetable", "red", "orange"};
+    EXPECT_VECTORS_EQ_UNORDERED(gs.get_all_groups(), expected_groups_vec);
+
+    // get_items_in_group
+    ItemSet expected_fruit = {"apple", "banana"};
+    EXPECT_EQ(gs.get_items_in_group("fruit"), expected_fruit);
+    EXPECT_TRUE(gs.get_items_in_group("non_existent_group").empty());
+
+    // get_groups_for_item
+    GroupSet expected_apple_groups = {"fruit", "red"};
+    EXPECT_EQ(gs.get_groups_for_item("apple"), expected_apple_groups);
+    EXPECT_TRUE(gs.get_groups_for_item("non_existent_item").empty());
+    EXPECT_TRUE(gs.get_groups_for_item("brocolli").empty());
+
+
+    // get_ungrouped_items
+    ItemSet expected_ungrouped = {"brocolli"};
+    EXPECT_EQ(gs.get_ungrouped_items(), expected_ungrouped);
+}
+
+TEST(GroupedSetTest, AdvancedQueryMethods) {
+    TestGroupedSet gs;
+    // Common items for intersection/union tests
+    gs.add_item_to_group("itemA", "group1");
+    gs.add_item_to_group("itemA", "group2");
+    gs.add_item_to_group("itemA", "group3");
+
+    gs.add_item_to_group("itemB", "group1");
+    gs.add_item_to_group("itemB", "group2");
+
+    gs.add_item_to_group("itemC", "group1");
+
+    gs.add_item_to_group("itemD", "group3");
+    gs.add_item_to_group("itemE", "group4"); // Only in group4
+
+    // get_items_in_all_groups
+    std::vector<Group> g1_g2 = {"group1", "group2"};
+    ItemSet expected_in_g1_g2 = {"itemA", "itemB"};
+    EXPECT_EQ(gs.get_items_in_all_groups(g1_g2), expected_in_g1_g2);
+
+    std::vector<Group> g1_g2_g3 = {"group1", "group2", "group3"};
+    ItemSet expected_in_g1_g2_g3 = {"itemA"};
+    EXPECT_EQ(gs.get_items_in_all_groups(g1_g2_g3), expected_in_g1_g2_g3);
+
+    std::vector<Group> g1_g4 = {"group1", "group4"}; // No common items
+    EXPECT_TRUE(gs.get_items_in_all_groups(g1_g4).empty());
+
+    std::vector<Group> empty_groups_vec;
+    EXPECT_TRUE(gs.get_items_in_all_groups(empty_groups_vec).empty());
+
+    std::vector<Group> non_existent_group_vec = {"non_existent_group"};
+    EXPECT_TRUE(gs.get_items_in_all_groups(non_existent_group_vec).empty());
+
+    std::vector<Group> g1_non_existent_group_vec = {"group1", "non_existent_group"};
+    EXPECT_TRUE(gs.get_items_in_all_groups(g1_non_existent_group_vec).empty());
+
+
+    // get_items_in_any_group
+    std::vector<Group> g2_g3 = {"group2", "group3"};
+    ItemSet expected_in_g2_or_g3 = {"itemA", "itemB", "itemD"};
+    EXPECT_EQ(gs.get_items_in_any_group(g2_g3), expected_in_g2_or_g3);
+
+    std::vector<Group> g1_g4_any = {"group1", "group4"};
+    ItemSet expected_in_g1_or_g4 = {"itemA", "itemB", "itemC", "itemE"};
+    EXPECT_EQ(gs.get_items_in_any_group(g1_g4_any), expected_in_g1_or_g4);
+
+    EXPECT_TRUE(gs.get_items_in_any_group(empty_groups_vec).empty());
+    EXPECT_TRUE(gs.get_items_in_any_group(non_existent_group_vec).empty());
+}
+
+TEST(GroupedSetTest, CustomComparators) {
+    struct CaseInsensitiveCompare {
+        bool operator()(const std::string& a, const std::string& b) const {
+            return std::lexicographical_compare(
+                a.begin(), a.end(),
+                b.begin(), b.end(),
+                [](char c1, char c2) {
+                    return std::tolower(c1) < std::tolower(c2);
+                }
+            );
+        }
+    };
+
+    cpp_collections::GroupedSet<std::string, std::string, CaseInsensitiveCompare, CaseInsensitiveCompare> gs_ci;
+
+    gs_ci.add_item_to_group("Apple", "Fruit");
+    gs_ci.add_item_to_group("apple", "Red"); // Should be treated as same item "Apple" for item_to_groups
+                                           // and new group "Red" for group_to_items
+
+    EXPECT_TRUE(gs_ci.item_exists("APPLE"));
+    EXPECT_TRUE(gs_ci.item_exists("apple"));
+    EXPECT_EQ(gs_ci.size(), 1); // Only one unique item "Apple" due to CI compare
+
+    EXPECT_TRUE(gs_ci.group_exists("FRUIT"));
+    EXPECT_TRUE(gs_ci.group_exists("fruit"));
+    EXPECT_EQ(gs_ci.group_count(), 2); // "Fruit" and "Red" are distinct if CI compare for groups is used correctly.
+
+    // Check item's groups
+    std::set<std::string, CaseInsensitiveCompare> expected_apple_groups_ci = {"Fruit", "Red"};
+    EXPECT_EQ(gs_ci.get_groups_for_item("aPpLe"), expected_apple_groups_ci);
+
+    // Check group's items
+    std::set<std::string, CaseInsensitiveCompare> expected_fruit_items_ci = {"apple"}; // or "Apple"
+    EXPECT_EQ(gs_ci.get_items_in_group("FRuiT").size(), 1);
+    EXPECT_TRUE(gs_ci.get_items_in_group("FRuiT").count("APPLE"));
+}
+
+TEST(GroupedSetTest, EdgeCasesAndComplexScenarios) {
+    TestGroupedSet gs;
+    gs.add_item("item1"); // Ungrouped initially
+    gs.add_item_to_group("item1", "groupA"); // Now grouped
+    gs.remove_item_from_group("item1", "groupA"); // Now ungrouped again
+
+    ItemSet expected_ungrouped = {"item1"};
+    EXPECT_EQ(gs.get_ungrouped_items(), expected_ungrouped);
+    EXPECT_EQ(gs.groups_for_item_count("item1"), 0);
+    EXPECT_TRUE(gs.item_exists("item1")); // Still exists globally
+
+    gs.add_item_to_group("item1", "groupB"); // Re-grouped
+    EXPECT_FALSE(gs.get_ungrouped_items().count("item1"));
+
+    // Remove group that makes an item ungrouped
+    gs.remove_group("groupB");
+    EXPECT_EQ(gs.get_ungrouped_items(), expected_ungrouped); // item1 becomes ungrouped again
+
+    // Removing non-existent item from group
+    EXPECT_FALSE(gs.remove_item_from_group("itemNonExistent", "groupA"));
+
+    // Removing item from non-existent group
+    EXPECT_FALSE(gs.remove_item_from_group("item1", "groupNonExistent"));
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Adds a new GroupedSet data structure to the library.

GroupedSet allows managing a collection of items where each item can belong to one or more groups. It provides functionalities to:
- Add/remove items and groups.
- Add/remove items from specific groups.
- Query items by group, and groups by item.
- Perform set operations like finding items in all/any of a given list of groups.
- Identify ungrouped items.

Includes:
- include/GroupedSet.h: Header-only implementation.
- examples/GroupedSet_example.cpp: Usage demonstration.
- tests/test_GroupedSet.cpp: Unit tests.

CMakeLists.txt files have been updated to integrate the new component.