### PR TITLE
feat: Add sorted_vector_map data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,10 @@ target_include_directories(BitfieldLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/inc
 add_library(RopeLib INTERFACE)
 target_include_directories(RopeLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define SortedVectorMapLib as an interface library (header-only)
+add_library(SortedVectorMapLib INTERFACE)
+target_include_directories(SortedVectorMapLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Future steps will add examples and tests here
 
@@ -441,6 +445,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         ValueOrErrorLib
         BitfieldLib
         RopeLib
+        SortedVectorMapLib
     )
 
     if(EXECUTABLE_NAME STREQUAL "partial_example")

--- a/docs/README_sorted_vector_map.md
+++ b/docs/README_sorted_vector_map.md
@@ -1,0 +1,68 @@
+# sorted_vector_map
+
+## Overview
+
+`sorted_vector_map` is a C++ data structure that implements an associative container with a `std::map`-like interface. It stores key-value pairs in a `std::vector`, sorted by key.
+
+This data structure is particularly useful in scenarios where the number of elements is relatively small, or when the map is built once and then accessed many times. In these cases, `sorted_vector_map` can be more efficient than `std::map` due to better cache locality.
+
+## Performance Characteristics
+
+-   **Lookup (`find`, `at`, `operator[]`):** O(log n) - performed using binary search.
+-   **Insertion (`insert`):** O(n) - requires shifting elements to maintain sorted order.
+-   **Deletion (`erase`):** O(n) - requires shifting elements to fill the gap.
+
+## Usage
+
+To use `sorted_vector_map`, include the header file `sorted_vector_map.h`:
+
+```cpp
+#include "sorted_vector_map.h"
+```
+
+### Creating a sorted_vector_map
+
+You can create an empty `sorted_vector_map` like this:
+
+```cpp
+sorted_vector_map<int, std::string> map;
+```
+
+### Inserting elements
+
+```cpp
+map.insert({5, "apple"});
+map.insert({2, "banana"});
+```
+
+### Accessing elements
+
+```cpp
+std::cout << map[2] << std::endl; // prints "banana"
+
+try {
+    std::cout << map.at(10) << std::endl;
+} catch (const std::out_of_range& e) {
+    std::cerr << "Key not found" << std::endl;
+}
+```
+
+### Iterating over elements
+
+The elements are iterated in sorted order of keys.
+
+```cpp
+for (const auto& pair : map) {
+    std::cout << pair.first << ": " << pair.second << std::endl;
+}
+```
+
+## When to use sorted_vector_map
+
+-   When you have a small number of elements.
+-   When the map is built once and then mostly read from.
+-   When you need to iterate over the elements in sorted order and cache performance is important.
+
+## When not to use sorted_vector_map
+
+-   When you have a large number of elements and frequent insertions or deletions. In this case, `std::map` or `std::unordered_map` would be more suitable.

--- a/examples/sorted_vector_map_example.cpp
+++ b/examples/sorted_vector_map_example.cpp
@@ -1,0 +1,56 @@
+#include "sorted_vector_map.h"
+#include <iostream>
+#include <string>
+
+int main() {
+    // Create a sorted_vector_map with integer keys and string values
+    sorted_vector_map<int, std::string> map;
+
+    // Insert some elements
+    map.insert({5, "apple"});
+    map.insert({2, "banana"});
+    map.insert({8, "cherry"});
+    map.insert({1, "date"});
+
+    // Print the elements in sorted order
+    std::cout << "Elements in the map:" << std::endl;
+    for (const auto& pair : map) {
+        std::cout << pair.first << ": " << pair.second << std::endl;
+    }
+
+    // Find an element
+    auto it = map.find(8);
+    if (it != map.end()) {
+        std::cout << "\nFound element with key 8: " << it->second << std::endl;
+    } else {
+        std::cout << "\nElement with key 8 not found" << std::endl;
+    }
+
+    // Try to find a non-existent element
+    it = map.find(3);
+    if (it != map.end()) {
+        std::cout << "Found element with key 3: " << it->second << std::endl;
+    } else {
+        std::cout << "Element with key 3 not found" << std::endl;
+    }
+
+    // Use the subscript operator
+    std::cout << "\nUsing the subscript operator:" << std::endl;
+    std::cout << "map[2]: " << map[2] << std::endl;
+    std::cout << "map[6]: " << map[6] << std::endl; // This will insert a new element
+
+    // Print the elements again to see the new element
+    std::cout << "\nElements in the map after using subscript operator:" << std::endl;
+    for (const auto& pair : map) {
+        std::cout << pair.first << ": " << pair.second << std::endl;
+    }
+
+    // Erase an element
+    map.erase(5);
+    std::cout << "\nElements in the map after erasing key 5:" << std::endl;
+    for (const auto& pair : map) {
+        std::cout << pair.first << ": " << pair.second << std::endl;
+    }
+
+    return 0;
+}

--- a/include/sorted_vector_map.h
+++ b/include/sorted_vector_map.h
@@ -1,0 +1,233 @@
+#pragma once
+
+#include <vector>
+#include <algorithm>
+#include <stdexcept>
+
+template<typename Key, typename Value, typename Compare = std::less<Key>>
+class sorted_vector_map {
+public:
+    using key_type = Key;
+    using mapped_type = Value;
+    using value_type = std::pair<Key, Value>;
+    using key_compare = Compare;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using iterator = typename std::vector<value_type>::iterator;
+    using const_iterator = typename std::vector<value_type>::const_iterator;
+    using reverse_iterator = typename std::vector<value_type>::reverse_iterator;
+    using const_reverse_iterator = typename std::vector<value_type>::const_reverse_iterator;
+    using size_type = typename std::vector<value_type>::size_type;
+
+private:
+    std::vector<value_type> data_;
+    key_compare comp_;
+
+public:
+    sorted_vector_map() = default;
+
+    template<class InputIt>
+    sorted_vector_map(InputIt first, InputIt last) {
+        data_.assign(first, last);
+        std::sort(data_.begin(), data_.end(), [this](const auto& a, const auto& b) {
+            return comp_(a.first, b.first);
+        });
+    }
+
+    iterator begin() noexcept {
+        return data_.begin();
+    }
+
+    const_iterator begin() const noexcept {
+        return data_.begin();
+    }
+
+    const_iterator cbegin() const noexcept {
+        return data_.cbegin();
+    }
+
+    iterator end() noexcept {
+        return data_.end();
+    }
+
+    const_iterator end() const noexcept {
+        return data_.end();
+    }
+
+    const_iterator cend() const noexcept {
+        return data_.cend();
+    }
+
+    reverse_iterator rbegin() noexcept {
+        return data_.rbegin();
+    }
+
+    const_reverse_iterator rbegin() const noexcept {
+        return data_.rbegin();
+    }
+
+    const_reverse_iterator crbegin() const noexcept {
+        return data_.crbegin();
+    }
+
+    reverse_iterator rend() noexcept {
+        return data_.rend();
+    }
+
+    const_reverse_iterator rend() const noexcept {
+        return data_.rend();
+    }
+
+    const_reverse_iterator crend() const noexcept {
+        return data_.crend();
+    }
+
+    bool empty() const noexcept {
+        return data_.empty();
+    }
+
+    size_type size() const noexcept {
+        return data_.size();
+    }
+
+    size_type max_size() const noexcept {
+        return data_.max_size();
+    }
+
+    mapped_type& at(const key_type& key) {
+        auto it = lower_bound(key);
+        if (it == end() || comp_(key, it->first)) {
+            throw std::out_of_range("sorted_vector_map::at");
+        }
+        return it->second;
+    }
+
+    const mapped_type& at(const key_type& key) const {
+        auto it = lower_bound(key);
+        if (it == end() || comp_(key, it->first)) {
+            throw std::out_of_range("sorted_vector_map::at");
+        }
+        return it->second;
+    }
+
+    mapped_type& operator[](const key_type& key) {
+        auto it = lower_bound(key);
+        if (it == end() || comp_(key, it->first)) {
+            return insert(it, {key, {}})->second;
+        }
+        return it->second;
+    }
+
+    mapped_type& operator[](key_type&& key) {
+        auto it = lower_bound(key);
+        if (it == end() || comp_(key, it->first)) {
+            return insert(it, {std::move(key), {}})->second;
+        }
+        return it->second;
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value) {
+        auto it = lower_bound(value.first);
+        if (it != end() && !comp_(value.first, it->first)) {
+            return {it, false};
+        }
+        return {data_.insert(it, value), true};
+    }
+
+    iterator insert(const_iterator pos, const value_type& value) {
+        (void)pos; // hint is ignored
+        return insert(value).first;
+    }
+
+    template<class InputIt>
+    void insert(InputIt first, InputIt last) {
+        for (; first != last; ++first) {
+            insert(*first);
+        }
+    }
+
+    iterator erase(const_iterator pos) {
+        return data_.erase(pos);
+    }
+
+    size_type erase(const key_type& key) {
+        auto it = find(key);
+        if (it == end()) {
+            return 0;
+        }
+        erase(it);
+        return 1;
+    }
+
+    void swap(sorted_vector_map& other) {
+        data_.swap(other.data_);
+        std::swap(comp_, other.comp_);
+    }
+
+    void clear() noexcept {
+        data_.clear();
+    }
+
+    iterator find(const key_type& key) {
+        auto it = lower_bound(key);
+        if (it != end() && !comp_(key, it->first)) {
+            return it;
+        }
+        return end();
+    }
+
+    const_iterator find(const key_type& key) const {
+        auto it = lower_bound(key);
+        if (it != end() && !comp_(key, it->first)) {
+            return it;
+        }
+        return end();
+    }
+
+    size_type count(const key_type& key) const {
+        return find(key) == end() ? 0 : 1;
+    }
+
+    iterator lower_bound(const key_type& key) {
+        return std::lower_bound(begin(), end(), key, [this](const auto& elem, const auto& k) {
+            return comp_(elem.first, k);
+        });
+    }
+
+    const_iterator lower_bound(const key_type& key) const {
+        return std::lower_bound(begin(), end(), key, [this](const auto& elem, const auto& k) {
+            return comp_(elem.first, k);
+        });
+    }
+
+    iterator upper_bound(const key_type& key) {
+        return std::upper_bound(begin(), end(), key, [this](const auto& k, const auto& elem) {
+            return comp_(k, elem.first);
+        });
+    }
+
+    const_iterator upper_bound(const key_type& key) const {
+        return std::upper_bound(begin(), end(), key, [this](const auto& k, const auto& elem) {
+            return comp_(k, elem.first);
+        });
+    }
+
+    std::pair<iterator, iterator> equal_range(const key_type& key) {
+        return {lower_bound(key), upper_bound(key)};
+    }
+
+    std::pair<const_iterator, const_iterator> equal_range(const key_type& key) const {
+        return {lower_bound(key), upper_bound(key)};
+    }
+
+private:
+    // a helper function for insertion
+    iterator insert_at(const_iterator pos, value_type&& value) {
+        return data_.insert(pos, std::move(value));
+    }
+};
+
+template<class Key, class T, class Compare>
+void swap(sorted_vector_map<Key, T, Compare>& lhs, sorted_vector_map<Key, T, Compare>& rhs) {
+    lhs.swap(rhs);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         ValueOrErrorLib
         BitfieldLib
         RopeLib
+        SortedVectorMapLib
     )
 
     # Specific configurations for certain tests

--- a/tests/sorted_vector_map_test.cpp
+++ b/tests/sorted_vector_map_test.cpp
@@ -1,0 +1,176 @@
+#include "gtest/gtest.h"
+#include "sorted_vector_map.h"
+#include <string>
+#include <vector>
+
+// Test fixture for sorted_vector_map tests
+class SortedVectorMapTest : public ::testing::Test {
+protected:
+    sorted_vector_map<int, std::string> map;
+};
+
+// Test default constructor
+TEST_F(SortedVectorMapTest, DefaultConstructor) {
+    EXPECT_TRUE(map.empty());
+    EXPECT_EQ(0, map.size());
+}
+
+// Test insertion and basic properties
+TEST_F(SortedVectorMapTest, InsertAndSize) {
+    auto result = map.insert({2, "banana"});
+    EXPECT_TRUE(result.second);
+    EXPECT_EQ(result.first->first, 2);
+    EXPECT_EQ(result.first->second, "banana");
+    EXPECT_EQ(map.size(), 1);
+    EXPECT_FALSE(map.empty());
+
+    map.insert({5, "apple"});
+    map.insert({1, "date"});
+
+    EXPECT_EQ(map.size(), 3);
+
+    // Check sorted order
+    auto it = map.begin();
+    EXPECT_EQ(it->first, 1);
+    ++it;
+    EXPECT_EQ(it->first, 2);
+    ++it;
+    EXPECT_EQ(it->first, 5);
+}
+
+// Test find
+TEST_F(SortedVectorMapTest, Find) {
+    map.insert({2, "banana"});
+    map.insert({5, "apple"});
+    map.insert({1, "date"});
+
+    auto it = map.find(2);
+    ASSERT_NE(it, map.end());
+    EXPECT_EQ(it->second, "banana");
+
+    it = map.find(4);
+    EXPECT_EQ(it, map.end());
+}
+
+// Test at
+TEST_F(SortedVectorMapTest, At) {
+    map.insert({2, "banana"});
+    map.insert({5, "apple"});
+
+    EXPECT_EQ(map.at(2), "banana");
+    EXPECT_THROW(map.at(4), std::out_of_range);
+}
+
+// Test operator[]
+TEST_F(SortedVectorMapTest, SubscriptOperator) {
+    map[2] = "banana";
+    map[5] = "apple";
+
+    EXPECT_EQ(map[2], "banana");
+    EXPECT_EQ(map[5], "apple");
+    EXPECT_EQ(map.size(), 2);
+
+    map[2] = "new banana";
+    EXPECT_EQ(map[2], "new banana");
+    EXPECT_EQ(map.size(), 2);
+
+    EXPECT_EQ(map[3], "");
+    EXPECT_EQ(map.size(), 3);
+}
+
+// Test erase
+TEST_F(SortedVectorMapTest, Erase) {
+    map.insert({2, "banana"});
+    map.insert({5, "apple"});
+    map.insert({1, "date"});
+
+    // Erase by key
+    EXPECT_EQ(map.erase(2), 1);
+    EXPECT_EQ(map.size(), 2);
+    EXPECT_EQ(map.find(2), map.end());
+
+    // Erase non-existent key
+    EXPECT_EQ(map.erase(3), 0);
+    EXPECT_EQ(map.size(), 2);
+
+    // Erase by iterator
+    auto it = map.find(1);
+    ASSERT_NE(it, map.end());
+    auto next_it = map.erase(it);
+    EXPECT_EQ(next_it->first, 5);
+    EXPECT_EQ(map.size(), 1);
+}
+
+// Test clear
+TEST_F(SortedVectorMapTest, Clear) {
+    map.insert({2, "banana"});
+    map.insert({5, "apple"});
+
+    map.clear();
+    EXPECT_TRUE(map.empty());
+    EXPECT_EQ(map.size(), 0);
+}
+
+// Test range constructor
+TEST_F(SortedVectorMapTest, RangeConstructor) {
+    std::vector<std::pair<int, std::string>> data = {{5, "apple"}, {2, "banana"}, {8, "cherry"}};
+    sorted_vector_map<int, std::string> new_map(data.begin(), data.end());
+
+    EXPECT_EQ(new_map.size(), 3);
+    auto it = new_map.begin();
+    EXPECT_EQ(it->first, 2);
+    ++it;
+    EXPECT_EQ(it->first, 5);
+    ++it;
+    EXPECT_EQ(it->first, 8);
+}
+
+// Test lower_bound and upper_bound
+TEST_F(SortedVectorMapTest, Bounds) {
+    map.insert({2, "banana"});
+    map.insert({5, "apple"});
+    map.insert({8, "cherry"});
+
+    auto lower = map.lower_bound(5);
+    EXPECT_EQ(lower->first, 5);
+
+    auto upper = map.upper_bound(5);
+    EXPECT_EQ(upper->first, 8);
+
+    lower = map.lower_bound(4);
+    EXPECT_EQ(lower->first, 5);
+
+    upper = map.upper_bound(9);
+    EXPECT_EQ(upper, map.end());
+}
+
+// Test equal_range
+TEST_F(SortedVectorMapTest, EqualRange) {
+    map.insert({2, "banana"});
+    map.insert({5, "apple"});
+    map.insert({8, "cherry"});
+
+    auto range = map.equal_range(5);
+    EXPECT_EQ(range.first->first, 5);
+    EXPECT_EQ(range.second->first, 8);
+}
+
+// Test swap
+TEST_F(SortedVectorMapTest, Swap) {
+    map.insert({2, "banana"});
+    map.insert({5, "apple"});
+
+    sorted_vector_map<int, std::string> other_map;
+    other_map.insert({1, "date"});
+    other_map.insert({10, "fig"});
+
+    map.swap(other_map);
+
+    EXPECT_EQ(map.size(), 2);
+    EXPECT_TRUE(map.find(1) != map.end());
+    EXPECT_TRUE(map.find(10) != map.end());
+
+    EXPECT_EQ(other_map.size(), 2);
+    EXPECT_TRUE(other_map.find(2) != other_map.end());
+    EXPECT_TRUE(other_map.find(5) != other_map.end());
+}


### PR DESCRIPTION
This commit introduces a new data structure, `sorted_vector_map`, which is an associative container with a `std::map`-like interface. It stores key-value pairs in a `std::vector`, sorted by key.

This data structure is particularly useful in scenarios where the number of elements is relatively small, or when the map is built once and then accessed many times. In these cases, `sorted_vector_map` can be more efficient than `std::map` due to better cache locality.

The implementation is header-only and can be found in `include/sorted_vector_map.h`.

A usage example has been added in `examples/sorted_vector_map_example.cpp`, and unit tests have been added in `tests/sorted_vector_map_test.cpp`.

The build system has been updated to include the new files.

Documentation has been added in `docs/README_sorted_vector_map.md`.