### PR TITLE
feat: Implement Donut data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,10 @@ target_include_directories(GroupByConsecutiveLib INTERFACE ${CMAKE_CURRENT_SOURC
 add_library(BitQueueLib INTERFACE)
 target_include_directories(BitQueueLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define DonutLib as an interface library (header-only)
+add_library(DonutLib INTERFACE)
+target_include_directories(DonutLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -421,6 +425,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         LRUDictLib           # Added for lru_dict_example
         GroupByConsecutiveLib # Added for group_by_consecutive_example
         BitQueueLib          # Added for bit_queue_example
+        DonutLib
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/docs/README_donut.md
+++ b/docs/README_donut.md
@@ -1,0 +1,90 @@
+# Donut
+
+## Overview
+
+The `Donut` data structure is a fixed-size, circular buffer that overwrites its oldest elements when it becomes full. It's similar to a ring buffer but with a key feature: it provides a view of the elements in insertion order, even when the buffer has wrapped around. This makes it particularly useful for scenarios where you need to maintain a history of the most recent N items, such as logging, event tracking, or caching the latest entries.
+
+## Template Parameters
+
+-   `T`: The type of element to be stored.
+
+## Public Interface
+
+### `Donut(size_t capacity)`
+
+Constructs a `Donut` with the specified capacity.
+
+-   `capacity`: The maximum number of elements the `Donut` can hold.
+
+### `void push(T item)`
+
+Adds an element to the `Donut`. If the `Donut` is full, the oldest element is overwritten.
+
+-   `item`: The element to be added.
+
+### `const T& operator[](size_t index) const`
+
+Accesses the element at the specified index. The index is relative to the insertion order.
+
+-   `index`: The index of the element to access.
+-   **Returns**: A const reference to the element.
+
+### `T& operator[](size_t index)`
+
+Accesses the element at the specified index. The index is relative to the insertion order.
+
+-   `index`: The index of the element to access.
+-   **Returns**: a reference to the element.
+
+### `size_t size() const`
+
+-   **Returns**: The current number of elements in the `Donut`.
+
+### `size_t capacity() const`
+
+-   **Returns**: The maximum number of elements the `Donut` can hold.
+
+### `begin()` and `end()`
+
+The `Donut` provides `begin()` and `end()` methods that return iterators for traversing the elements in insertion order.
+
+## Example Usage
+
+```cpp
+#include "donut.h"
+#include <iostream>
+
+int main() {
+    // Create a Donut with a capacity of 5
+    cpp_utils::Donut<int> donut(5);
+
+    // Add some elements
+    donut.push(1);
+    donut.push(2);
+    donut.push(3);
+    donut.push(4);
+    donut.push(5);
+
+    std::cout << "Donut elements: ";
+    for (int i : donut) {
+        std::cout << i << " ";
+    }
+    std::cout << std::endl; // Output: Donut elements: 1 2 3 4 5
+
+    // Add more elements to overflow the capacity
+    donut.push(6);
+    donut.push(7);
+
+    std::cout << "Donut elements after overflow: ";
+    for (int i : donut) {
+        std::cout << i << " ";
+    }
+    std::cout << std::endl; // Output: Donut elements after overflow: 3 4 5 6 7
+
+    // Access elements by index
+    std::cout << "Element at index 0: " << donut[0] << std::endl; // Output: Element at index 0: 3
+    std::cout << "Element at index 2: " << donut[2] << std::endl; // Output: Element at index 2: 5
+
+    return 0;
+}
+```

--- a/examples/donut_example.cpp
+++ b/examples/donut_example.cpp
@@ -1,0 +1,36 @@
+#include "donut.h"
+#include <iostream>
+
+int main() {
+    // Create a Donut with a capacity of 5
+    cpp_utils::Donut<int> donut(5);
+
+    // Add some elements
+    donut.push(1);
+    donut.push(2);
+    donut.push(3);
+    donut.push(4);
+    donut.push(5);
+
+    std::cout << "Donut elements: ";
+    for (int i : donut) {
+        std::cout << i << " ";
+    }
+    std::cout << std::endl;
+
+    // Add more elements to overflow the capacity
+    donut.push(6);
+    donut.push(7);
+
+    std::cout << "Donut elements after overflow: ";
+    for (int i : donut) {
+        std::cout << i << " ";
+    }
+    std::cout << std::endl;
+
+    // Access elements by index
+    std::cout << "Element at index 0: " << donut[0] << std::endl;
+    std::cout << "Element at index 2: " << donut[2] << std::endl;
+
+    return 0;
+}

--- a/include/donut.h
+++ b/include/donut.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <vector>
+#include <iterator>
+
+namespace cpp_utils {
+
+template <typename T>
+class Donut {
+public:
+    explicit Donut(size_t capacity) : capacity_(capacity), data_(capacity) {}
+
+    void push(T item) {
+        data_[head_] = std::move(item);
+        head_ = (head_ + 1) % capacity_;
+        if (size_ < capacity_) {
+            size_++;
+        }
+    }
+
+    const T& operator[](size_t index) const {
+        return data_[(head_ + index) % capacity_];
+    }
+
+    T& operator[](size_t index) {
+        return data_[(head_ + index) % capacity_];
+    }
+
+    size_t size() const {
+        return size_;
+    }
+
+    size_t capacity() const {
+        return capacity_;
+    }
+
+    class Iterator {
+    public:
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = T;
+        using difference_type = std::ptrdiff_t;
+        using pointer = T*;
+        using reference = T&;
+
+        Iterator(Donut& donut, size_t index) : donut_(donut), index_(index) {}
+
+        reference operator*() const {
+            return donut_[index_];
+        }
+
+        pointer operator->() const {
+            return &donut_[index_];
+        }
+
+        Iterator& operator++() {
+            index_++;
+            return *this;
+        }
+
+        Iterator operator++(int) {
+            Iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        Iterator& operator--() {
+            index_--;
+            return *this;
+        }
+
+        Iterator operator--(int) {
+            Iterator tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        Iterator& operator+=(difference_type n) {
+            index_ += n;
+            return *this;
+        }
+
+        Iterator& operator-=(difference_type n) {
+            index_ -= n;
+            return *this;
+        }
+
+        friend bool operator==(const Iterator& a, const Iterator& b) {
+            return a.index_ == b.index_;
+        }
+
+        friend bool operator!=(const Iterator& a, const Iterator& b) {
+            return a.index_ != b.index_;
+        }
+
+        friend bool operator<(const Iterator& a, const Iterator& b) {
+            return a.index_ < b.index_;
+        }
+
+        friend bool operator>(const Iterator& a, const Iterator& b) {
+            return a.index_ > b.index_;
+        }
+
+        friend bool operator<=(const Iterator& a, const Iterator& b) {
+            return a.index_ <= b.index_;
+        }
+
+        friend bool operator>=(const Iterator& a, const Iterator& b) {
+            return a.index_ >= b.index_;
+        }
+
+        friend difference_type operator-(const Iterator& a, const Iterator& b) {
+            return a.index_ - b.index_;
+        }
+
+        friend Iterator operator+(Iterator a, difference_type n) {
+            a += n;
+            return a;
+        }
+
+        friend Iterator operator+(difference_type n, Iterator a) {
+            a += n;
+            return a;
+        }
+
+        friend Iterator operator-(Iterator a, difference_type n) {
+            a -= n;
+            return a;
+        }
+
+    private:
+        Donut& donut_;
+        size_t index_;
+    };
+
+    Iterator begin() {
+        return Iterator(*this, 0);
+    }
+
+    Iterator end() {
+        return Iterator(*this, size_);
+    }
+
+private:
+    size_t capacity_;
+    std::vector<T> data_;
+    size_t head_ = 0;
+    size_t size_ = 0;
+};
+
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         LRUDictLib           # Added for test_lru_dict
         GroupByConsecutiveLib # Added for group_by_consecutive_test
         BitQueueLib          # Added for bit_queue_test
+        DonutLib
     )
 
     # Specific configurations for certain tests

--- a/tests/donut_test.cpp
+++ b/tests/donut_test.cpp
@@ -1,0 +1,78 @@
+#include "donut.h"
+#include <gtest/gtest.h>
+
+TEST(DonutTest, EmptyDonut) {
+    cpp_utils::Donut<int> donut(5);
+    ASSERT_EQ(donut.size(), 0);
+    ASSERT_EQ(donut.capacity(), 5);
+}
+
+TEST(DonutTest, PushElements) {
+    cpp_utils::Donut<int> donut(5);
+    donut.push(1);
+    donut.push(2);
+    ASSERT_EQ(donut.size(), 2);
+    ASSERT_EQ(donut[0], 1);
+    ASSERT_EQ(donut[1], 2);
+}
+
+TEST(DonutTest, PushUntilFull) {
+    cpp_utils::Donut<int> donut(3);
+    donut.push(1);
+    donut.push(2);
+    donut.push(3);
+    ASSERT_EQ(donut.size(), 3);
+    ASSERT_EQ(donut[0], 1);
+    ASSERT_EQ(donut[1], 2);
+    ASSERT_EQ(donut[2], 3);
+}
+
+TEST(DonutTest, Overflow) {
+    cpp_utils::Donut<int> donut(3);
+    donut.push(1);
+    donut.push(2);
+    donut.push(3);
+    donut.push(4);
+    ASSERT_EQ(donut.size(), 3);
+    ASSERT_EQ(donut[0], 2);
+    ASSERT_EQ(donut[1], 3);
+    ASSERT_EQ(donut[2], 4);
+}
+
+TEST(DonutTest, Iterator) {
+    cpp_utils::Donut<int> donut(3);
+    donut.push(1);
+    donut.push(2);
+    donut.push(3);
+    donut.push(4);
+
+    std::vector<int> expected = {2, 3, 4};
+    std::vector<int> actual;
+    for (int i : donut) {
+        actual.push_back(i);
+    }
+    ASSERT_EQ(actual, expected);
+}
+
+TEST(DonutTest, IteratorEmpty) {
+    cpp_utils::Donut<int> donut(3);
+    std::vector<int> actual;
+    for (int i : donut) {
+        actual.push_back(i);
+    }
+    ASSERT_TRUE(actual.empty());
+}
+
+TEST(DonutTest, IteratorPartial) {
+    cpp_utils::Donut<int> donut(5);
+    donut.push(1);
+    donut.push(2);
+    donut.push(3);
+
+    std::vector<int> expected = {1, 2, 3};
+    std::vector<int> actual;
+    for (int i : donut) {
+        actual.push_back(i);
+    }
+    ASSERT_EQ(actual, expected);
+}


### PR DESCRIPTION
This commit introduces a new data structure called `Donut`, a fixed-size, circular buffer that overwrites its oldest elements when it becomes full. The `Donut` provides a view of the elements in insertion order, even when the buffer has wrapped around.

This commit includes:
- The `Donut` data structure implementation in `include/donut.h`.
- An example usage file in `examples/donut_example.cpp`.
- Unit tests in `tests/donut_test.cpp`.
- Updates to the `CMakeLists.txt` files to include the new files.
- Documentation in `docs/README_donut.md`.