### PR TITLE
feat: Add group_by_consecutive utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,10 @@ target_include_directories(InsertionOrderedMapLib INTERFACE ${CMAKE_CURRENT_SOUR
 add_library(LRUDictLib INTERFACE)
 target_include_directories(LRUDictLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define GroupByConsecutiveLib as an interface library (header-only)
+add_library(GroupByConsecutiveLib INTERFACE)
+target_include_directories(GroupByConsecutiveLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -406,6 +410,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         VectorWrapperLib     # Added for vector_wrapper_example
         InsertionOrderedMapLib # Added for insertion_ordered_map_example
         LRUDictLib           # Added for lru_dict_example
+        GroupByConsecutiveLib # Added for group_by_consecutive_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This includes:
     *   Threading: `thread_pool.h`, `worker_pool.h`.
 *   **Resource Management:** `context_mgr.h` ([ContextMgr](docs/README_context_mgr.md)), `delayed_init.h` ([DelayedInit](docs/README_delayed_init.md)), `memory_mapped_file.h`, `object_pool.h`, `observer_ptr.h`, `scoped_flag.h`, `weak_ref.h`.
 *   **Functional Programming & Pipelines:** `function_pipeline.h`, `optional_pipeline.h`, `partial.h`, `unique_function.h`.
-*   **Iterator and Algorithm Utilities:** `any_all.h` ([AnyAll](docs/README_any_all.md)), `group_by_consecutive.h`, `lazy_sorted_merger.h`, `peekable.h`, `split_view.h`, `zip_view.h`.
+*   **Iterator and Algorithm Utilities:** `any_all.h` ([AnyAll](docs/README_any_all.md)), `group_by_consecutive.h` ([GroupByConsecutive](docs/README_group_by_consecutive.md)), `lazy_sorted_merger.h`, `peekable.h`, `split_view.h`, `zip_view.h`.
 *   **JSON Utilities:** `json_fieldmask.h`, `jsonpatch.h`.
 *   **String Utilities:** `cord.h` ([Cord](docs/README_Cord.md)), `duration_parser.h`, `interning_pool.h`, `parse_utils.h`, `random_string.h`, `string_interner.h`, `string_utils.h`.
 *   **Miscellaneous Utilities:** `batcher.h` ([Batcher](docs/README_batcher.md)), `id_pool.h`, `interval_counter.h`, `optional_utilities.h`, `pretty_print.h`, `safe_numerics.h`, `signal_handler.h`, `simple_moving_average.h`, `singleton.h`, `sliding_window_minmax.h`, `sliding_window.h`, `type_safe_id.h`, `undo.h`, `varint.h`, `version.h`, `WeightedRandomList.h`, `weighted_round_robin.h`.

--- a/include/group_by_consecutive.h
+++ b/include/group_by_consecutive.h
@@ -1,60 +1,168 @@
-#ifndef GROUP_BY_CONSECUTIVE_HPP
-#define GROUP_BY_CONSECUTIVE_HPP
+#pragma once
 
 #include <vector>
-#include <utility> // For std::pair
-#include <type_traits> // For std::decay_t
+#include <functional>
 #include <iterator> // For std::iterator_traits
+#include <type_traits> // For std::invoke_result_t
 
-namespace utils {
+namespace cpp_collections {
 
-// Iterator-based version
-template<typename Iterator, typename KeyFunc>
-auto group_by_consecutive(Iterator begin, Iterator end, KeyFunc key_func)
-    -> std::vector<std::pair<
-           typename std::decay_t<decltype(key_func(*begin))>,
-           std::vector<typename std::iterator_traits<Iterator>::value_type>
-       >>
-{
-    using KeyType = typename std::decay_t<decltype(key_func(*begin))>;
-    using ValueType = typename std::iterator_traits<Iterator>::value_type;
-    using GroupType = std::vector<ValueType>;
-    using ResultType = std::vector<std::pair<KeyType, GroupType>>;
+// Helper struct to represent a group
+template <typename Key, typename Value>
+struct Group {
+    Key key;
+    std::vector<Value> items;
 
-    ResultType result;
-    if (begin == end) {
+    // Default constructor
+    Group() = default;
+
+    // Constructor
+    Group(Key k, std::vector<Value> i) : key(std::move(k)), items(std::move(i)) {}
+
+    // Equality operator for easy testing
+    bool operator==(const Group<Key, Value>& other) const {
+        return key == other.key && items == other.items;
+    }
+};
+
+/**
+ * @brief Groups consecutive elements in a range that share the same key.
+ *
+ * This function iterates through the provided range [first, last) and groups
+ * consecutive elements for which the getKey function returns the same key.
+ *
+ * @tparam InputIt Type of the input iterator. Must meet the requirements of ForwardIterator.
+ * @tparam GetKey Unary function object that takes an element from the input range
+ *                and returns its key. The key type must be comparable with operator==.
+ * @tparam ValueType The type of the elements in the input range. Deduced from InputIt.
+ * @tparam KeyType The type of the key returned by getKey. Deduced from GetKey.
+ *
+ * @param first The beginning of the range to group.
+ * @param last The end of the range to group.
+ * @param getKey A function object that extracts a key from an element.
+ *
+ * @return A std::vector of Group<KeyType, ValueType> objects. Each Group object
+ *         contains the common key and a std::vector of items belonging to that group.
+ *         Returns an empty vector if the input range is empty.
+ */
+template <typename InputIt, typename GetKey>
+auto group_by_consecutive(InputIt first, InputIt last, GetKey getKey)
+    -> std::vector<Group<
+           typename std::decay_t<std::invoke_result_t<GetKey, typename std::iterator_traits<InputIt>::value_type>>,
+           typename std::iterator_traits<InputIt>::value_type>> {
+
+    using ValueType = typename std::iterator_traits<InputIt>::value_type;
+    using DeducedKeyType = std::invoke_result_t<GetKey, ValueType>;
+    using KeyType = typename std::decay_t<DeducedKeyType>; // Store key by value
+    using ResultGroupType = Group<KeyType, ValueType>;
+    std::vector<ResultGroupType> result;
+
+    if (first == last) {
         return result;
     }
 
-    KeyType current_key = key_func(*begin);
-    GroupType current_group;
-    current_group.push_back(*begin);
+    // For the first element, we initialize the first group
+    KeyType current_key = getKey(*first);
+    std::vector<ValueType> current_items;
+    current_items.push_back(*first);
 
-    for (Iterator it = std::next(begin); it != end; ++it) {
-        KeyType key = key_func(*it);
-        if (key == current_key) {
-            current_group.push_back(*it);
+    InputIt it = std::next(first);
+    while (it != last) {
+        KeyType next_key = getKey(*it);
+        if (next_key == current_key) {
+            current_items.push_back(*it);
         } else {
-            result.emplace_back(std::move(current_key), std::move(current_group));
-            current_key = std::move(key); // Use std::move for key if it's a movable type
-            current_group.clear();
-            current_group.push_back(*it);
+            // Key changed, finalize the current group and start a new one
+            result.emplace_back(std::move(current_key), std::move(current_items));
+
+            // Reset for the new group
+            current_key = std::move(next_key); // Use the already computed next_key
+            // current_items is already empty due to std::move, but clear() is good for explicit safety if not moved
+            current_items.clear();
+            current_items.push_back(*it);
         }
+        ++it;
     }
-    // Add the last group
-    result.emplace_back(std::move(current_key), std::move(current_group));
+
+    // Add the last processed group
+    // This check ensures that if the input range had elements, the last group is always added.
+    if (!current_items.empty()) {
+        result.emplace_back(std::move(current_key), std::move(current_items));
+    }
 
     return result;
 }
 
-// Container-based wrapper version
-template<typename Container, typename KeyFunc>
-auto group_by_consecutive(const Container& container, KeyFunc key_func)
-    -> decltype(group_by_consecutive(container.begin(), container.end(), key_func))
-{
-    return group_by_consecutive(container.begin(), container.end(), key_func);
+// Overload for a binary predicate
+/**
+ * @brief Groups consecutive elements in a range based on a binary predicate.
+ *
+ * This function iterates through the provided range [first, last) and groups
+ * consecutive elements. A new group is started when the 'are_in_same_group'
+ * predicate returns false for the current element and the previous element.
+ * The "key" of the group will be the first element of that group.
+ *
+ * @tparam InputIt Type of the input iterator. Must meet the requirements of ForwardIterator.
+ * @tparam AreInSameGroup Binary predicate that takes two elements (previous element, current element)
+ *                        and returns true if they belong to the same group.
+ * @tparam ValueType The type of the elements in the input range. Deduced from InputIt.
+ *
+ * @param first The beginning of the range to group.
+ * @param last The end of the range to group.
+ * @param are_in_same_group A binary predicate to determine if the current element
+ *                          should be grouped with the previous one.
+ *
+ * @return A std::vector of Group<ValueType, ValueType> objects. Each Group object
+ *         contains the first element of the group as its key, and a std::vector
+ *         of items belonging to that group.
+ *         Returns an empty vector if the input range is empty.
+ */
+template <typename InputIt, typename AreInSameGroup>
+auto group_by_consecutive_pred(InputIt first, InputIt last, AreInSameGroup are_in_same_group)
+    -> std::vector<Group<
+           typename std::iterator_traits<InputIt>::value_type,
+           typename std::iterator_traits<InputIt>::value_type>> {
+
+    using ValueType = typename std::iterator_traits<InputIt>::value_type;
+    using ResultGroupType = Group<ValueType, ValueType>;
+    std::vector<ResultGroupType> result;
+
+    if (first == last) {
+        return result;
+    }
+
+    // The first element always starts a new group. Its value is used as the key for this group.
+    ValueType current_group_key_representative = *first;
+    std::vector<ValueType> current_items;
+    current_items.push_back(*first);
+
+    InputIt prev_it = first; // Keep track of the previous element for the predicate
+    InputIt it = std::next(first);
+
+    while (it != last) {
+        // The predicate checks if the current element (*it) belongs to the same group as the previous one (*prev_it)
+        if (are_in_same_group(*prev_it, *it)) {
+            current_items.push_back(*it);
+        } else {
+            // Predicate returned false, finalize the current group
+            result.emplace_back(std::move(current_group_key_representative), std::move(current_items));
+
+            // Start a new group with the current element
+            current_group_key_representative = *it; // New group's key is the current element
+            // current_items is already empty due to std::move, but clear() is good for explicit safety
+            current_items.clear();
+            current_items.push_back(*it);
+        }
+        prev_it = it;
+        ++it;
+    }
+
+    // Add the last processed group
+    if (!current_items.empty()) {
+        result.emplace_back(std::move(current_group_key_representative), std::move(current_items));
+    }
+
+    return result;
 }
 
-} // namespace utils
-
-#endif // GROUP_BY_CONSECUTIVE_HPP
+} // namespace cpp_collections

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         VectorWrapperLib     # Added for vector_wrapper_test
         InsertionOrderedMapLib # Added for test_insertion_ordered_map
         LRUDictLib           # Added for test_lru_dict
+        GroupByConsecutiveLib # Added for group_by_consecutive_test
     )
 
     # Specific configurations for certain tests

--- a/tests/group_by_consecutive_test.cpp
+++ b/tests/group_by_consecutive_test.cpp
@@ -1,273 +1,278 @@
 #include "gtest/gtest.h"
-#include "group_by_consecutive.h" // Adjust path as needed by CMake include directories
+#include "group_by_consecutive.h" // The header to test
 #include <vector>
 #include <string>
-#include <utility> // For std::pair
+#include <list> // To test with other iterator types
+#include <cmath> // For std::abs
+#include <ostream> // For custom struct printing in GTest
 
-// Test fixture for common data types or setup if needed later, not strictly necessary for now
+// Helper to compare vectors of groups
+template <typename Key, typename Value>
+void ExpectGroupsEqual(const std::vector<cpp_collections::Group<Key, Value>>& actual,
+                       const std::vector<cpp_collections::Group<Key, Value>>& expected) {
+    ASSERT_EQ(actual.size(), expected.size()) << "Number of groups differ.";
+    for (size_t i = 0; i < actual.size(); ++i) {
+        EXPECT_EQ(actual[i].key, expected[i].key) << "Mismatch in key for group " << i;
+        ASSERT_EQ(actual[i].items.size(), expected[i].items.size()) << "Mismatch in item count for group " << i << " with key " << actual[i].key;
+        for(size_t j = 0; j < actual[i].items.size(); ++j) {
+            EXPECT_EQ(actual[i].items[j], expected[i].items[j]) << "Mismatch in item " << j << " for group " << i << " with key " << actual[i].key;
+        }
+    }
+}
+
+// Test fixture for GroupByConsecutive tests
 class GroupByConsecutiveTest : public ::testing::Test {
 protected:
-    // Per-test set-up logic, if any
-    void SetUp() override {}
+    // Simple struct for testing with objects
+    struct TestObject {
+        int id;
+        std::string category;
+        double value;
 
-    // Per-test tear-down logic, if any
-    void TearDown() override {}
-};
-
-// Test case: Empty input container
-TEST_F(GroupByConsecutiveTest, HandlesEmptyInput) {
-    std::vector<std::pair<char, int>> data = {};
-    auto groups = utils::group_by_consecutive(data, [](const auto& p) { return p.first; });
-    EXPECT_TRUE(groups.empty());
-
-    std::vector<int> numbers = {};
-    auto groups_numbers = utils::group_by_consecutive(numbers, [](int n){ return n; });
-    EXPECT_TRUE(groups_numbers.empty());
-}
-
-// Test case: All items with the same key
-TEST_F(GroupByConsecutiveTest, HandlesAllSameKey) {
-    std::vector<std::pair<char, int>> data = {
-        {'a', 1}, {'a', 2}, {'a', 3}
-    };
-    auto groups = utils::group_by_consecutive(data, [](const auto& p) { return p.first; });
-
-    ASSERT_EQ(groups.size(), 1);
-    EXPECT_EQ(groups[0].first, 'a');
-    ASSERT_EQ(groups[0].second.size(), 3);
-    EXPECT_EQ(groups[0].second[0].second, 1);
-    EXPECT_EQ(groups[0].second[1].second, 2);
-    EXPECT_EQ(groups[0].second[2].second, 3);
-}
-
-// Test case: All items with different keys
-TEST_F(GroupByConsecutiveTest, HandlesAllDifferentKeys) {
-    std::vector<int> numbers = {1, 2, 3, 4, 5};
-    auto groups = utils::group_by_consecutive(numbers.begin(), numbers.end(), [](int n) { return n; });
-
-    ASSERT_EQ(groups.size(), 5);
-    for (size_t i = 0; i < groups.size(); ++i) {
-        EXPECT_EQ(groups[i].first, numbers[i]);
-        ASSERT_EQ(groups[i].second.size(), 1);
-        EXPECT_EQ(groups[i].second[0], numbers[i]);
-    }
-}
-
-// Test case: Mixed alternating patterns (original example)
-TEST_F(GroupByConsecutiveTest, HandlesMixedAlternatingPattern) {
-    std::vector<std::pair<char, int>> data = {
-        {'a', 1}, {'a', 2}, {'b', 3}, {'b', 4}, {'a', 5}
-    };
-    auto groups = utils::group_by_consecutive(data, [](const auto& p) { return p.first; });
-
-    ASSERT_EQ(groups.size(), 3);
-
-    EXPECT_EQ(groups[0].first, 'a');
-    ASSERT_EQ(groups[0].second.size(), 2);
-    EXPECT_EQ(groups[0].second[0].second, 1);
-    EXPECT_EQ(groups[0].second[1].second, 2);
-
-    EXPECT_EQ(groups[1].first, 'b');
-    ASSERT_EQ(groups[1].second.size(), 2);
-    EXPECT_EQ(groups[1].second[0].second, 3);
-    EXPECT_EQ(groups[1].second[1].second, 4);
-
-    EXPECT_EQ(groups[2].first, 'a');
-    ASSERT_EQ(groups[2].second.size(), 1);
-    EXPECT_EQ(groups[2].second[0].second, 5);
-}
-
-// Test case: Custom key function (struct with a member function pointer as key)
-struct MyData {
-    int id;
-    std::string type;
-    double val;
-
-    const std::string& getType() const { return type; }
-};
-
-TEST_F(GroupByConsecutiveTest, HandlesCustomKeyFunctionStructMethod) {
-    std::vector<MyData> items = {
-        {1, "type1", 10.0}, {2, "type1", 12.0},
-        {3, "type2", 20.0},
-        {4, "type1", 15.0}, {5, "type1", 18.0}
-    };
-
-    // Using a lambda to call the member function
-    auto groups = utils::group_by_consecutive(items, [](const MyData& md){ return md.getType(); });
-
-    ASSERT_EQ(groups.size(), 3);
-
-    EXPECT_EQ(groups[0].first, "type1");
-    ASSERT_EQ(groups[0].second.size(), 2);
-    EXPECT_EQ(groups[0].second[0].id, 1);
-    EXPECT_EQ(groups[0].second[1].id, 2);
-
-    EXPECT_EQ(groups[1].first, "type2");
-    ASSERT_EQ(groups[1].second.size(), 1);
-    EXPECT_EQ(groups[1].second[0].id, 3);
-
-    EXPECT_EQ(groups[2].first, "type1");
-    ASSERT_EQ(groups[2].second.size(), 2);
-    EXPECT_EQ(groups[2].second[0].id, 4);
-    EXPECT_EQ(groups[2].second[1].id, 5);
-}
-
-// Test case: Grouping strings by length
-TEST_F(GroupByConsecutiveTest, HandlesGroupingStringsByLength) {
-    std::vector<std::string> words = {"a", "b", "cc", "dd", "eee", "f", "gg"};
-    auto groups = utils::group_by_consecutive(words, [](const std::string& s){ return s.length(); });
-
-    ASSERT_EQ(groups.size(), 5);
-
-    EXPECT_EQ(groups[0].first, 1); // "a", "b"
-    ASSERT_EQ(groups[0].second.size(), 2);
-    EXPECT_EQ(groups[0].second[0], "a");
-    EXPECT_EQ(groups[0].second[1], "b");
-
-    EXPECT_EQ(groups[1].first, 2); // "cc", "dd"
-    ASSERT_EQ(groups[1].second.size(), 2);
-    EXPECT_EQ(groups[1].second[0], "cc");
-    EXPECT_EQ(groups[1].second[1], "dd");
-
-    EXPECT_EQ(groups[2].first, 3); // "eee"
-    ASSERT_EQ(groups[2].second.size(), 1);
-    EXPECT_EQ(groups[2].second[0], "eee");
-
-    EXPECT_EQ(groups[3].first, 1); // "f"
-    ASSERT_EQ(groups[3].second.size(), 1);
-    EXPECT_EQ(groups[3].second[0], "f");
-
-    EXPECT_EQ(groups[4].first, 2); // "gg"
-    ASSERT_EQ(groups[4].second.size(), 1);
-    EXPECT_EQ(groups[4].second[0], "gg");
-}
-
-
-// Test with a stateful key function (using a lambda with captures)
-TEST_F(GroupByConsecutiveTest, StatefulKeyFunction) {
-    std::vector<int> data = {1, 2, 3, 10, 11, 12, 20, 21};
-    // int group_size = 0; // Not needed for this version of the test
-    // int group_id_counter = 0; // Not needed for this version of the test
-
-    auto key_func_decade = [](int item) {
-        return item / 10;
-    };
-
-    auto groups = utils::group_by_consecutive(data, key_func_decade);
-
-    ASSERT_EQ(groups.size(), 3);
-
-    EXPECT_EQ(groups[0].first, 0); // for 1, 2, 3
-    ASSERT_EQ(groups[0].second.size(), 3);
-    EXPECT_EQ(groups[0].second[0], 1);
-    EXPECT_EQ(groups[0].second[1], 2);
-    EXPECT_EQ(groups[0].second[2], 3);
-
-    EXPECT_EQ(groups[1].first, 1); // for 10, 11, 12
-    ASSERT_EQ(groups[1].second.size(), 3);
-    EXPECT_EQ(groups[1].second[0], 10);
-    EXPECT_EQ(groups[1].second[1], 11);
-    EXPECT_EQ(groups[1].second[2], 12);
-
-    EXPECT_EQ(groups[2].first, 2); // for 20, 21
-    ASSERT_EQ(groups[2].second.size(), 2);
-    EXPECT_EQ(groups[2].second[0], 20);
-    EXPECT_EQ(groups[2].second[1], 21);
-}
-
-// Test for container-based overload
-TEST_F(GroupByConsecutiveTest, ContainerOverload) {
-    std::vector<std::pair<char, int>> data = {
-        {'x', 1}, {'x', 2}, {'y', 3}, {'x', 4}
-    };
-    auto groups = utils::group_by_consecutive(data, [](const auto& p) { return p.first; });
-
-    ASSERT_EQ(groups.size(), 3);
-
-    EXPECT_EQ(groups[0].first, 'x');
-    ASSERT_EQ(groups[0].second.size(), 2);
-    EXPECT_EQ(groups[0].second[0].second, 1);
-    EXPECT_EQ(groups[0].second[1].second, 2);
-
-    EXPECT_EQ(groups[1].first, 'y');
-    ASSERT_EQ(groups[1].second.size(), 1);
-    EXPECT_EQ(groups[1].second[0].second, 3);
-
-    EXPECT_EQ(groups[2].first, 'x');
-    ASSERT_EQ(groups[2].second.size(), 1);
-    EXPECT_EQ(groups[2].second[0].second, 4);
-}
-
-
-// It's good practice to also test with iterators explicitly if the container one is just a wrapper
-TEST_F(GroupByConsecutiveTest, IteratorOverloadExplicit) {
-    std::vector<std::pair<char, int>> data = {
-        {'x', 1}, {'x', 2}, {'y', 3}, {'x', 4}
-    };
-    auto groups = utils::group_by_consecutive(data.begin(), data.end(), [](const auto& p) { return p.first; });
-
-    ASSERT_EQ(groups.size(), 3);
-    EXPECT_EQ(groups[0].first, 'x');
-    ASSERT_EQ(groups[0].second.size(), 2);
-    EXPECT_EQ(groups[1].first, 'y');
-    ASSERT_EQ(groups[1].second.size(), 1);
-    EXPECT_EQ(groups[2].first, 'x');
-    ASSERT_EQ(groups[2].second.size(), 1);
-}
-
-// Consider a case where the key function returns a reference
-struct ComplexKey {
-    std::string key_val;
-    bool operator==(const ComplexKey& other) const { return key_val == other.key_val; }
-    ComplexKey(const std::string& kv) : key_val(kv) {}
-    ComplexKey(const ComplexKey& other) : key_val(other.key_val) {}
-    ComplexKey(ComplexKey&& other) noexcept : key_val(std::move(other.key_val)) {}
-    ComplexKey& operator=(const ComplexKey& other) {
-        key_val = other.key_val;
-        return *this;
-    }
-    ComplexKey& operator=(ComplexKey&& other) noexcept {
-        key_val = std::move(other.key_val);
-        return *this;
-    }
-};
-
-std::ostream& operator<<(std::ostream& os, const ComplexKey& ck) {
-    return os << ck.key_val;
-}
-
-namespace std {
-    template <> struct hash<ComplexKey> {
-        std::size_t operator()(const ComplexKey& ck) const {
-            return std::hash<std::string>()(ck.key_val);
+        bool operator==(const TestObject& other) const {
+            return id == other.id && category == other.category && value == other.value;
+        }
+        // For GTest printing
+        friend std::ostream& operator<<(std::ostream& os, const TestObject& obj) {
+            return os << "{id:" << obj.id << ", cat:" << obj.category << ", val:" << obj.value << "}";
         }
     };
-}
 
-TEST_F(GroupByConsecutiveTest, KeyFunctionReturnsReference) {
-    std::vector<std::pair<ComplexKey, int>> data = {
-        {ComplexKey("key1"), 1}, {ComplexKey("key1"), 2}, {ComplexKey("key2"), 3}
+    // Key extractor for TestObject's category
+    struct CategoryExtractor {
+        const std::string& operator()(const TestObject& obj) const {
+            return obj.category;
+        }
     };
 
-    auto groups = utils::group_by_consecutive(data, [](const std::pair<ComplexKey, int>& p){
-        return p.first;
-    });
+    // Predicate for TestObject's value proximity
+    // True if o2 is "close" to o1 (previous element)
+    struct ValueProximityPredicate {
+        bool operator()(const TestObject& o1_prev, const TestObject& o2_curr) const {
+            return std::abs(o1_prev.value - o2_curr.value) < 0.5;
+        }
+    };
+};
 
-    ASSERT_EQ(groups.size(), 2);
-    EXPECT_EQ(groups[0].first.key_val, "key1");
-    ASSERT_EQ(groups[0].second.size(), 2);
-    EXPECT_EQ(groups[0].second[0].second, 1);
-    EXPECT_EQ(groups[0].second[1].second, 2);
+// --- Tests for group_by_consecutive (Key Function Version) ---
 
-    EXPECT_EQ(groups[1].first.key_val, "key2");
-    ASSERT_EQ(groups[1].second.size(), 1);
-    EXPECT_EQ(groups[1].second[0].second, 3);
+TEST_F(GroupByConsecutiveTest, KeyFunc_EmptyRange) {
+    std::vector<int> input = {};
+    auto getKey = [](int x){ return x; };
+    auto result = cpp_collections::group_by_consecutive(input.begin(), input.end(), getKey);
+    std::vector<cpp_collections::Group<int, int>> expected = {};
+    ExpectGroupsEqual(result, expected);
 }
 
-// main function is not needed here, as GTest::gtest_main is linked,
-// both for the aggregate 'run_tests' target and individual test executables.
-// int main(int argc, char **argv) {
-//     ::testing::InitGoogleTest(&argc, argv);
-//     return RUN_ALL_TESTS();
-// }
+TEST_F(GroupByConsecutiveTest, KeyFunc_AllUniqueElements) {
+    std::vector<int> input = {1, 2, 3, 4, 5};
+    auto getKey = [](int x){ return x; };
+    auto result = cpp_collections::group_by_consecutive(input.begin(), input.end(), getKey);
+    std::vector<cpp_collections::Group<int, int>> expected = {
+        {1, {1}}, {2, {2}}, {3, {3}}, {4, {4}}, {5, {5}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, KeyFunc_AllSameElements) {
+    std::vector<int> input = {7, 7, 7, 7};
+    auto getKey = [](int x){ return x; };
+    auto result = cpp_collections::group_by_consecutive(input.begin(), input.end(), getKey);
+    std::vector<cpp_collections::Group<int, int>> expected = {
+        {7, {7, 7, 7, 7}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, KeyFunc_MixedGroupsIntegers) {
+    std::vector<int> input = {1, 1, 2, 2, 2, 1, 3, 3, 2};
+    auto getKey = [](int x){ return x; };
+    auto result = cpp_collections::group_by_consecutive(input.begin(), input.end(), getKey);
+    std::vector<cpp_collections::Group<int, int>> expected = {
+        {1, {1, 1}},
+        {2, {2, 2, 2}},
+        {1, {1}},
+        {3, {3, 3}},
+        {2, {2}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, KeyFunc_StringsByFirstChar) {
+    std::vector<std::string> input = {"apple", "apricot", "banana", "blue", "berry", "cherry"};
+    auto getKey = [](const std::string& s){ return s.empty() ? ' ' : s[0]; };
+    auto result = cpp_collections::group_by_consecutive(input.begin(), input.end(), getKey);
+    std::vector<cpp_collections::Group<char, std::string>> expected = {
+        {'a', {"apple", "apricot"}},
+        {'b', {"banana", "blue", "berry"}},
+        {'c', {"cherry"}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, KeyFunc_CustomObjectsByCategory) {
+    std::vector<TestObject> input = {
+        {1, "A", 1.0}, {2, "A", 1.1}, {3, "B", 2.0}, {4, "A", 1.2}
+    };
+    auto result = cpp_collections::group_by_consecutive(input.begin(), input.end(), CategoryExtractor());
+    std::vector<cpp_collections::Group<std::string, TestObject>> expected = {
+        {"A", {{1, "A", 1.0}, {2, "A", 1.1}}},
+        {"B", {{3, "B", 2.0}}},
+        {"A", {{4, "A", 1.2}}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, KeyFunc_ListIterators) {
+    std::list<int> input = {1, 1, 2, 3, 3, 3};
+    auto getKey = [](int x){ return x; };
+    auto result = cpp_collections::group_by_consecutive(input.begin(), input.end(), getKey);
+    std::vector<cpp_collections::Group<int, int>> expected = {
+        {1, {1, 1}},
+        {2, {2}},
+        {3, {3, 3, 3}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, KeyFunc_SingleElementRange) {
+    std::vector<std::string> input = {"hello"};
+    auto getKey = [](const std::string& s){ return s.length(); };
+    auto result = cpp_collections::group_by_consecutive(input.begin(), input.end(), getKey);
+    std::vector<cpp_collections::Group<size_t, std::string>> expected = {
+        {5, {"hello"}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+// --- Tests for group_by_consecutive_pred (Predicate Version) ---
+
+TEST_F(GroupByConsecutiveTest, Pred_EmptyRange) {
+    std::vector<int> input = {};
+    auto pred = [](int, int){ return false; }; // Predicate won't be called
+    auto result = cpp_collections::group_by_consecutive_pred(input.begin(), input.end(), pred);
+    std::vector<cpp_collections::Group<int, int>> expected = {};
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, Pred_AllUniqueGroups) {
+    std::vector<int> input = {1, 3, 5, 7}; // Difference is always 2
+    auto pred = [](int prev, int curr){ return std::abs(curr - prev) <= 1; };
+    auto result = cpp_collections::group_by_consecutive_pred(input.begin(), input.end(), pred);
+    std::vector<cpp_collections::Group<int, int>> expected = {
+        {1, {1}}, {3, {3}}, {5, {5}}, {7, {7}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, Pred_AllInOneGroup) {
+    std::vector<int> input = {2, 2, 2, 2};
+    auto pred = [](int prev, int curr){ return prev == curr; };
+    auto result = cpp_collections::group_by_consecutive_pred(input.begin(), input.end(), pred);
+    std::vector<cpp_collections::Group<int, int>> expected = {
+        {2, {2, 2, 2, 2}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, Pred_MixedGroupsIntegers_Sequential) {
+    std::vector<int> input = {1, 2, 3, 5, 6, 8, 9, 10, 12};
+    auto pred = [](int prev, int curr){ return curr == prev + 1; };
+    auto result = cpp_collections::group_by_consecutive_pred(input.begin(), input.end(), pred);
+    std::vector<cpp_collections::Group<int, int>> expected = {
+        {1, {1, 2, 3}},
+        {5, {5, 6}},
+        {8, {8, 9, 10}},
+        {12, {12}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, Pred_StringsSameLength) {
+    std::vector<std::string> input = {"a", "b", "cat", "dog", "Sun", "moon", "stars", "x", "y"};
+    auto pred = [](const std::string& s1, const std::string& s2){ return s1.length() == s2.length(); };
+    auto result = cpp_collections::group_by_consecutive_pred(input.begin(), input.end(), pred);
+    std::vector<cpp_collections::Group<std::string, std::string>> expected = {
+        {"a", {"a", "b"}},
+        {"cat", {"cat", "dog", "Sun"}},
+        {"moon", {"moon"}},
+        {"stars", {"stars"}},
+        {"x", {"x", "y"}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, Pred_CustomObjectsByValueProximity) {
+    // Predicate logic: are_in_same_group(previous_element, current_element)
+    // Group key for predicate version is the *first* element of that group.
+    std::vector<TestObject> input = {
+        {1, "V", 10.1}, {2, "V", 10.3}, // Group1: Key {1,V,10.1}. Item {2} vs {1} -> abs(10.1-10.3)=0.2 (<0.5) -> same group.
+        {3, "V", 10.8},                // Item {3} vs {2} -> abs(10.3-10.8)=0.5 (not <0.5) -> new group. Group2: Key {3,V,10.8}
+        {4, "W", 20.0}, {5, "W", 20.4}, {6, "X", 20.7}, // Item {4} vs {3} -> new group. Group3: Key {4,W,20.0}
+                                       // Item {5} vs {4} -> abs(20.0-20.4)=0.4 (<0.5) -> same group.
+                                       // Item {6} vs {5} -> abs(20.4-20.7)=0.3 (<0.5) -> same group.
+        {7, "Y", 30.0}                 // Item {7} vs {6} -> new group. Group4: Key {7,Y,30.0}
+    };
+
+    auto result = cpp_collections::group_by_consecutive_pred(input.begin(), input.end(), ValueProximityPredicate());
+    std::vector<cpp_collections::Group<TestObject, TestObject>> expected = {
+        {{1, "V", 10.1}, {{1, "V", 10.1}, {2, "V", 10.3}}},
+        {{3, "V", 10.8}, {{3, "V", 10.8}}},
+        {{4, "W", 20.0}, {{4, "W", 20.0}, {5, "W", 20.4}, {6, "X", 20.7}}},
+        {{7, "Y", 30.0}, {{7, "Y", 30.0}}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, Pred_ListIterators) {
+    std::list<int> input = {1, 2, 4, 5, 6, 8};
+    auto pred = [](int prev, int curr){ return std::abs(curr - prev) <= 1; }; // Group if consecutive or same
+    auto result = cpp_collections::group_by_consecutive_pred(input.begin(), input.end(), pred);
+    std::vector<cpp_collections::Group<int, int>> expected = {
+        {1, {1, 2}},
+        {4, {4, 5, 6}},
+        {8, {8}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, Pred_SingleElementRange) {
+    std::vector<int> input = {42};
+    auto pred = [](int, int) -> bool {
+        ADD_FAILURE() << "Predicate should not be called for single element range";
+        return false; // Return a value; ADD_FAILURE records a non-fatal failure.
+    };
+    auto result = cpp_collections::group_by_consecutive_pred(input.begin(), input.end(), pred);
+    std::vector<cpp_collections::Group<int, int>> expected = {
+        {42, {42}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, Pred_AllElementsGroupTogether) {
+    std::vector<TestObject> input = {
+        {1, "A", 1.0}, {2, "B", 1.1}, {3, "C", 1.2}, {4, "D", 1.3}
+    };
+    // Predicate always returns true, so all elements should be in one group
+    auto pred_always_true = [](const TestObject&, const TestObject&){ return true; };
+    auto result = cpp_collections::group_by_consecutive_pred(input.begin(), input.end(), pred_always_true);
+    std::vector<cpp_collections::Group<TestObject, TestObject>> expected = {
+        {{1, "A", 1.0}, {{1, "A", 1.0}, {2, "B", 1.1}, {3, "C", 1.2}, {4, "D", 1.3}}}
+    };
+    ExpectGroupsEqual(result, expected);
+}
+
+TEST_F(GroupByConsecutiveTest, Pred_NoElementsGroupTogether) {
+    std::vector<TestObject> input = {
+        {1, "A", 1.0}, {2, "B", 2.0}, {3, "C", 3.0}
+    };
+    // Predicate always returns false, so each element is its own group
+    auto pred_always_false = [](const TestObject&, const TestObject&){ return false; };
+    auto result = cpp_collections::group_by_consecutive_pred(input.begin(), input.end(), pred_always_false);
+    std::vector<cpp_collections::Group<TestObject, TestObject>> expected = {
+        {{1, "A", 1.0}, {{1, "A", 1.0}}},
+        {{2, "B", 2.0}, {{2, "B", 2.0}}},
+        {{3, "C", 3.0}, {{3, "C", 3.0}}}
+    };
+    ExpectGroupsEqual(result, expected);
+}


### PR DESCRIPTION
This commit introduces a new header-only utility `group_by_consecutive.h` in the `cpp_collections` namespace.

Features:
- Groups consecutive elements in a range based on a key or predicate.
- `group_by_consecutive(iter_first, iter_last, key_func)`: Groups elements sharing the same key returned by `key_func`.
- `group_by_consecutive_pred(iter_first, iter_last, predicate_func)`: Groups elements if `predicate_func(prev_elem, curr_elem)` is true.
- Returns a `std::vector<cpp_collections::Group<Key, Value>>`, where `Group` holds the key and a vector of items.

Includes:
- Implementation in `include/group_by_consecutive.h`
- Usage examples in `examples/group_by_consecutive_example.cpp`
- Unit tests in `tests/group_by_consecutive_test.cpp`
- Documentation in `docs/README_group_by_consecutive.md`
- Updates to CMakeLists.txt for integration.
- Update to main README.md.