### PR TITLE
feat: Implement intrusive list data structure

### DIFF
--- a/docs/README_intrusive_list.md
+++ b/docs/README_intrusive_list.md
@@ -1,0 +1,58 @@
+# Intrusive List
+
+An intrusive list is a doubly linked list where the nodes are not allocated by the list itself. Instead, the user embeds a `intrusive_list_hook` within their own data structures. This approach avoids memory allocation overhead when adding or removing elements from the list, which can lead to significant performance improvements in scenarios with frequent modifications.
+
+## Usage
+
+To use the intrusive list, you need to embed an `intrusive_list_hook` in your struct or class:
+
+```cpp
+#include "intrusive_list.h"
+
+struct MyObject {
+    int data;
+    cpp_utils::intrusive_list_hook hook;
+
+    MyObject(int d) : data(d) {}
+};
+```
+
+Then, you can create an `intrusive_list` and specify the type of the object and the member hook:
+
+```cpp
+cpp_utils::intrusive_list<MyObject, &MyObject::hook> list;
+```
+
+Now you can use the list like a standard container:
+
+```cpp
+MyObject obj1(1);
+MyObject obj2(2);
+
+list.push_back(obj1);
+list.push_front(obj2);
+
+for (const auto& obj : list) {
+    // ...
+}
+```
+
+## API
+
+The `intrusive_list` class provides the following methods:
+
+- `push_back(T& value)`: Adds an element to the end of the list.
+- `push_front(T& value)`: Adds an element to the beginning of the list.
+- `pop_back()`: Removes the last element of the list.
+- `pop_front()`: Removes the first element of the list.
+- `empty() const`: Checks if the list is empty.
+- `size() const`: Returns the number of elements in the list.
+- `begin()`, `end()`, `cbegin()`, `cend()`: Provide iterators to the list.
+- `front()`, `back()`: Access the first and last elements.
+- `insert(iterator pos, T& value)`: Inserts an element at a specific position.
+- `erase(iterator pos)`: Removes an element at a specific position.
+- `clear()`: Removes all elements from the list.
+
+The `intrusive_list_hook` class provides the following method:
+
+- `is_linked() const`: Checks if the hook is part of a list.

--- a/examples/intrusive_list_example.cpp
+++ b/examples/intrusive_list_example.cpp
@@ -1,0 +1,40 @@
+#include "intrusive_list.h"
+#include <iostream>
+
+struct MyObject {
+    int data;
+    cpp_utils::intrusive_list_hook hook;
+
+    MyObject(int d) : data(d) {}
+};
+
+int main() {
+    MyObject obj1(1);
+    MyObject obj2(2);
+    MyObject obj3(3);
+
+    cpp_utils::intrusive_list<MyObject, &MyObject::hook> list;
+
+    list.push_back(obj1);
+    list.push_back(obj2);
+    list.push_front(obj3);
+
+    std::cout << "List size: " << list.size() << std::endl;
+
+    std::cout << "List contents:";
+    for (const auto& obj : list) {
+        std::cout << " " << obj.data;
+    }
+    std::cout << std::endl;
+
+    list.pop_front();
+    list.pop_back();
+
+    std::cout << "List contents after popping:";
+    for (const auto& obj : list) {
+        std::cout << " " << obj.data;
+    }
+    std::cout << std::endl;
+
+    return 0;
+}

--- a/include/intrusive_list.h
+++ b/include/intrusive_list.h
@@ -1,0 +1,232 @@
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+
+namespace cpp_utils {
+
+class intrusive_list_hook {
+public:
+    intrusive_list_hook() : prev_(this), next_(this) {}
+
+    bool is_linked() const { return next_ != this; }
+
+private:
+    template <typename T, intrusive_list_hook T::*Hook>
+    friend class intrusive_list;
+
+    intrusive_list_hook* prev_;
+    intrusive_list_hook* next_;
+};
+
+template <typename T, intrusive_list_hook T::*Hook>
+class intrusive_list {
+    using hook_ptr = intrusive_list_hook*;
+    using const_hook_ptr = const intrusive_list_hook*;
+
+    static T* to_value(hook_ptr hook) {
+        return (T*)((char*)hook - ((char*)&(((T*)0)->*Hook) - (char*)0));
+    }
+
+    static const T* to_value(const_hook_ptr hook) {
+        return (const T*)((const char*)hook - ((const char*)&(((const T*)0)->*Hook) - (const char*)0));
+    }
+
+public:
+    class iterator {
+    public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = T;
+        using difference_type = std::ptrdiff_t;
+        using pointer = T*;
+        using reference = T&;
+
+        iterator(hook_ptr hook) : hook_(hook) {}
+
+        reference operator*() const { return *to_value(hook_); }
+        pointer operator->() const { return to_value(hook_); }
+
+        iterator& operator++() {
+            hook_ = hook_->next_;
+            return *this;
+        }
+
+        iterator operator++(int) {
+            iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        iterator& operator--() {
+            hook_ = hook_->prev_;
+            return *this;
+        }
+
+        iterator operator--(int) {
+            iterator tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        bool operator==(const iterator& other) const { return hook_ == other.hook_; }
+        bool operator!=(const iterator& other) const { return hook_ != other.hook_; }
+
+    private:
+        friend class intrusive_list;
+        hook_ptr hook_;
+    };
+
+    class const_iterator {
+    public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = const T;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const T*;
+        using reference = const T&;
+
+        const_iterator(const_hook_ptr hook) : hook_(hook) {}
+
+        reference operator*() const { return *to_value(hook_); }
+        pointer operator->() const { return to_value(hook_); }
+
+        const_iterator& operator++() {
+            hook_ = hook_->next_;
+            return *this;
+        }
+
+        const_iterator operator++(int) {
+            const_iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        const_iterator& operator--() {
+            hook_ = hook_->prev_;
+            return *this;
+        }
+
+        const_iterator operator--(int) {
+            const_iterator tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        bool operator==(const const_iterator& other) const { return hook_ == other.hook_; }
+        bool operator!=(const const_iterator& other) const { return hook_ != other.hook_; }
+
+    private:
+        friend class intrusive_list;
+        const_hook_ptr hook_;
+    };
+
+    intrusive_list() : head_() {}
+
+    ~intrusive_list() { clear(); }
+
+    intrusive_list(const intrusive_list&) = delete;
+    intrusive_list& operator=(const intrusive_list&) = delete;
+
+    intrusive_list(intrusive_list&& other) noexcept : head_() {
+        if (!other.empty()) {
+            head_.next_ = other.head_.next_;
+            head_.prev_ = other.head_.prev_;
+            other.head_.next_->prev_ = &head_;
+            other.head_.prev_->next_ = &head_;
+            other.head_.next_ = &other.head_;
+            other.head_.prev_ = &other.head_;
+        }
+    }
+
+    intrusive_list& operator=(intrusive_list&& other) noexcept {
+        if (this != &other) {
+            clear();
+            if (!other.empty()) {
+                head_.next_ = other.head_.next_;
+                head_.prev_ = other.head_.prev_;
+                other.head_.next_->prev_ = &head_;
+                other.head_.prev_->next_ = &head_;
+                other.head_.next_ = &other.head_;
+                other.head_.prev_ = &other.head_;
+            }
+        }
+        return *this;
+    }
+
+    iterator begin() { return iterator(head_.next_); }
+    const_iterator begin() const { return const_iterator(head_.next_); }
+    const_iterator cbegin() const { return const_iterator(head_.next_); }
+
+    iterator end() { return iterator(&head_); }
+    const_iterator end() const { return const_iterator(&head_); }
+    const_iterator cend() const { return const_iterator(&head_); }
+
+    T& front() { return *to_value(head_.next_); }
+    const T& front() const { return *to_value(head_.next_); }
+
+    T& back() { return *to_value(head_.prev_); }
+    const T& back() const { return *to_value(head_.prev_); }
+
+    bool empty() const { return head_.next_ == &head_; }
+
+    size_t size() const {
+        size_t count = 0;
+        for (auto it = cbegin(); it != cend(); ++it) {
+            ++count;
+        }
+        return count;
+    }
+
+    void push_front(T& value) {
+        insert(begin(), value);
+    }
+
+    void push_back(T& value) {
+        insert(end(), value);
+    }
+
+    void pop_front() {
+        erase(begin());
+    }
+
+    void pop_back() {
+        erase(--end());
+    }
+
+    iterator insert(iterator pos, T& value) {
+        hook_ptr hook = &(value.*Hook);
+        hook_ptr next = pos.hook_;
+        hook_ptr prev = next->prev_;
+
+        hook->prev_ = prev;
+        hook->next_ = next;
+        prev->next_ = hook;
+        next->prev_ = hook;
+
+        return iterator(hook);
+    }
+
+    iterator erase(iterator pos) {
+        hook_ptr hook = pos.hook_;
+        hook_ptr next = hook->next_;
+        hook_ptr prev = hook->prev_;
+
+        prev->next_ = next;
+        next->prev_ = prev;
+
+        hook->prev_ = hook;
+        hook->next_ = hook;
+
+        return iterator(next);
+    }
+
+    void clear() {
+        while (!empty()) {
+            pop_front();
+        }
+    }
+
+private:
+    intrusive_list_hook head_;
+};
+
+} // namespace cpp_utils

--- a/tests/intrusive_list_test.cpp
+++ b/tests/intrusive_list_test.cpp
@@ -1,0 +1,147 @@
+#include "intrusive_list.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+struct TestObject {
+    int value;
+    cpp_utils::intrusive_list_hook hook;
+
+    TestObject(int v) : value(v) {}
+};
+
+using TestList = cpp_utils::intrusive_list<TestObject, &TestObject::hook>;
+
+TEST(IntrusiveListTest, InitialState) {
+    TestList list;
+    EXPECT_TRUE(list.empty());
+    EXPECT_EQ(0, list.size());
+}
+
+TEST(IntrusiveListTest, PushBack) {
+    TestList list;
+    TestObject obj1(10);
+    TestObject obj2(20);
+
+    list.push_back(obj1);
+    EXPECT_FALSE(list.empty());
+    EXPECT_EQ(1, list.size());
+    EXPECT_EQ(10, list.front().value);
+    EXPECT_EQ(10, list.back().value);
+
+    list.push_back(obj2);
+    EXPECT_EQ(2, list.size());
+    EXPECT_EQ(10, list.front().value);
+    EXPECT_EQ(20, list.back().value);
+}
+
+TEST(IntrusiveListTest, PushFront) {
+    TestList list;
+    TestObject obj1(10);
+    TestObject obj2(20);
+
+    list.push_front(obj1);
+    EXPECT_FALSE(list.empty());
+    EXPECT_EQ(1, list.size());
+    EXPECT_EQ(10, list.front().value);
+    EXPECT_EQ(10, list.back().value);
+
+    list.push_front(obj2);
+    EXPECT_EQ(2, list.size());
+    EXPECT_EQ(20, list.front().value);
+    EXPECT_EQ(10, list.back().value);
+}
+
+TEST(IntrusiveListTest, PopFront) {
+    TestList list;
+    TestObject obj1(10);
+    TestObject obj2(20);
+    list.push_back(obj1);
+    list.push_back(obj2);
+
+    list.pop_front();
+    EXPECT_EQ(1, list.size());
+    EXPECT_EQ(20, list.front().value);
+
+    list.pop_front();
+    EXPECT_TRUE(list.empty());
+}
+
+TEST(IntrusiveListTest, PopBack) {
+    TestList list;
+    TestObject obj1(10);
+    TestObject obj2(20);
+    list.push_back(obj1);
+    list.push_back(obj2);
+
+    list.pop_back();
+    EXPECT_EQ(1, list.size());
+    EXPECT_EQ(10, list.front().value);
+
+    list.pop_back();
+    EXPECT_TRUE(list.empty());
+}
+
+TEST(IntrusiveListTest, Erase) {
+    TestList list;
+    TestObject obj1(10);
+    TestObject obj2(20);
+    TestObject obj3(30);
+    list.push_back(obj1);
+    list.push_back(obj2);
+    list.push_back(obj3);
+
+    auto it = ++list.begin();
+    list.erase(it);
+
+    EXPECT_EQ(2, list.size());
+    EXPECT_EQ(10, list.front().value);
+    EXPECT_EQ(30, list.back().value);
+}
+
+TEST(IntrusiveListTest, Iterator) {
+    TestList list;
+    TestObject obj1(10);
+    TestObject obj2(20);
+    list.push_back(obj1);
+    list.push_back(obj2);
+
+    auto it = list.begin();
+    EXPECT_EQ(10, it->value);
+    ++it;
+    EXPECT_EQ(20, it->value);
+    ++it;
+    EXPECT_EQ(list.end(), it);
+}
+
+TEST(IntrusiveListTest, ConstIterator) {
+    TestList list;
+    TestObject obj1(10);
+    TestObject obj2(20);
+    list.push_back(obj1);
+    list.push_back(obj2);
+
+    const TestList& const_list = list;
+    auto it = const_list.cbegin();
+    EXPECT_EQ(10, it->value);
+    ++it;
+    EXPECT_EQ(20, it->value);
+    ++it;
+    EXPECT_EQ(const_list.cend(), it);
+}
+
+TEST(IntrusiveListTest, Clear) {
+    TestList list;
+    TestObject obj1(10);
+    TestObject obj2(20);
+    list.push_back(obj1);
+    list.push_back(obj2);
+
+    list.clear();
+    EXPECT_TRUE(list.empty());
+    EXPECT_EQ(0, list.size());
+    EXPECT_FALSE(obj1.hook.is_linked());
+    EXPECT_FALSE(obj2.hook.is_linked());
+}
+
+} // namespace


### PR DESCRIPTION
I have implemented an intrusive list data structure, which is a doubly linked list that avoids memory allocation overhead by embedding the list hooks within the user's own data structures.

I have created the following files:
- `include/intrusive_list.h`: The header file for the intrusive list.
- `examples/intrusive_list_example.cpp`: An example of how to use the intrusive list.
- `tests/intrusive_list_test.cpp`: A test suite for the intrusive list.
- `docs/README_intrusive_list.md`: Documentation for the intrusive list.

I was unable to build and run the tests to verify my implementation. I believe I was stuck in a loop and I was unable to make progress.