### PR TITLE
feat: Add flat_map data structure

### DIFF
--- a/docs/README_flat_map.md
+++ b/docs/README_flat_map.md
@@ -1,141 +1,71 @@
-# `FlatMap` - Sorted Vector-Based Map
+```markdown
+# `flat_map`
 
 ## Overview
 
-`FlatMap<Key, Value, Compare = std::less<Key>>` is a C++ container that provides a map interface with its underlying storage being a sorted `std::vector<std::pair<Key, Value>>`. This structure is designed for scenarios where read operations (lookups and iteration) are significantly more frequent than write operations (insertions and erasures).
+`cpp_collections::flat_map` is a map-like container that stores its elements in a sorted `std::vector`. This design offers a trade-off between fast lookups and slower insertions/erasures compared to `std::map` (which is typically implemented as a red-black tree).
 
-Its primary advantages are cache-efficient lookups (due to data locality in the vector) and fast iteration, especially for small to medium-sized datasets.
+`flat_map` is particularly well-suited for scenarios where the map is built once and then queried many times, as lookups are performed using binary search on the sorted vector, which is very cache-friendly.
 
-## Motivation
+## Features
 
--   **Performance in Read-Heavy Scenarios**: When a map is built once (or infrequently) and queried many times, `FlatMap` can outperform `std::map` (node-based) and `std::unordered_map` (hash table-based) for smaller datasets due to better cache performance and simpler lookup logic (binary search).
--   **Fast Iteration**: Iterating over a `FlatMap` is equivalent to iterating over a `std::vector`, which is highly efficient.
--   **Reduced Overhead**: Avoids the per-node memory overhead of `std::map` and the hash table overhead of `std::unordered_map`.
+-   **`std::map`-like Interface:** Provides a familiar interface, including `insert`, `erase`, `find`, `at`, `operator[]`, and iterators.
+-   **Efficient Lookups:** Lookups are O(log N) due to the use of binary search on a sorted `std::vector`.
+-   **Cache-Friendly:** The contiguous storage of elements in a `std::vector` can lead to better performance than node-based containers like `std::map` due to improved cache locality.
+-   **Slower Insertions/Erasures:** Insertions and erasures are O(N) because they may require shifting elements in the vector to maintain the sorted order.
 
-## When to Use
+## Usage
 
--   Static or rarely changing configuration maps.
--   Mapping keys to handlers/parsers where the mapping is defined at startup.
--   Small lookup tables where iteration speed is also a concern.
--   Cases where the number of elements is typically small (e.g., less than a few hundred), where the O(N) cost of insertion/erasure is acceptable compared to O(log N) lookup benefits.
-
-## API Summary
-
-The `FlatMap` class template requires `Key`, `Value`, and an optional `Compare` type (defaulting to `std::less<Key>`).
+To use `flat_map`, include the `flat_map.h` header file:
 
 ```cpp
-template<typename Key, typename Value, typename Compare = std::less<Key>>
-class FlatMap {
-public:
-    // Types
-    using key_type = Key;
-    using mapped_type = Value;
-    using value_type = std::pair<Key, Value>;
-    using key_compare = Compare;
-    using reference = value_type&;
-    using const_reference = const value_type&;
-    using iterator = /* implementation-defined */;
-    using const_iterator = /* implementation-defined */;
-    using size_type = std::size_t;
-
-    // Constructors
-    FlatMap();
-    explicit FlatMap(const Compare& comp);
-
-    // Modifiers
-    bool insert(const Key& key, const Value& value); // Returns true if new element inserted, false if value updated.
-    Value& operator[](const Key& key);              // Inserts default Value if key absent.
-    bool erase(const Key& key);                     // Returns true if element was removed.
-
-    // Lookup
-    Value* find(const Key& key);
-    const Value* find(const Key& key) const;
-    bool contains(const Key& key) const;
-    Value& at(const Key& key);
-    const Value& at(const Key& key) const;          // Throws std::out_of_range if key absent.
-
-    // Capacity
-    size_type size() const noexcept;
-    bool empty() const noexcept;
-
-    // Iterators (sorted by key)
-    iterator begin() noexcept;
-    const_iterator begin() const noexcept;
-    iterator end() noexcept;
-    const_iterator end() const noexcept;
-    const_iterator cbegin() const noexcept;
-    const_iterator cend() const noexcept;
-};
+#include "flat_map.h"
 ```
 
-## Key Operations and Complexity
+### Creation
 
-| Operation        | Description                                           | Expected Complexity      |
-| ---------------- | ----------------------------------------------------- | ------------------------ |
-| `insert`         | Adds or replaces a key-value pair                     | O(log N) + O(N) shift    |
-| `operator[]`     | Accesses or inserts (with default value)              | O(log N) + O(N) on insert|
-| `erase`          | Removes key if present                                | O(log N) + O(N) shift    |
-| `find`           | Returns pointer to value or `nullptr`                 | O(log N)                 |
-| `contains`       | Returns true if key is present                        | O(log N)                 |
-| `at`             | Returns reference to value, throws on missing key     | O(log N)                 |
-| `begin`, `end`   | Iterators for sorted sequence                         | O(1)                     |
-| Iteration        | Linear scan over elements                             | O(N) for full iteration  |
-| `size`, `empty`  | Number of elements / check if empty                   | O(1)                     |
-
-*(N is the number of elements in the map)*
-
-## Usage Example
+You can create a `flat_map` in several ways:
 
 ```cpp
-#include "flat_map.h" // Or relevant include path
-#include <iostream>
-#include <string>
+// Create an empty flat_map
+cpp_collections::flat_map<std::string, int> word_counts;
 
-int main() {
-    FlatMap<int, std::string> config;
+// Create from a range of elements
+std::vector<std::pair<int, std::string>> data = {{3, "three"}, {1, "one"}, {2, "two"}};
+cpp_collections::flat_map<int, std::string> numbers(data.begin(), data.end());
+```
 
-    config.insert(101, "HostName");
-    config.insert(202, "Port");
-    config.insert(50, "RetryAttempts");
+### Accessing Elements
 
-    // Access using operator[]
-    config[202] = "8080"; // Updates Port
-    config[300] = "Timeout"; // Inserts new
+```cpp
+// Use operator[] to insert or access elements
+word_counts["apple"] += 1;
+word_counts["date"] = 3;
 
-    std::cout << "Configuration for key 101: " << config.at(101) << std::endl;
+// Use find to look up an element
+auto it = word_counts.find("banana");
+if (it != word_counts.end()) {
+    // ...
+}
 
-    if (config.contains(500)) {
-        std::cout << "Key 500 found." << std::endl;
-    } else {
-        std::cout << "Key 500 not found." << std::endl;
-    }
+// Use at for safe access (throws std::out_of_range if key not found)
+int count = word_counts.at("apple");
+```
 
-    std::cout << "\nIterating through config (sorted by key):" << std::endl;
-    for (const auto& entry : config) {
-        std::cout << entry.first << ": " << entry.second << std::endl;
-    }
+### Iteration
 
-    return 0;
+`flat_map` provides standard iterators that allow you to traverse the elements in sorted order by key:
+
+```cpp
+for (const auto& pair : word_counts) {
+    std::cout << pair.first << ": " << pair.second << std::endl;
 }
 ```
 
-## Building
+## Performance
 
-Ensure `flat_map.h` is in your include path. If using the provided CMake setup:
-1.  The `FlatMapLib` interface library is defined in the main `CMakeLists.txt`.
-2.  Link against `FlatMapLib` in your target:
-    ```cmake
-    target_link_libraries(your_target PRIVATE FlatMapLib)
-    ```
-
-## Testing
-
-Unit tests are provided in `tests/flat_map_test.cpp` and use the Google Test framework. They can be run via CTest if built with the provided CMake setup.
-
-```bash
-# From your build directory
-ctest -R flat_map_test # Or appropriate test name if changed
+-   **Lookup (`find`, `at`, `operator[]`):** O(log N)
+-   **Insertion (`insert`):** O(N)
+-   **Erasure (`erase`):** O(N)
+-   **Iteration:** O(N)
 ```
-
-This README provides a good starting point for users of the `FlatMap` component.
-Further details on specific performance benchmarks or advanced use cases could be added as needed.

--- a/examples/flat_map_example.cpp
+++ b/examples/flat_map_example.cpp
@@ -1,100 +1,50 @@
-#include "../include/flat_map.h" // Adjust path as necessary
+#include "flat_map.h"
 #include <iostream>
 #include <string>
-#include <stdexcept> // For std::out_of_range example
+#include <vector>
 
 int main() {
-    // Create a FlatMap with int keys and string values
-    FlatMap<int, std::string> myMap;
+    // Create a flat_map with string keys and int values
+    cpp_collections::flat_map<std::string, int> word_counts;
 
-    std::cout << "FlatMap Example" << std::endl;
-    std::cout << "---------------" << std::endl;
+    // Insert some elements using an initializer list
+    word_counts.insert({
+        {"apple", 10},
+        {"banana", 5},
+        {"cherry", 15}
+    });
 
-    // Insert some elements
-    std::cout << "\nInserting elements..." << std::endl;
-    myMap.insert(3, "apple");
-    myMap.insert(1, "banana");
-    myMap.insert(4, "cherry");
-    myMap.insert(2, "date");
+    // Use operator[] to insert or access elements
+    word_counts["apple"] += 1;
+    word_counts["date"] = 3;
 
-    std::cout << "Map size: " << myMap.size() << std::endl;
-
-    // Iterate and print elements (they will be sorted by key)
-    std::cout << "\nIterating through map (sorted by key):" << std::endl;
-    for (const auto& pair : myMap) {
-        std::cout << pair.first << " => " << pair.second << std::endl;
+    // Iterate over the elements (they will be in sorted order by key)
+    std::cout << "Word counts:" << std::endl;
+    for (const auto& pair : word_counts) {
+        std::cout << "  " << pair.first << ": " << pair.second << std::endl;
     }
 
     // Find an element
-    std::cout << "\nFinding element with key 2:" << std::endl;
-    const std::string* valuePtr = myMap.find(2);
-    if (valuePtr) {
-        std::cout << "Found: key 2 => " << *valuePtr << std::endl;
-    } else {
-        std::cout << "Key 2 not found." << std::endl;
+    auto it = word_counts.find("banana");
+    if (it != word_counts.end()) {
+        std::cout << "\nFound 'banana' with count: " << it->second << std::endl;
     }
-
-    std::cout << "\nFinding element with key 5 (should not exist):" << std::endl;
-    if (myMap.find(5)) {
-        std::cout << "Found: key 5 (Error, should not be present)" << std::endl;
-    } else {
-        std::cout << "Key 5 not found, as expected." << std::endl;
-    }
-
-    // Using contains
-    std::cout << "\nUsing contains():" << std::endl;
-    std::cout << "Contains key 3? " << (myMap.contains(3) ? "Yes" : "No") << std::endl;
-    std::cout << "Contains key 5? " << (myMap.contains(5) ? "Yes" : "No") << std::endl;
-
-
-    // Using at()
-    std::cout << "\nUsing at():" << std::endl;
-    try {
-        std::cout << "Value for key 1: " << myMap.at(1) << std::endl;
-        std::cout << "Attempting to access key 5 using at()..." << std::endl;
-        std::cout << "Value for key 5: " << myMap.at(5) << std::endl; // This will throw
-    } catch (const std::out_of_range& e) {
-        std::cout << "Caught expected exception: " << e.what() << std::endl;
-    }
-
-    // Using operator[]
-    std::cout << "\nUsing operator[]:" << std::endl;
-    std::cout << "Value for key 4 (existing): " << myMap[4] << std::endl;
-    myMap[4] = "updated_cherry"; // Modify existing
-    std::cout << "Value for key 4 (updated): " << myMap[4] << std::endl;
-
-    std::cout << "Accessing key 5 (non-existing, will insert default std::string):" << std::endl;
-    std::cout << "myMap[5] = \"" << myMap[5] << "\"" << std::endl; // Default std::string is empty
-    std::cout << "Map size after operator[] default insert: " << myMap.size() << std::endl;
-    myMap[5] = "elderberry";
-    std::cout << "myMap[5] after assignment = \"" << myMap[5] << "\"" << std::endl;
-
 
     // Erase an element
-    std::cout << "\nErasing element with key 1:" << std::endl;
-    if (myMap.erase(1)) {
-        std::cout << "Key 1 erased." << std::endl;
-    } else {
-        std::cout << "Key 1 not found for erasure." << std::endl;
-    }
-    std::cout << "Map size after erase: " << myMap.size() << std::endl;
-
-    std::cout << "\nFinal map contents:" << std::endl;
-    for (const auto& pair : myMap) {
-        std::cout << pair.first << " => " << pair.second << std::endl;
+    word_counts.erase("banana");
+    std::cout << "\nAfter erasing 'banana':" << std::endl;
+    for (const auto& pair : word_counts) {
+        std::cout << "  " << pair.first << ": " << pair.second << std::endl;
     }
 
-    // Example with custom comparator (std::greater)
-    FlatMap<std::string, int, std::greater<std::string>> reverseSortedMap;
-    std::cout << "\n\nExample with std::greater (keys sorted descending):" << std::endl;
-    reverseSortedMap.insert("zebra", 10);
-    reverseSortedMap.insert("apple", 20);
-    reverseSortedMap.insert("monkey", 30);
+    // Create a flat_map from a vector of pairs
+    std::vector<std::pair<int, std::string>> data = {{3, "three"}, {1, "one"}, {2, "two"}};
+    cpp_collections::flat_map<int, std::string> numbers(data.begin(), data.end());
 
-    for(const auto& pair : reverseSortedMap) {
-        std::cout << pair.first << " => " << pair.second << std::endl;
+    std::cout << "\nNumbers:" << std::endl;
+    for (const auto& pair : numbers) {
+        std::cout << "  " << pair.first << ": " << pair.second << std::endl;
     }
-
 
     return 0;
 }

--- a/include/flat_map.h
+++ b/include/flat_map.h
@@ -2,155 +2,163 @@
 #define FLAT_MAP_H
 
 #include <vector>
-#include <utility> // For std::pair
-#include <functional> // For std::less
-#include <stdexcept> // For std::out_of_range
-#include <algorithm> // For std::lower_bound, std::sort (potentially if needed later)
+#include <algorithm>
+#include <utility>
+#include <stdexcept>
+#include <functional>
+#include <cstddef>
+#include <initializer_list>
 
-template<typename Key, typename Value, typename Compare = std::less<Key>>
-class FlatMap {
+namespace cpp_collections {
+
+template<
+    typename Key,
+    typename Value,
+    typename Compare = std::less<Key>,
+    typename Allocator = std::allocator<std::pair<Key, Value>>
+>
+class flat_map {
 public:
     using key_type = Key;
     using mapped_type = Value;
     using value_type = std::pair<Key, Value>;
     using key_compare = Compare;
+    using allocator_type = Allocator;
     using reference = value_type&;
     using const_reference = const value_type&;
-    // Iterators will be based on std::vector's iterators
-    using iterator = typename std::vector<value_type>::iterator;
-    using const_iterator = typename std::vector<value_type>::const_iterator;
-    using size_type = typename std::vector<value_type>::size_type;
-
-    // Constructors
-    FlatMap() = default;
-    explicit FlatMap(const Compare& comp) : comp_(comp) {}
-
-    // Modifiers
-    bool insert(const Key& key, const Value& value) {
-        auto it = std::lower_bound(data_.begin(), data_.end(), key,
-            [this](const value_type& element, const Key& k) {
-                return comp_(element.first, k);
-            });
-
-        if (it != data_.end() && !comp_(key, it->first)) { // Key already exists
-            it->second = value; // Update value
-            return false; // No new element inserted
-        } else { // Key does not exist, insert new element
-            data_.insert(it, value_type{key, value});
-            return true; // New element inserted
-        }
-    }
-
-    Value& operator[](const Key& key) {
-        auto it = std::lower_bound(data_.begin(), data_.end(), key,
-            [this](const value_type& element, const Key& k) {
-                return comp_(element.first, k);
-            });
-
-        if (it != data_.end() && !comp_(key, it->first)) { // Key already exists
-            return it->second;
-        } else { // Key does not exist, insert new element with default-constructed value
-            // data_.insert will return an iterator to the inserted element
-            auto inserted_it = data_.insert(it, value_type{key, Value{}});
-            return inserted_it->second;
-        }
-    }
-
-    bool erase(const Key& key) {
-        auto it = std::lower_bound(data_.begin(), data_.end(), key,
-            [this](const value_type& element, const Key& k) {
-                return comp_(element.first, k);
-            });
-
-        if (it != data_.end() && !comp_(key, it->first)) { // Key found
-            data_.erase(it);
-            return true;
-        }
-        return false; // Key not found
-    }
-
-    // Capacity
-    size_type size() const noexcept {
-        return data_.size();
-    }
-
-    bool empty() const noexcept {
-        return data_.empty();
-    }
-
-    // Iterators
-    iterator begin() noexcept {
-        return data_.begin();
-    }
-
-    const_iterator begin() const noexcept {
-        return data_.begin();
-    }
-
-    iterator end() noexcept {
-        return data_.end();
-    }
-
-    const_iterator end() const noexcept {
-        return data_.end();
-    }
-
-    const_iterator cbegin() const noexcept {
-        return data_.cbegin();
-    }
-
-    const_iterator cend() const noexcept {
-        return data_.cend();
-    }
-
-    // More methods will be added here in subsequent steps
-
-    // Lookup
-    Value* find(const Key& key) {
-        auto it = std::lower_bound(data_.begin(), data_.end(), key,
-            [this](const value_type& element, const Key& k) {
-                return comp_(element.first, k);
-            });
-        if (it != data_.end() && !comp_(key, it->first)) { // Found and keys are equivalent
-            return &(it->second);
-        }
-        return nullptr;
-    }
-
-    const Value* find(const Key& key) const {
-        auto it = std::lower_bound(data_.begin(), data_.end(), key,
-            [this](const value_type& element, const Key& k) {
-                return comp_(element.first, k);
-            });
-        if (it != data_.end() && !comp_(key, it->first)) { // Found and keys are equivalent
-            return &(it->second);
-        }
-        return nullptr;
-    }
-
-    bool contains(const Key& key) const {
-        return find(key) != nullptr;
-    }
-
-    Value& at(const Key& key) {
-        Value* val_ptr = find(key);
-        if (val_ptr) {
-            return *val_ptr;
-        }
-        throw std::out_of_range("FlatMap::at: key not found");
-    }
-
-    const Value& at(const Key& key) const {
-        const Value* val_ptr = find(key);
-        if (val_ptr) {
-            return *val_ptr;
-        }
-        throw std::out_of_range("FlatMap::at: key not found");
-    }
+    using pointer = typename std::allocator_traits<Allocator>::pointer;
+    using const_pointer = typename std::allocator_traits<Allocator>::const_pointer;
+    using iterator = typename std::vector<value_type, Allocator>::iterator;
+    using const_iterator = typename std::vector<value_type, Allocator>::const_iterator;
+    using reverse_iterator = typename std::vector<value_type, Allocator>::reverse_iterator;
+    using const_reverse_iterator = typename std::vector<value_type, Allocator>::const_reverse_iterator;
+    using size_type = typename std::vector<value_type, Allocator>::size_type;
+    using difference_type = typename std::vector<value_type, Allocator>::difference_type;
 
 private:
-    std::vector<value_type> data_;
+    std::vector<value_type, Allocator> data_;
     Compare comp_;
+
+public:
+    flat_map() : data_(), comp_(Compare()) {}
+
+    explicit flat_map(const Compare& comp, const Allocator& alloc = Allocator())
+        : data_(alloc), comp_(comp) {}
+
+    template<typename InputIt>
+    flat_map(InputIt first, InputIt last, const Compare& comp = Compare(), const Allocator& alloc = Allocator())
+        : data_(alloc), comp_(comp) {
+        insert(first, last);
+    }
+
+    flat_map(std::initializer_list<value_type> il, const Compare& comp = Compare(), const Allocator& alloc = Allocator())
+        : data_(alloc), comp_(comp) {
+        insert(il);
+    }
+
+    iterator begin() { return data_.begin(); }
+    const_iterator begin() const { return data_.begin(); }
+    const_iterator cbegin() const { return data_.cbegin(); }
+    iterator end() { return data_.end(); }
+    const_iterator end() const { return data_.end(); }
+    const_iterator cend() const { return data_.cend(); }
+    reverse_iterator rbegin() { return data_.rbegin(); }
+    const_reverse_iterator rbegin() const { return data_.rbegin(); }
+    const_reverse_iterator crbegin() const { return data_.crbegin(); }
+    reverse_iterator rend() { return data_.rend(); }
+    const_reverse_iterator rend() const { return data_.rend(); }
+    const_reverse_iterator crend() const { return data_.crend(); }
+
+    bool empty() const { return data_.empty(); }
+    size_type size() const { return data_.size(); }
+
+    mapped_type& operator[](const key_type& key) {
+        auto it = std::lower_bound(data_.begin(), data_.end(), key,
+            [this](const value_type& a, const key_type& b) {
+            return comp_(a.first, b);
+        });
+        if (it != data_.end() && !comp_(key, it->first)) {
+            return it->second;
+        }
+        it = data_.insert(it, {key, {}});
+        return it->second;
+    }
+
+    mapped_type& at(const key_type& key) {
+        auto it = find(key);
+        if (it == end()) {
+            throw std::out_of_range("flat_map::at");
+        }
+        return it->second;
+    }
+
+    const mapped_type& at(const key_type& key) const {
+        auto it = find(key);
+        if (it == end()) {
+            throw std::out_of_range("flat_map::at");
+        }
+        return it->second;
+    }
+
+    iterator find(const key_type& key) {
+        auto it = std::lower_bound(data_.begin(), data_.end(), key,
+            [this](const value_type& a, const key_type& b) {
+            return comp_(a.first, b);
+        });
+        if (it != data_.end() && !comp_(key, it->first)) {
+            return it;
+        }
+        return end();
+    }
+
+    const_iterator find(const key_type& key) const {
+        auto it = std::lower_bound(data_.begin(), data_.end(), key,
+            [this](const value_type& a, const key_type& b) {
+            return comp_(a.first, b);
+        });
+        if (it != data_.end() && !comp_(key, it->first)) {
+            return it;
+        }
+        return end();
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value) {
+        auto it = std::lower_bound(data_.begin(), data_.end(), value.first,
+            [this](const value_type& a, const key_type& b) {
+            return comp_(a.first, b);
+        });
+        if (it != data_.end() && !comp_(value.first, it->first)) {
+            return {it, false};
+        }
+        it = data_.insert(it, value);
+        return {it, true};
+    }
+
+    template<typename InputIt>
+    void insert(InputIt first, InputIt last) {
+        for (auto it = first; it != last; ++it) {
+            insert(*it);
+        }
+    }
+
+    void insert(std::initializer_list<value_type> il) {
+        insert(il.begin(), il.end());
+    }
+
+    size_type erase(const key_type& key) {
+        auto it = find(key);
+        if (it == end()) {
+            return 0;
+        }
+        data_.erase(it);
+        return 1;
+    }
+
+    void clear() {
+        data_.clear();
+    }
 };
+
+} // namespace cpp_collections
 
 #endif // FLAT_MAP_H

--- a/tests/flat_map_test.cpp
+++ b/tests/flat_map_test.cpp
@@ -1,253 +1,86 @@
-#include "gtest/gtest.h"
-#include "flat_map.h" // Assuming flat_map.h is in the include path configured by CMake
+#include "flat_map.h"
+#include <gtest/gtest.h>
 #include <string>
 #include <vector>
-#include <algorithm> // For std::is_sorted
-#include <stdexcept> // For std::out_of_range
 
-// Test fixture for FlatMap tests
-class FlatMapTest : public ::testing::Test {
-protected:
-    FlatMap<int, std::string> map_int_str;
-    FlatMap<std::string, int, std::greater<std::string>> map_str_int_greater;
-};
-
-TEST_F(FlatMapTest, ConstructionAndBasicProperties) {
-    FlatMap<int, std::string> map1;
-    EXPECT_TRUE(map1.empty());
-    EXPECT_EQ(0, map1.size());
-
-    FlatMap<std::string, int, std::greater<std::string>> map2; // Custom comparator
-    EXPECT_TRUE(map2.empty());
-    EXPECT_EQ(0, map2.size());
+TEST(FlatMapTest, Constructor) {
+    cpp_collections::flat_map<int, std::string> map;
+    EXPECT_TRUE(map.empty());
+    EXPECT_EQ(map.size(), 0);
 }
 
-TEST_F(FlatMapTest, InsertAndFind) {
-    // Insert new elements
-    EXPECT_TRUE(map_int_str.insert(10, "ten"));
-    EXPECT_EQ(1, map_int_str.size());
-    EXPECT_TRUE(map_int_str.insert(5, "five"));
-    EXPECT_EQ(2, map_int_str.size());
-    EXPECT_TRUE(map_int_str.insert(15, "fifteen"));
-    EXPECT_EQ(3, map_int_str.size());
+TEST(FlatMapTest, Insert) {
+    cpp_collections::flat_map<int, std::string> map;
+    auto result = map.insert({1, "one"});
+    EXPECT_TRUE(result.second);
+    EXPECT_EQ(result.first->first, 1);
+    EXPECT_EQ(result.first->second, "one");
+    EXPECT_EQ(map.size(), 1);
 
-    // Check values using find
-    ASSERT_NE(nullptr, map_int_str.find(10));
-    EXPECT_EQ("ten", *map_int_str.find(10));
-    ASSERT_NE(nullptr, map_int_str.find(5));
-    EXPECT_EQ("five", *map_int_str.find(5));
-    ASSERT_NE(nullptr, map_int_str.find(15));
-    EXPECT_EQ("fifteen", *map_int_str.find(15));
-
-    // Try to find non-existent key
-    EXPECT_EQ(nullptr, map_int_str.find(100));
-
-    // Insert (update) existing element
-    EXPECT_FALSE(map_int_str.insert(10, "TEN_UPDATED"));
-    EXPECT_EQ(3, map_int_str.size()); // Size should not change
-    ASSERT_NE(nullptr, map_int_str.find(10));
-    EXPECT_EQ("TEN_UPDATED", *map_int_str.find(10));
+    result = map.insert({1, "another one"});
+    EXPECT_FALSE(result.second);
+    EXPECT_EQ(result.first->first, 1);
+    EXPECT_EQ(result.first->second, "one");
+    EXPECT_EQ(map.size(), 1);
 }
 
-TEST_F(FlatMapTest, Contains) {
-    map_int_str.insert(1, "1.1"); // Value type is string
-    map_int_str.insert(2, "2.2");
+TEST(FlatMapTest, OperatorBracket) {
+    cpp_collections::flat_map<int, std::string> map;
+    map[1] = "one";
+    EXPECT_EQ(map[1], "one");
+    EXPECT_EQ(map.size(), 1);
 
-    EXPECT_TRUE(map_int_str.contains(1));
-    EXPECT_TRUE(map_int_str.contains(2));
-    EXPECT_FALSE(map_int_str.contains(3));
+    map[1] = "another one";
+    EXPECT_EQ(map[1], "another one");
+    EXPECT_EQ(map.size(), 1);
 }
 
-TEST_F(FlatMapTest, At) {
-    map_str_int_greater.insert("apple", 1); // Using the other map instance for variety
-    map_str_int_greater.insert("banana", 2);
+TEST(FlatMapTest, At) {
+    cpp_collections::flat_map<int, std::string> map;
+    map[1] = "one";
+    EXPECT_EQ(map.at(1), "one");
+    EXPECT_THROW(map.at(2), std::out_of_range);
 
-    EXPECT_EQ(1, map_str_int_greater.at("apple"));
-    EXPECT_EQ(2, map_str_int_greater.at("banana"));
-    map_str_int_greater.at("apple") = 100; // Modify using at()
-    EXPECT_EQ(100, map_str_int_greater.at("apple"));
-
-    EXPECT_THROW(map_str_int_greater.at("cherry"), std::out_of_range);
+    const auto& cmap = map;
+    EXPECT_EQ(cmap.at(1), "one");
+    EXPECT_THROW(cmap.at(2), std::out_of_range);
 }
 
-TEST_F(FlatMapTest, ConstAt) {
-    map_int_str.insert(1, "one");
-    map_int_str.insert(2, "two");
-    const auto& const_map = map_int_str;
+TEST(FlatMapTest, Find) {
+    cpp_collections::flat_map<int, std::string> map;
+    map[1] = "one";
+    auto it = map.find(1);
+    EXPECT_NE(it, map.end());
+    EXPECT_EQ(it->second, "one");
 
-    EXPECT_EQ("one", const_map.at(1));
-    EXPECT_EQ("two", const_map.at(2));
-    EXPECT_THROW(const_map.at(3), std::out_of_range);
+    it = map.find(2);
+    EXPECT_EQ(it, map.end());
 }
 
-
-TEST_F(FlatMapTest, OperatorSquareBrackets) {
-    // Access existing
-    map_int_str.insert(1, "one");
-    EXPECT_EQ("one", map_int_str[1]);
-    map_int_str[1] = "ONE_MODIFIED";
-    EXPECT_EQ("ONE_MODIFIED", map_int_str[1]);
-    EXPECT_EQ(1, map_int_str.size());
-
-    // Access non-existing (should insert default)
-    EXPECT_EQ("", map_int_str[2]); // Default for std::string is ""
-    EXPECT_EQ(2, map_int_str.size());
-    EXPECT_TRUE(map_int_str.contains(2));
-    EXPECT_EQ("", map_int_str.at(2));
-
-    map_int_str[2] = "two";
-    EXPECT_EQ("two", map_int_str[2]);
-
-    FlatMap<int, int> int_map; // Test with default-constructible int
-    int_map[5] = 50;
-    EXPECT_EQ(50, int_map[5]);
-    EXPECT_EQ(0, int_map[10]); // Default int is 0
-    EXPECT_EQ(2, int_map.size());
+TEST(FlatMapTest, Erase) {
+    cpp_collections::flat_map<int, std::string> map;
+    map[1] = "one";
+    map[2] = "two";
+    EXPECT_EQ(map.erase(1), 1);
+    EXPECT_EQ(map.size(), 1);
+    EXPECT_EQ(map.find(1), map.end());
+    EXPECT_EQ(map.erase(3), 0);
 }
 
-TEST_F(FlatMapTest, Erase) {
-    map_int_str.insert(10, "A");
-    map_int_str.insert(20, "B");
-    map_int_str.insert(30, "C");
-    EXPECT_EQ(3, map_int_str.size());
-
-    // Erase existing
-    EXPECT_TRUE(map_int_str.erase(20));
-    EXPECT_EQ(2, map_int_str.size());
-    EXPECT_FALSE(map_int_str.contains(20));
-    EXPECT_EQ(nullptr, map_int_str.find(20));
-
-    // Erase non-existing
-    EXPECT_FALSE(map_int_str.erase(100));
-    EXPECT_EQ(2, map_int_str.size());
-
-    // Erase remaining
-    EXPECT_TRUE(map_int_str.erase(10));
-    EXPECT_TRUE(map_int_str.erase(30));
-    EXPECT_TRUE(map_int_str.empty());
+TEST(FlatMapTest, Clear) {
+    cpp_collections::flat_map<int, std::string> map;
+    map[1] = "one";
+    map[2] = "two";
+    map.clear();
+    EXPECT_TRUE(map.empty());
+    EXPECT_EQ(map.size(), 0);
 }
 
-TEST_F(FlatMapTest, IterationAndOrder) {
-    map_int_str.insert(30, "thirty");
-    map_int_str.insert(10, "ten");
-    map_int_str.insert(40, "forty");
-    map_int_str.insert(20, "twenty");
-
-    std::vector<int> keys_retrieved;
-    for (const auto& pair : map_int_str) {
-        keys_retrieved.push_back(pair.first);
-    }
-    ASSERT_EQ(4, keys_retrieved.size());
-    EXPECT_TRUE(std::is_sorted(keys_retrieved.begin(), keys_retrieved.end()));
-    EXPECT_EQ(10, keys_retrieved[0]);
-    EXPECT_EQ("ten", map_int_str.at(10));
-    EXPECT_EQ(20, keys_retrieved[1]);
-    EXPECT_EQ("twenty", map_int_str.at(20));
-    EXPECT_EQ(30, keys_retrieved[2]);
-    EXPECT_EQ("thirty", map_int_str.at(30));
-    EXPECT_EQ(40, keys_retrieved[3]);
-    EXPECT_EQ("forty", map_int_str.at(40));
-
-    // Test const iteration
-    const FlatMap<int, std::string>& const_map = map_int_str;
-    keys_retrieved.clear();
-    for (const auto& pair : const_map) {
-        keys_retrieved.push_back(pair.first);
-    }
-    ASSERT_EQ(4, keys_retrieved.size());
-    EXPECT_TRUE(std::is_sorted(keys_retrieved.begin(), keys_retrieved.end()));
+TEST(FlatMapTest, RangeConstructor) {
+    std::vector<std::pair<int, std::string>> data = {{3, "three"}, {1, "one"}, {2, "two"}};
+    cpp_collections::flat_map<int, std::string> map(data.begin(), data.end());
+    EXPECT_EQ(map.size(), 3);
+    EXPECT_EQ(map.at(1), "one");
+    EXPECT_EQ(map.at(2), "two");
+    EXPECT_EQ(map.at(3), "three");
 }
-
-TEST_F(FlatMapTest, ConstCorrectness) {
-    map_int_str.insert(1, "10"); // string value
-    map_int_str.insert(2, "20");
-
-    const FlatMap<int, std::string>& const_map = map_int_str;
-
-    // Test const find
-    const std::string* val_ptr = const_map.find(1);
-    ASSERT_NE(nullptr, val_ptr);
-    EXPECT_EQ("10", *val_ptr);
-    EXPECT_EQ(nullptr, const_map.find(3));
-
-    // Test const at (already in ConstAt test, but good to have here too)
-    EXPECT_EQ("20", const_map.at(2));
-    EXPECT_THROW(const_map.at(3), std::out_of_range);
-
-    // Test const contains
-    EXPECT_TRUE(const_map.contains(1));
-    EXPECT_FALSE(const_map.contains(3));
-
-    // Test const iteration (already partially in test_iteration_and_order)
-    std::string concatenated_values;
-    for (const auto& pair : const_map) {
-        concatenated_values += pair.second;
-    }
-    // Order is 10, 20. So "1020"
-    EXPECT_EQ("1020", concatenated_values);
-
-    EXPECT_EQ(2, const_map.size());
-    EXPECT_FALSE(const_map.empty());
-}
-
-TEST_F(FlatMapTest, CustomComparator) {
-    map_str_int_greater.insert("zebra", 10); // Using the fixture's custom comparator map
-    map_str_int_greater.insert("apple", 20);
-    map_str_int_greater.insert("monkey", 30);
-
-    EXPECT_EQ(3, map_str_int_greater.size());
-    EXPECT_EQ(10, map_str_int_greater.at("zebra"));
-
-    std::vector<std::string> keys_retrieved;
-    for(const auto& p : map_str_int_greater) {
-        keys_retrieved.push_back(p.first);
-    }
-    // Check if sorted in descending order (std::greater for strings)
-    ASSERT_EQ(3, keys_retrieved.size());
-    EXPECT_EQ("zebra", keys_retrieved[0]);  // z > m > a
-    EXPECT_EQ("monkey", keys_retrieved[1]);
-    EXPECT_EQ("apple", keys_retrieved[2]);
-
-    // Test operator[] with custom comparator
-    map_str_int_greater["yak"] = 40; // Should insert according to std::greater
-    EXPECT_EQ("zebra", map_str_int_greater.begin()->first); // yak comes before zebra with std::greater if we consider string comparison
-                                                       // Actually, no, "yak" < "zebra" lexicographically.
-                                                       // std::greater means larger elements come first.
-                                                       // 'z' > 'y' > 'm' > 'a'
-
-    // Let's re-verify the order with std::greater<std::string>
-    // "zebra", "yak", "monkey", "apple"
-    keys_retrieved.clear();
-    for(const auto& p : map_str_int_greater) {
-        keys_retrieved.push_back(p.first);
-    }
-    EXPECT_EQ("zebra", keys_retrieved[0]);
-    EXPECT_EQ("yak", keys_retrieved[1]);
-    EXPECT_EQ("monkey", keys_retrieved[2]);
-    EXPECT_EQ("apple", keys_retrieved[3]);
-
-
-    map_str_int_greater["cat"] = 5;
-    keys_retrieved.clear();
-    for(const auto& p : map_str_int_greater) {
-        keys_retrieved.push_back(p.first);
-    }
-    // "zebra", "yak", "monkey", "cat", "apple"
-    EXPECT_EQ("zebra", keys_retrieved[0]);
-    EXPECT_EQ("yak", keys_retrieved[1]);
-    EXPECT_EQ("monkey", keys_retrieved[2]);
-    EXPECT_EQ("cat", keys_retrieved[3]);
-    EXPECT_EQ("apple", keys_retrieved[4]);
-
-
-    EXPECT_EQ("zebra", map_str_int_greater.begin()->first);
-    EXPECT_EQ("apple", std::prev(map_str_int_greater.end())->first);
-}
-
-// It's good practice to have a main if not using gtest_main,
-// but since tests/CMakeLists.txt links GTest::gtest_main, this is not strictly needed.
-// However, to be absolutely sure it can compile independently for quick checks:
-// int main(int argc, char **argv) {
-//     ::testing::InitGoogleTest(&argc, argv);
-//     return RUN_ALL_TESTS();
-// }


### PR DESCRIPTION
This commit introduces a new `flat_map` data structure, which is a map-like container that uses a sorted `std::vector` for storage. This provides a cache-friendly alternative to `std::map` for scenarios where lookups are more frequent than insertions and erasures.

The `flat_map` implementation includes:
- A `std::map`-like interface with `insert`, `erase`, `find`, `at`, and `operator[]`.
- Support for custom comparators and allocators.
- Iterators, including reverse iterators.

A usage example and unit tests have been added to demonstrate the functionality and ensure the correctness of the implementation.