### PR TITLE
feat: Add Bitfield class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,10 @@ target_include_directories(DonutLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/includ
 add_library(ValueOrErrorLib INTERFACE)
 target_include_directories(ValueOrErrorLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define BitfieldLib as an interface library (header-only)
+add_library(BitfieldLib INTERFACE)
+target_include_directories(BitfieldLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -431,6 +435,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         BitQueueLib          # Added for bit_queue_example
         DonutLib
         ValueOrErrorLib
+        BitfieldLib
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/examples/bitfield_example.cpp
+++ b/examples/bitfield_example.cpp
@@ -1,0 +1,42 @@
+#include "bitfield.h"
+#include <iostream>
+
+// Define the layout of our bitfield.
+// This could represent a hardware register, a network packet header, etc.
+using MyBitfield = Bitfield<uint32_t,
+    BitfieldFlag<0>, // A boolean flag at bit 0
+    BitfieldValue<1, 3, uint8_t>, // A 3-bit unsigned integer at bit 1
+    BitfieldValue<4, 12, uint16_t> // A 12-bit unsigned integer at bit 4
+>;
+
+// Give meaningful names to the fields.
+using IsEnabled = BitfieldFlag<0>;
+using Mode = BitfieldValue<1, 3, uint8_t>;
+using Value = BitfieldValue<4, 12, uint16_t>;
+
+int main() {
+    MyBitfield bf;
+
+    // Set some values.
+    bf.set<IsEnabled>(true);
+    bf.set<Mode>(5);
+    bf.set<Value>(1024);
+
+    // Get the values back.
+    std::cout << "IsEnabled: " << bf.get<IsEnabled>() << std::endl;
+    std::cout << "Mode: " << static_cast<int>(bf.get<Mode>()) << std::endl;
+    std::cout << "Value: " << bf.get<Value>() << std::endl;
+
+    // Print the underlying integer value.
+    std::cout << "Underlying value: " << bf.to_underlying() << std::endl;
+
+    // Create a bitfield from an existing value.
+    MyBitfield bf2(0b1010101010101010);
+
+    std::cout << "\nFrom existing value:" << std::endl;
+    std::cout << "IsEnabled: " << bf2.get<IsEnabled>() << std::endl;
+    std::cout << "Mode: " << static_cast<int>(bf2.get<Mode>()) << std::endl;
+    std::cout << "Value: " << bf2.get<Value>() << std::endl;
+
+    return 0;
+}

--- a/include/bitfield.h
+++ b/include/bitfield.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+// A type to represent a field in the bitfield.
+template<std::size_t Offset, std::size_t Bits, typename Type = bool>
+struct BitfieldValue {
+    static_assert(std::is_integral_v<Type> || std::is_enum_v<Type>, "Type must be an integral or enum type.");
+    static_assert(Bits > 0, "Bits must be greater than 0.");
+    static_assert(Bits <= (sizeof(Type) * 8), "Bits must be less than or equal to the number of bits in Type.");
+
+    using type = Type;
+    static constexpr std::size_t offset = Offset;
+    static constexpr std::size_t bits = Bits;
+};
+
+// A type to represent a boolean flag in the bitfield.
+template<std::size_t Offset>
+using BitfieldFlag = BitfieldValue<Offset, 1, bool>;
+
+template<typename Underlying, typename... Fields>
+class Bitfield {
+public:
+    using underlying_type = Underlying;
+
+    constexpr Bitfield() : data_(0) {}
+    constexpr explicit Bitfield(Underlying data) : data_(data) {}
+
+    template<typename Field>
+    constexpr typename Field::type get() const {
+        constexpr auto mask = (static_cast<Underlying>(1) << Field::bits) - 1;
+        if constexpr (std::is_same_v<typename Field::type, bool>) {
+            return (data_ >> Field::offset) & 1;
+        } else {
+            return static_cast<typename Field::type>((data_ >> Field::offset) & mask);
+        }
+    }
+
+    template<typename Field>
+    constexpr void set(typename Field::type value) {
+        constexpr auto mask = (static_cast<Underlying>(1) << Field::bits) - 1;
+        if constexpr (std::is_same_v<typename Field::type, bool>) {
+            if (value) {
+                data_ |= (static_cast<Underlying>(1) << Field::offset);
+            } else {
+                data_ &= ~(static_cast<Underlying>(1) << Field::offset);
+            }
+        } else {
+            data_ = (data_ & ~(mask << Field::offset)) |
+                    ((static_cast<Underlying>(value) & mask) << Field::offset);
+        }
+    }
+
+    constexpr Underlying to_underlying() const {
+        return data_;
+    }
+
+private:
+    Underlying data_;
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,6 +115,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         BitQueueLib          # Added for bit_queue_test
         DonutLib
         ValueOrErrorLib
+        BitfieldLib
     )
 
     # Specific configurations for certain tests

--- a/tests/bitfield_test.cpp
+++ b/tests/bitfield_test.cpp
@@ -1,0 +1,112 @@
+#include "bitfield.h"
+#include <gtest/gtest.h>
+
+// Define a test bitfield layout.
+using TestBitfield = Bitfield<uint32_t,
+    BitfieldFlag<0>,
+    BitfieldValue<1, 3, uint8_t>,
+    BitfieldValue<4, 12, uint16_t>,
+    BitfieldValue<16, 8, uint8_t>
+>;
+
+// Field definitions for the test bitfield.
+using FlagField = BitfieldFlag<0>;
+using ThreeBitField = BitfieldValue<1, 3, uint8_t>;
+using TwelveBitField = BitfieldValue<4, 12, uint16_t>;
+using EightBitField = BitfieldValue<16, 8, uint8_t>;
+
+TEST(BitfieldTest, InitialState) {
+    TestBitfield bf;
+    EXPECT_EQ(bf.to_underlying(), 0);
+    EXPECT_FALSE(bf.get<FlagField>());
+    EXPECT_EQ(bf.get<ThreeBitField>(), 0);
+    EXPECT_EQ(bf.get<TwelveBitField>(), 0);
+    EXPECT_EQ(bf.get<EightBitField>(), 0);
+}
+
+TEST(BitfieldTest, SetAndGetFlag) {
+    TestBitfield bf;
+    bf.set<FlagField>(true);
+    EXPECT_TRUE(bf.get<FlagField>());
+    EXPECT_EQ(bf.to_underlying(), 1);
+
+    bf.set<FlagField>(false);
+    EXPECT_FALSE(bf.get<FlagField>());
+    EXPECT_EQ(bf.to_underlying(), 0);
+}
+
+TEST(BitfieldTest, SetAndGetThreeBit) {
+    TestBitfield bf;
+    bf.set<ThreeBitField>(5); // 101 in binary
+    EXPECT_EQ(bf.get<ThreeBitField>(), 5);
+    EXPECT_EQ(bf.to_underlying(), 5 << 1);
+
+    bf.set<ThreeBitField>(0);
+    EXPECT_EQ(bf.get<ThreeBitField>(), 0);
+    EXPECT_EQ(bf.to_underlying(), 0);
+}
+
+TEST(BitfieldTest, SetAndGetTwelveBit) {
+    TestBitfield bf;
+    bf.set<TwelveBitField>(2048); // 100000000000 in binary
+    EXPECT_EQ(bf.get<TwelveBitField>(), 2048);
+    EXPECT_EQ(bf.to_underlying(), 2048 << 4);
+
+    bf.set<TwelveBitField>(0);
+    EXPECT_EQ(bf.get<TwelveBitField>(), 0);
+    EXPECT_EQ(bf.to_underlying(), 0);
+}
+
+TEST(BitfieldTest, SetAndGetEightBit) {
+    TestBitfield bf;
+    bf.set<EightBitField>(255); // 11111111 in binary
+    EXPECT_EQ(bf.get<EightBitField>(), 255);
+    EXPECT_EQ(bf.to_underlying(), 255 << 16);
+
+    bf.set<EightBitField>(0);
+    EXPECT_EQ(bf.get<EightBitField>(), 0);
+    EXPECT_EQ(bf.to_underlying(), 0);
+}
+
+TEST(BitfieldTest, CombinedSetAndGet) {
+    TestBitfield bf;
+    bf.set<FlagField>(true);
+    bf.set<ThreeBitField>(5);
+    bf.set<TwelveBitField>(1024);
+    bf.set<EightBitField>(128);
+
+    EXPECT_TRUE(bf.get<FlagField>());
+    EXPECT_EQ(bf.get<ThreeBitField>(), 5);
+    EXPECT_EQ(bf.get<TwelveBitField>(), 1024);
+    EXPECT_EQ(bf.get<EightBitField>(), 128);
+
+    uint32_t expected = (1 << 0) | (5 << 1) | (1024 << 4) | (128 << 16);
+    EXPECT_EQ(bf.to_underlying(), expected);
+}
+
+TEST(BitfieldTest, ConstructFromValue) {
+    uint32_t value = (1 << 0) | (3 << 1) | (512 << 4) | (64 << 16);
+    TestBitfield bf(value);
+
+    EXPECT_TRUE(bf.get<FlagField>());
+    EXPECT_EQ(bf.get<ThreeBitField>(), 3);
+    EXPECT_EQ(bf.get<TwelveBitField>(), 512);
+    EXPECT_EQ(bf.get<EightBitField>(), 64);
+}
+
+TEST(BitfieldTest, OverwriteField) {
+    TestBitfield bf;
+    bf.set<ThreeBitField>(7);
+    bf.set<ThreeBitField>(1);
+    EXPECT_EQ(bf.get<ThreeBitField>(), 1);
+    EXPECT_EQ(bf.to_underlying(), 1 << 1);
+}
+
+TEST(BitfieldTest, MaxValues) {
+    TestBitfield bf;
+    bf.set<ThreeBitField>(7);
+    EXPECT_EQ(bf.get<ThreeBitField>(), 7);
+
+    bf.set<TwelveBitField>(4095);
+    EXPECT_EQ(bf.get<TwelveBitField>(), 4095);
+}


### PR DESCRIPTION
This commit introduces a new `Bitfield` class, which provides a type-safe and memory-efficient way to manage packed bit-level data.

The `Bitfield` class is a header-only library that allows you to define custom bitfield layouts and access individual fields in a type-safe manner. It is inspired by bitfield usage in other languages and libraries, and it complements the existing data structures in this repository.

This commit includes:
- The `Bitfield` class implementation in `include/bitfield.h`.
- An example usage file in `examples/bitfield_example.cpp`.
- Unit tests in `tests/bitfield_test.cpp`.
- Updates to the `CMakeLists.txt` files to include the new files.