### PR TITLE
feat: Add BitQueue data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,10 @@ target_include_directories(LRUDictLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/incl
 add_library(GroupByConsecutiveLib INTERFACE)
 target_include_directories(GroupByConsecutiveLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define BitQueueLib as an interface library (header-only)
+add_library(BitQueueLib INTERFACE)
+target_include_directories(BitQueueLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -416,6 +420,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         InsertionOrderedMapLib # Added for insertion_ordered_map_example
         LRUDictLib           # Added for lru_dict_example
         GroupByConsecutiveLib # Added for group_by_consecutive_example
+        BitQueueLib          # Added for bit_queue_example
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This includes:
 *   **Iterator and Algorithm Utilities:** `any_all.h` ([AnyAll](docs/README_any_all.md)), `group_by_consecutive.h` ([GroupByConsecutive](docs/README_group_by_consecutive.md)), `lazy_sorted_merger.h`, `peekable.h`, `split_view.h`, `zip_view.h`.
 *   **JSON Utilities:** `json_fieldmask.h`, `jsonpatch.h`.
 *   **String Utilities:** `cord.h` ([Cord](docs/README_Cord.md)), `duration_parser.h`, `interning_pool.h`, `parse_utils.h`, `random_string.h`, `string_interner.h`, `string_utils.h`.
-*   **Miscellaneous Utilities:** `batcher.h` ([Batcher](docs/README_batcher.md)), `id_pool.h`, `interval_counter.h`, `optional_utilities.h`, `pretty_print.h`, `safe_numerics.h`, `signal_handler.h`, `simple_moving_average.h`, `singleton.h`, `sliding_window_minmax.h`, `sliding_window.h`, `type_safe_id.h`, `undo.h`, `varint.h`, `version.h`, `WeightedRandomList.h`, `weighted_round_robin.h`.
+*   **Miscellaneous Utilities:** `batcher.h` ([Batcher](docs/README_batcher.md)), `bit_queue.h` ([BitQueue](docs/README_bit_queue.md)), `id_pool.h`, `interval_counter.h`, `optional_utilities.h`, `pretty_print.h`, `safe_numerics.h`, `signal_handler.h`, `simple_moving_average.h`, `singleton.h`, `sliding_window_minmax.h`, `sliding_window.h`, `type_safe_id.h`, `undo.h`, `varint.h`, `version.h`, `WeightedRandomList.h`, `weighted_round_robin.h`.
 
 ## Documentation
 

--- a/docs/README_bit_queue.md
+++ b/docs/README_bit_queue.md
@@ -1,0 +1,93 @@
+# BitQueue
+
+## Overview
+
+`BitQueue` is a C++ data structure that provides a queue for individual bits. It's useful for applications that require bit-level manipulation, such as custom serialization formats, network protocols, or compression algorithms.
+
+`BitQueue` is a header-only library, so you can simply include `bit_queue.h` in your project.
+
+## Features
+
+- Enqueue and dequeue single bits.
+- Enqueue and dequeue sequences of bits up to 64 bits at a time.
+- Peek at the next bit without removing it.
+- Check the number of bits in the queue.
+- Clear the queue.
+
+## Usage
+
+Here's a simple example of how to use `BitQueue`:
+
+```cpp
+#include "bit_queue.h"
+#include <iostream>
+
+int main() {
+    cpp_utils::BitQueue bq;
+
+    // Enqueue some bits
+    bq.push(true);
+    bq.push(false);
+    bq.push(true);
+    bq.push(true);
+
+    std::cout << "Initial size: " << bq.size() << std::endl;
+
+    // Dequeue and print the bits
+    std::cout << "Bits: ";
+    while (!bq.empty()) {
+        std::cout << bq.pop() << " ";
+    }
+    std::cout << std::endl;
+    std::cout << "Final size: " << bq.size() << std::endl;
+
+    // Enqueue a 10-bit value
+    bq.push(0x2A, 10); // 0b0000101010
+    std::cout << "\nEnqueued 10 bits (0x2A). Size: " << bq.size() << std::endl;
+
+    // Dequeue the 10-bit value
+    uint64_t val = bq.pop(10);
+    std::cout << "Dequeued 10 bits: " << std::hex << "0x" << val << std::dec << std::endl;
+    std::cout << "Final size: " << bq.size() << std::endl;
+
+    return 0;
+}
+```
+
+## API Reference
+
+### `BitQueue()`
+
+Default constructor.
+
+### `void push(bool bit)`
+
+Enqueues a single bit.
+
+### `void push(uint64_t value, uint8_t count)`
+
+Enqueues the `count` least significant bits from `value`.
+
+### `bool pop()`
+
+Dequeues and returns a single bit. Throws `std::out_of_range` if the queue is empty.
+
+### `uint64_t pop(uint8_t count)`
+
+Dequeues `count` bits and returns them as a `uint64_t`. Throws `std::out_of_range` if there are not enough bits in the queue.
+
+### `bool front() const`
+
+Returns the next bit in the queue without removing it. Throws `std::out_of_range` if the queue is empty.
+
+### `size_t size() const`
+
+Returns the number of bits in the queue.
+
+### `bool empty() const`
+
+Returns `true` if the queue is empty, `false` otherwise.
+
+### `void clear()`
+
+Removes all bits from the queue.

--- a/examples/bit_queue_example.cpp
+++ b/examples/bit_queue_example.cpp
@@ -1,0 +1,33 @@
+#include "bit_queue.h"
+#include <iostream>
+
+int main() {
+    cpp_utils::BitQueue bq;
+
+    // Enqueue some bits
+    bq.push(true);
+    bq.push(false);
+    bq.push(true);
+    bq.push(true);
+
+    std::cout << "Initial size: " << bq.size() << std::endl;
+
+    // Dequeue and print the bits
+    std::cout << "Bits: ";
+    while (!bq.empty()) {
+        std::cout << bq.pop() << " ";
+    }
+    std::cout << std::endl;
+    std::cout << "Final size: " << bq.size() << std::endl;
+
+    // Enqueue a 10-bit value
+    bq.push(0x2A, 10); // 0b0000101010
+    std::cout << "\nEnqueued 10 bits (0x2A). Size: " << bq.size() << std::endl;
+
+    // Dequeue the 10-bit value
+    uint64_t val = bq.pop(10);
+    std::cout << "Dequeued 10 bits: " << std::hex << "0x" << val << std::dec << std::endl;
+    std::cout << "Final size: " << bq.size() << std::endl;
+
+    return 0;
+}

--- a/include/bit_queue.h
+++ b/include/bit_queue.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <deque>
+#include <vector>
+#include <cstdint>
+#include <stdexcept>
+
+namespace cpp_utils {
+
+class BitQueue {
+public:
+    BitQueue() : num_bits_(0) {}
+
+    // Enqueue a single bit
+    void push(bool bit) {
+        if (num_bits_ % 8 == 0) {
+            buffer_.push_back(0);
+        }
+        if (bit) {
+            buffer_.back() |= (1 << (7 - (num_bits_ % 8)));
+        }
+        num_bits_++;
+    }
+
+    // Enqueue a sequence of bits from a uint64_t value
+    void push(uint64_t value, uint8_t count) {
+        if (count > 64) {
+            throw std::invalid_argument("Count cannot be greater than 64.");
+        }
+        for (int i = count - 1; i >= 0; --i) {
+            push((value >> i) & 1);
+        }
+    }
+
+    // Dequeue a single bit
+    bool pop() {
+        if (empty()) {
+            throw std::out_of_range("BitQueue is empty.");
+        }
+        uint8_t byte = buffer_.front();
+        bool bit = (byte >> (7 - (write_pos_ % 8))) & 1;
+        num_bits_--;
+        write_pos_++;
+        if (write_pos_ % 8 == 0) {
+            buffer_.pop_front();
+        }
+        return bit;
+    }
+
+    // Dequeue a sequence of bits into a uint64_t value
+    uint64_t pop(uint8_t count) {
+        if (count > 64) {
+            throw std::invalid_argument("Count cannot be greater than 64.");
+        }
+        if (size() < count) {
+            throw std::out_of_range("Not enough bits in BitQueue.");
+        }
+        uint64_t value = 0;
+        for (int i = 0; i < count; ++i) {
+            value = (value << 1) | pop();
+        }
+        return value;
+    }
+
+    // Peek at the next bit without dequeuing it
+    bool front() const {
+        if (empty()) {
+            throw std::out_of_range("BitQueue is empty.");
+        }
+        uint8_t byte = buffer_.front();
+        return (byte >> (7 - (write_pos_ % 8))) & 1;
+    }
+
+    // Returns the number of bits in the queue
+    size_t size() const {
+        return num_bits_;
+    }
+
+    // Checks if the queue is empty
+    bool empty() const {
+        return num_bits_ == 0;
+    }
+
+    // Clears the queue
+    void clear() {
+        buffer_.clear();
+        num_bits_ = 0;
+        write_pos_ = 0;
+    }
+
+private:
+    std::deque<uint8_t> buffer_;
+    size_t num_bits_;
+    size_t write_pos_ = 0;
+};
+
+} // namespace cpp_utils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,6 +112,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         InsertionOrderedMapLib # Added for test_insertion_ordered_map
         LRUDictLib           # Added for test_lru_dict
         GroupByConsecutiveLib # Added for group_by_consecutive_test
+        BitQueueLib          # Added for bit_queue_test
     )
 
     # Specific configurations for certain tests

--- a/tests/bit_queue_test.cpp
+++ b/tests/bit_queue_test.cpp
@@ -1,0 +1,91 @@
+#include "gtest/gtest.h"
+#include "bit_queue.h"
+
+TEST(BitQueueTest, PushAndPopSingleBits) {
+    cpp_utils::BitQueue bq;
+    bq.push(true);
+    bq.push(false);
+    bq.push(true);
+    EXPECT_EQ(bq.size(), 3);
+    EXPECT_EQ(bq.pop(), true);
+    EXPECT_EQ(bq.pop(), false);
+    EXPECT_EQ(bq.pop(), true);
+    EXPECT_TRUE(bq.empty());
+}
+
+TEST(BitQueueTest, PushAndPopMultiBitValues) {
+    cpp_utils::BitQueue bq;
+    bq.push(0b1011, 4);
+    bq.push(0b01, 2);
+    EXPECT_EQ(bq.size(), 6);
+    EXPECT_EQ(bq.pop(4), 0b1011);
+    EXPECT_EQ(bq.pop(2), 0b01);
+    EXPECT_TRUE(bq.empty());
+}
+
+TEST(BitQueueTest, MixedPushAndPop) {
+    cpp_utils::BitQueue bq;
+    bq.push(true);
+    bq.push(0b101, 3);
+    bq.push(false);
+    EXPECT_EQ(bq.size(), 5);
+    EXPECT_EQ(bq.pop(), true);
+    EXPECT_EQ(bq.pop(3), 0b101);
+    EXPECT_EQ(bq.pop(), false);
+    EXPECT_TRUE(bq.empty());
+}
+
+TEST(BitQueueTest, PopEmpty) {
+    cpp_utils::BitQueue bq;
+    EXPECT_THROW(bq.pop(), std::out_of_range);
+}
+
+TEST(BitQueueTest, PopTooManyBits) {
+    cpp_utils::BitQueue bq;
+    bq.push(0b101, 3);
+    EXPECT_THROW(bq.pop(4), std::out_of_range);
+}
+
+TEST(BitQueueTest, Front) {
+    cpp_utils::BitQueue bq;
+    bq.push(true);
+    bq.push(false);
+    EXPECT_EQ(bq.front(), true);
+    bq.pop();
+    EXPECT_EQ(bq.front(), false);
+}
+
+TEST(BitQueueTest, FrontEmpty) {
+    cpp_utils::BitQueue bq;
+    EXPECT_THROW(bq.front(), std::out_of_range);
+}
+
+TEST(BitQueueTest, Clear) {
+    cpp_utils::BitQueue bq;
+    bq.push(0b101, 3);
+    bq.clear();
+    EXPECT_TRUE(bq.empty());
+    EXPECT_EQ(bq.size(), 0);
+}
+
+TEST(BitQueueTest, LargeNumberOfBits) {
+    cpp_utils::BitQueue bq;
+    for (int i = 0; i < 1000; ++i) {
+        bq.push(i % 2);
+    }
+    EXPECT_EQ(bq.size(), 1000);
+    for (int i = 0; i < 1000; ++i) {
+        EXPECT_EQ(bq.pop(), i % 2);
+    }
+    EXPECT_TRUE(bq.empty());
+}
+
+TEST(BitQueueTest, PushMoreThan64Bits) {
+    cpp_utils::BitQueue bq;
+    EXPECT_THROW(bq.push(0, 65), std::invalid_argument);
+}
+
+TEST(BitQueueTest, PopMoreThan64Bits) {
+    cpp_utils::BitQueue bq;
+    EXPECT_THROW(bq.pop(65), std::invalid_argument);
+}


### PR DESCRIPTION
This commit introduces a new `BitQueue` data structure, which is a queue for individual bits. It is useful for applications that require bit-level manipulation, such as custom serialization formats, network protocols, or compression algorithms.

The commit includes:
- The `BitQueue` implementation in `include/bit_queue.h`
- A usage example in `examples/bit_queue_example.cpp`
- Unit tests in `tests/bit_queue_test.cpp`
- Updates to the `CMakeLists.txt` files to include the new files
- Documentation in `docs/README_bit_queue.md`