### PR TITLE
feat: Add CircularBuffer data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,10 @@ target_include_directories(TaggedUnionLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/
 add_library(ChronoRingLib INTERFACE)
 target_include_directories(ChronoRingLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# Define CircularBufferLib as an interface library (header-only)
+add_library(CircularBufferLib INTERFACE)
+target_include_directories(CircularBufferLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Define TaggedPtrLib as an interface library (header-only)
 add_library(TaggedPtrLib INTERFACE)
 target_include_directories(TaggedPtrLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -425,6 +429,7 @@ foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
         OneOfLib             # Added for one_of_example
         PackedSlotMapLib     # Added for packed_slot_map_example
         ChronoRingLib        # Added for chrono_ring_example
+        CircularBufferLib    # Added for circular_buffer_example
         AsyncValueLib
         TaggedPtrLib         # Added for tagged_ptr_example
         PredicateCacheLib    # Added for predicate_cache_example

--- a/docs/README_circular_buffer.md
+++ b/docs/README_circular_buffer.md
@@ -1,0 +1,82 @@
+# CircularBuffer
+
+`CircularBuffer` is a container that supports adding and removing elements from both ends. It has a fixed capacity, and when it's full, adding a new element will overwrite the oldest element. It is implemented as a circular array, which allows for efficient rotation of its elements.
+
+This data structure is useful for a variety of purposes, including:
+- Caching a fixed number of items.
+- Implementing a fixed-size log or history.
+- Buffering data for I/O operations.
+- Any situation where you need a queue-like container with a fixed capacity and efficient rotation.
+
+## Template Parameters
+
+```cpp
+template<
+    typename T,
+    typename Allocator = std::allocator<T>
+>
+class CircularBuffer;
+```
+
+- `T`: The type of the elements.
+- `Allocator`: The allocator to use for all memory allocations of this container.
+
+## Member Functions
+
+| Function | Description | Time Complexity |
+|----------|-------------|-----------------|
+| `(constructor)` | Constructs the `CircularBuffer` with a given capacity. | O(N) |
+| `size` | Returns the number of elements in the buffer. | O(1) |
+| `capacity` | Returns the maximum number of elements the buffer can hold. | O(1) |
+| `empty` | Checks if the buffer is empty. | O(1) |
+| `full` | Checks if the buffer is full. | O(1) |
+| `push_back` | Adds an element to the back of the buffer. If the buffer is full, the oldest element is overwritten. | O(1) |
+| `push_front` | Adds an element to the front of the buffer. If the buffer is full, the oldest element is overwritten. | O(1) |
+| `pop_back` | Removes the last element from the buffer. | O(1) |
+| `pop_front` | Removes the first element from the buffer. | O(1) |
+| `front` | Returns a reference to the first element in the buffer. | O(1) |
+| `back` | Returns a reference to the last element in the buffer. | O(1) |
+| `operator[]` | Returns a reference to the element at the specified index. | O(1) |
+| `rotate` | Rotates the elements in the buffer by a given amount. | O(1) |
+| `clear` | Clears the contents of the buffer. | O(1) |
+| `begin`, `end`, `cbegin`, `cend` | Returns an iterator to the beginning or end of the buffer. | O(1) |
+| `rbegin`, `rend`, `crbegin`, `crend` | Returns a reverse iterator to the beginning or end of the buffer. | O(1) |
+
+## Usage Example
+
+```cpp
+#include "circular_buffer.h"
+#include <iostream>
+
+int main() {
+    CircularBuffer<int> buffer(5);
+
+    for (int i = 1; i <= 5; ++i) {
+        buffer.push_back(i);
+    }
+
+    std::cout << "Initial buffer: ";
+    for (int x : buffer) {
+        std::cout << x << " ";
+    }
+    std::cout << std::endl; // Output: 1 2 3 4 5
+
+    buffer.rotate(2);
+
+    std::cout << "Buffer after rotating by 2: ";
+    for (int x : buffer) {
+        std::cout << x << " ";
+    }
+    std::cout << std::endl; // Output: 4 5 1 2 3
+
+    buffer.push_back(6); // Overwrites 1
+
+    std::cout << "Buffer after pushing 6: ";
+    for (int x : buffer) {
+        std::cout << x << " ";
+    }
+    std::cout << std::endl; // Output: 5 1 2 3 6
+
+    return 0;
+}
+```

--- a/examples/circular_buffer_example.cpp
+++ b/examples/circular_buffer_example.cpp
@@ -1,0 +1,64 @@
+#include "circular_buffer.h"
+#include <iostream>
+#include <string>
+
+void print_buffer(const CircularBuffer<std::string>& buffer) {
+    std::cout << "Buffer (size " << buffer.size() << "/" << buffer.capacity() << "): ";
+    for (const auto& item : buffer) {
+        std::cout << item << " ";
+    }
+    std::cout << std::endl;
+}
+
+int main() {
+    std::cout << "Creating a CircularBuffer of strings with capacity 5." << std::endl;
+    CircularBuffer<std::string> buffer(5);
+
+    std::cout << "\nPushing elements to the back:" << std::endl;
+    buffer.push_back("A");
+    buffer.push_back("B");
+    buffer.push_back("C");
+    print_buffer(buffer);
+
+    std::cout << "\nPushing more elements to fill the buffer:" << std::endl;
+    buffer.push_back("D");
+    buffer.push_back("E");
+    print_buffer(buffer);
+
+    std::cout << "\nPushing one more element ('F'), which overwrites the oldest ('A'):" << std::endl;
+    buffer.push_back("F");
+    print_buffer(buffer);
+    std::cout << "Front is now: " << buffer.front() << ", Back is now: " << buffer.back() << std::endl;
+
+    std::cout << "\nPopping from the front:" << std::endl;
+    buffer.pop_front();
+    print_buffer(buffer);
+
+    std::cout << "\nPushing to the front ('G'):" << std::endl;
+    buffer.push_front("G");
+    print_buffer(buffer);
+    std::cout << "Front is now: " << buffer.front() << ", Back is now: " << buffer.back() << std::endl;
+
+
+    std::cout << "\n--- Testing Rotation ---" << std::endl;
+    std::cout << "Initial state for rotation tests:" << std::endl;
+    print_buffer(buffer);
+
+    std::cout << "\nRotating by +2:" << std::endl;
+    buffer.rotate(2);
+    print_buffer(buffer);
+    std::cout << "Front is now: " << buffer.front() << ", Back is now: " << buffer.back() << std::endl;
+    std::cout << "Element at index 0: " << buffer[0] << ", Element at index 3: " << buffer[3] << std::endl;
+
+
+    std::cout << "\nRotating by -1:" << std::endl;
+    buffer.rotate(-1);
+    print_buffer(buffer);
+    std::cout << "Front is now: " << buffer.front() << ", Back is now: " << buffer.back() << std::endl;
+
+    std::cout << "\nClearing the buffer." << std::endl;
+    buffer.clear();
+    print_buffer(buffer);
+
+    return 0;
+}

--- a/include/circular_buffer.h
+++ b/include/circular_buffer.h
@@ -1,0 +1,272 @@
+#pragma once
+
+#include <vector>
+#include <stdexcept>
+#include <iterator>
+#include <algorithm>
+#include <type_traits>
+
+template<typename T, typename Allocator = std::allocator<T>>
+class CircularBuffer {
+public:
+    using value_type = T;
+    using allocator_type = Allocator;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using pointer = typename std::allocator_traits<Allocator>::pointer;
+    using const_pointer = typename std::allocator_traits<Allocator>::const_pointer;
+
+private:
+    using vector_type = std::vector<T, Allocator>;
+    vector_type data_;
+    size_type head_ = 0;
+    size_type tail_ = 0;
+    size_type count_ = 0;
+    size_type capacity_ = 0;
+
+public:
+    explicit CircularBuffer(size_type capacity, const Allocator& alloc = Allocator())
+        : data_(alloc), capacity_(capacity) {
+        if (capacity == 0) {
+            throw std::invalid_argument("CircularBuffer capacity must be positive.");
+        }
+        data_.resize(capacity_);
+    }
+
+    // Capacity
+    size_type size() const noexcept { return count_; }
+    size_type capacity() const noexcept { return capacity_; }
+    bool empty() const noexcept { return count_ == 0; }
+    bool full() const noexcept { return count_ == capacity_; }
+
+    void push_back(const_reference item) {
+        if (full()) {
+            // Overwrite the oldest element
+            head_ = (head_ + 1) % capacity_;
+        } else {
+            count_++;
+        }
+        data_[tail_] = item;
+        tail_ = (tail_ + 1) % capacity_;
+    }
+
+    void push_front(const_reference item) {
+        head_ = (head_ + capacity_ - 1) % capacity_;
+        data_[head_] = item;
+        if (full()) {
+            tail_ = (tail_ + capacity_ - 1) % capacity_;
+        } else {
+            count_++;
+        }
+    }
+
+    void pop_front() {
+        if (empty()) {
+            throw std::runtime_error("pop_front() on empty CircularBuffer");
+        }
+        head_ = (head_ + 1) % capacity_;
+        count_--;
+    }
+
+    void pop_back() {
+        if (empty()) {
+            throw std::runtime_error("pop_back() on empty CircularBuffer");
+        }
+        tail_ = (tail_ + capacity_ - 1) % capacity_;
+        count_--;
+    }
+
+    reference front() {
+        if (empty()) {
+            throw std::runtime_error("front() on empty CircularBuffer");
+        }
+        return data_[head_];
+    }
+
+    const_reference front() const {
+        if (empty()) {
+            throw std::runtime_error("front() on empty CircularBuffer");
+        }
+        return data_[head_];
+    }
+
+    reference back() {
+        if (empty()) {
+            throw std::runtime_error("back() on empty CircularBuffer");
+        }
+        return data_[(tail_ + capacity_ - 1) % capacity_];
+    }
+
+    const_reference back() const {
+        if (empty()) {
+            throw std::runtime_error("back() on empty CircularBuffer");
+        }
+        return data_[(tail_ + capacity_ - 1) % capacity_];
+    }
+
+    reference operator[](size_type index) {
+        if (index >= count_) {
+            throw std::out_of_range("Index out of range");
+        }
+        return data_[(head_ + index) % capacity_];
+    }
+
+    const_reference operator[](size_type index) const {
+        if (index >= count_) {
+            throw std::out_of_range("Index out of range");
+        }
+        return data_[(head_ + index) % capacity_];
+    }
+
+    void rotate(difference_type n) {
+        if (empty()) {
+            return;
+        }
+        if (n > 0) {
+            head_ = (head_ + n) % capacity_;
+            tail_ = (tail_ + n) % capacity_;
+        } else {
+            head_ = (head_ + capacity_ - ((-n) % capacity_)) % capacity_;
+            tail_ = (tail_ + capacity_ - ((-n) % capacity_)) % capacity_;
+        }
+    }
+
+    void clear() noexcept {
+        head_ = 0;
+        tail_ = 0;
+        count_ = 0;
+    }
+
+    // Iterator implementation
+    template <bool IsConst>
+    class base_iterator {
+    public:
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = CircularBuffer::value_type;
+        using difference_type = CircularBuffer::difference_type;
+        using pointer = std::conditional_t<IsConst, CircularBuffer::const_pointer, CircularBuffer::pointer>;
+        using reference = std::conditional_t<IsConst, CircularBuffer::const_reference, CircularBuffer::reference>;
+
+    private:
+        using parent_type = std::conditional_t<IsConst, const CircularBuffer*, CircularBuffer*>;
+        parent_type buf_;
+        size_type index_;
+
+    public:
+        base_iterator(parent_type buf, size_type index) : buf_(buf), index_(index) {}
+        base_iterator() : buf_(nullptr), index_(0) {}
+
+        // Allow conversion from non-const to const iterator
+        operator base_iterator<true>() const {
+            return base_iterator<true>(buf_, index_);
+        }
+
+        reference operator*() const {
+            return (*buf_)[index_];
+        }
+
+        pointer operator->() const {
+            return &(*buf_)[index_];
+        }
+
+        base_iterator& operator++() {
+            ++index_;
+            return *this;
+        }
+
+        base_iterator operator++(int) {
+            base_iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        base_iterator& operator--() {
+            --index_;
+            return *this;
+        }
+
+        base_iterator operator--(int) {
+            base_iterator tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        base_iterator& operator+=(difference_type n) {
+            index_ += n;
+            return *this;
+        }
+
+        base_iterator operator+(difference_type n) const {
+            base_iterator tmp = *this;
+            return tmp += n;
+        }
+
+        base_iterator& operator-=(difference_type n) {
+            index_ -= n;
+            return *this;
+        }
+
+        base_iterator operator-(difference_type n) const {
+            base_iterator tmp = *this;
+            return tmp -= n;
+        }
+
+        difference_type operator-(const base_iterator& other) const {
+            return index_ - other.index_;
+        }
+
+        reference operator[](difference_type n) const {
+            return *(*this + n);
+        }
+
+        bool operator==(const base_iterator& other) const {
+            return buf_ == other.buf_ && index_ == other.index_;
+        }
+
+        bool operator!=(const base_iterator& other) const {
+            return !(*this == other);
+        }
+
+        bool operator<(const base_iterator& other) const {
+            return index_ < other.index_;
+        }
+
+        bool operator>(const base_iterator& other) const {
+            return index_ > other.index_;
+        }
+
+        bool operator<=(const base_iterator& other) const {
+            return index_ <= other.index_;
+        }
+
+        bool operator>=(const base_iterator& other) const {
+            return index_ >= other.index_;
+        }
+    };
+
+    using iterator = base_iterator<false>;
+    using const_iterator = base_iterator<true>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    iterator begin() { return iterator(this, 0); }
+    iterator end() { return iterator(this, count_); }
+    const_iterator begin() const { return const_iterator(this, 0); }
+    const_iterator end() const { return const_iterator(this, count_); }
+    const_iterator cbegin() const { return const_iterator(this, 0); }
+    const_iterator cend() const { return const_iterator(this, count_); }
+
+    reverse_iterator rbegin() { return reverse_iterator(end()); }
+    reverse_iterator rend() { return reverse_iterator(begin()); }
+    const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+    const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+    const_reverse_iterator crbegin() const { return const_reverse_iterator(cend()); }
+    const_reverse_iterator crend() const { return const_reverse_iterator(cbegin()); }
+};
+
+template <typename T, typename Alloc>
+void swap(CircularBuffer<T, Alloc>& lhs, CircularBuffer<T, Alloc>& rhs) noexcept {
+    lhs.swap(rhs);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ foreach(TEST_FILE ${INDIVIDUAL_TEST_FILES})
         OneOfLib             # Added for one_of_test
         PackedSlotMapLib     # Added for packed_slot_map_test
         ChronoRingLib        # Added for chrono_ring_test
+        CircularBufferLib    # Added for circular_buffer_test
         TaggedPtrLib         # Added for tagged_ptr_test
         PredicateCacheLib    # Added for predicate_cache_test
         ShadowCopyLib        # Added for shadow_copy_test

--- a/tests/circular_buffer_test.cpp
+++ b/tests/circular_buffer_test.cpp
@@ -1,0 +1,245 @@
+#include "gtest/gtest.h"
+#include "circular_buffer.h"
+#include <string>
+#include <numeric>
+
+TEST(CircularBufferTest, ConstructorAndCapacity) {
+    CircularBuffer<int> buffer(5);
+    EXPECT_EQ(buffer.capacity(), 5);
+    EXPECT_EQ(buffer.size(), 0);
+    EXPECT_TRUE(buffer.empty());
+    EXPECT_FALSE(buffer.full());
+
+    EXPECT_THROW(CircularBuffer<int>(0), std::invalid_argument);
+}
+
+TEST(CircularBufferTest, PushBack) {
+    CircularBuffer<int> buffer(3);
+    buffer.push_back(1);
+    buffer.push_back(2);
+
+    EXPECT_EQ(buffer.size(), 2);
+    EXPECT_EQ(buffer.front(), 1);
+    EXPECT_EQ(buffer.back(), 2);
+    EXPECT_FALSE(buffer.full());
+
+    buffer.push_back(3);
+    EXPECT_EQ(buffer.size(), 3);
+    EXPECT_EQ(buffer.front(), 1);
+    EXPECT_EQ(buffer.back(), 3);
+    EXPECT_TRUE(buffer.full());
+
+    // Test overwrite
+    buffer.push_back(4);
+    EXPECT_EQ(buffer.size(), 3);
+    EXPECT_EQ(buffer.front(), 2); // Oldest element (1) was overwritten
+    EXPECT_EQ(buffer.back(), 4);
+    EXPECT_TRUE(buffer.full());
+}
+
+TEST(CircularBufferTest, PushFront) {
+    CircularBuffer<std::string> buffer(3);
+    buffer.push_front("A");
+    buffer.push_front("B");
+
+    EXPECT_EQ(buffer.size(), 2);
+    EXPECT_EQ(buffer.front(), "B");
+    EXPECT_EQ(buffer.back(), "A");
+
+    buffer.push_front("C");
+    EXPECT_TRUE(buffer.full());
+    EXPECT_EQ(buffer.front(), "C");
+    EXPECT_EQ(buffer.back(), "A");
+
+    // Test overwrite
+    buffer.push_front("D");
+    EXPECT_TRUE(buffer.full());
+    EXPECT_EQ(buffer.front(), "D");
+    EXPECT_EQ(buffer.back(), "B"); // Oldest element ("A") was overwritten at the back
+}
+
+TEST(CircularBufferTest, PopFront) {
+    CircularBuffer<int> buffer(3);
+    buffer.push_back(10);
+    buffer.push_back(20);
+    buffer.push_back(30);
+
+    buffer.pop_front();
+    EXPECT_EQ(buffer.size(), 2);
+    EXPECT_EQ(buffer.front(), 20);
+    EXPECT_EQ(buffer.back(), 30);
+
+    buffer.pop_front();
+    buffer.pop_front();
+    EXPECT_TRUE(buffer.empty());
+
+    EXPECT_THROW(buffer.pop_front(), std::runtime_error);
+}
+
+TEST(CircularBufferTest, PopBack) {
+    CircularBuffer<int> buffer(3);
+    buffer.push_back(10);
+    buffer.push_back(20);
+    buffer.push_back(30);
+
+    buffer.pop_back();
+    EXPECT_EQ(buffer.size(), 2);
+    EXPECT_EQ(buffer.front(), 10);
+    EXPECT_EQ(buffer.back(), 20);
+
+    buffer.pop_back();
+    buffer.pop_back();
+    EXPECT_TRUE(buffer.empty());
+
+    EXPECT_THROW(buffer.pop_back(), std::runtime_error);
+}
+
+TEST(CircularBufferTest, ElementAccess) {
+    CircularBuffer<int> buffer(5);
+    for (int i = 0; i < 5; ++i) {
+        buffer.push_back(i * 10);
+    }
+
+    EXPECT_EQ(buffer[0], 0);
+    EXPECT_EQ(buffer[2], 20);
+    EXPECT_EQ(buffer[4], 40);
+    EXPECT_THROW(buffer[5], std::out_of_range);
+
+    const auto& c_buffer = buffer;
+    EXPECT_EQ(c_buffer[1], 10);
+    EXPECT_THROW(c_buffer[5], std::out_of_range);
+
+    buffer.push_back(50); // Overwrites 0
+    EXPECT_EQ(buffer.front(), 10);
+    EXPECT_EQ(buffer[0], 10);
+    EXPECT_EQ(buffer[4], 50);
+}
+
+TEST(CircularBufferTest, Clear) {
+    CircularBuffer<int> buffer(5);
+    buffer.push_back(1);
+    buffer.push_back(2);
+    buffer.clear();
+
+    EXPECT_EQ(buffer.size(), 0);
+    EXPECT_TRUE(buffer.empty());
+    EXPECT_FALSE(buffer.full());
+    EXPECT_THROW(buffer.front(), std::runtime_error);
+}
+
+TEST(CircularBufferTest, Rotation) {
+    CircularBuffer<int> buffer(5);
+    for (int i = 1; i <= 5; ++i) {
+        buffer.push_back(i);
+    }
+
+    // Rotate right
+    buffer.rotate(2);
+    EXPECT_EQ(buffer[0], 4);
+    EXPECT_EQ(buffer[1], 5);
+    EXPECT_EQ(buffer[2], 1);
+    EXPECT_EQ(buffer[3], 2);
+    EXPECT_EQ(buffer[4], 3);
+
+    // Rotate left
+    buffer.rotate(-3);
+    EXPECT_EQ(buffer[0], 2);
+    EXPECT_EQ(buffer[1], 3);
+    EXPECT_EQ(buffer[2], 4);
+    EXPECT_EQ(buffer[3], 5);
+    EXPECT_EQ(buffer[4], 1);
+
+    // Rotate by 0
+    buffer.rotate(0);
+    EXPECT_EQ(buffer[0], 2);
+    EXPECT_EQ(buffer[4], 1);
+
+    // Rotate large number
+    buffer.rotate(7); // Same as rotate(2)
+    EXPECT_EQ(buffer[0], 5);
+    EXPECT_EQ(buffer[1], 1);
+    EXPECT_EQ(buffer[2], 2);
+}
+
+TEST(CircularBufferTest, Iterator) {
+    CircularBuffer<int> buffer(4);
+    buffer.push_back(10);
+    buffer.push_back(20);
+    buffer.push_back(30);
+
+    // Forward iterator
+    auto it = buffer.begin();
+    EXPECT_EQ(*it, 10);
+    ++it;
+    EXPECT_EQ(*it, 20);
+    it++;
+    EXPECT_EQ(*it, 30);
+    ++it;
+    EXPECT_EQ(it, buffer.end());
+
+    // Sum using std::accumulate
+    int sum = std::accumulate(buffer.begin(), buffer.end(), 0);
+    EXPECT_EQ(sum, 60);
+
+    // Test with overwrite
+    buffer.push_back(40);
+    buffer.push_back(50); // Overwrites 10
+    sum = std::accumulate(buffer.begin(), buffer.end(), 0);
+    EXPECT_EQ(sum, 20 + 30 + 40 + 50);
+    EXPECT_EQ(*buffer.begin(), 20);
+}
+
+TEST(CircularBufferTest, ConstIterator) {
+    CircularBuffer<int> buffer(3);
+    buffer.push_back(1);
+    buffer.push_back(2);
+    buffer.push_back(3);
+    buffer.push_back(4); // Overwrites 1
+
+    const CircularBuffer<int>& c_buffer = buffer;
+    auto it = c_buffer.cbegin();
+    EXPECT_EQ(*it, 2);
+    ++it;
+    EXPECT_EQ(*it, 3);
+    ++it;
+    EXPECT_EQ(*it, 4);
+    ++it;
+    EXPECT_EQ(it, c_buffer.cend());
+}
+
+TEST(CircularBufferTest, ReverseIterator) {
+    CircularBuffer<int> buffer(5);
+    for (int i = 0; i < 5; ++i) {
+        buffer.push_back(i);
+    }
+    buffer.push_back(5); // Overwrite 0 -> buffer is 1,2,3,4,5
+
+    auto it = buffer.rbegin();
+    EXPECT_EQ(*it, 5);
+    ++it;
+    EXPECT_EQ(*it, 4);
+    ++it;
+    EXPECT_EQ(*it, 3);
+    ++it;
+    EXPECT_EQ(*it, 2);
+    ++it;
+    EXPECT_EQ(*it, 1);
+    ++it;
+    EXPECT_EQ(it, buffer.rend());
+}
+
+TEST(CircularBufferTest, RandomAccessIterator) {
+    CircularBuffer<int> buffer(5);
+    for (int i=1; i<=5; ++i) buffer.push_back(i);
+
+    auto it = buffer.begin();
+    EXPECT_EQ(*(it + 3), 4);
+    it += 2;
+    EXPECT_EQ(*it, 3);
+    auto it2 = it - 1;
+    EXPECT_EQ(*it2, 2);
+
+    EXPECT_GT(it, it2);
+    EXPECT_LT(it2, it);
+    EXPECT_EQ(it - it2, 1);
+}


### PR DESCRIPTION
This commit introduces a new data structure, `CircularBuffer`, to the library.

The `CircularBuffer` is a fixed-capacity container that supports adding and removing elements from both ends. When full, new elements overwrite the oldest ones. It is implemented using a `std::vector` as the underlying storage.

Key features include:
- O(1) time complexity for `push_back`, `push_front`, `pop_back`, `pop_front`.
- O(1) time complexity for the `rotate()` method, which shifts all elements.
- Random access iterators.

This addition includes:
- The implementation in `include/circular_buffer.h`.
- Unit tests in `tests/circular_buffer_test.cpp`.
- An example in `examples/circular_buffer_example.cpp`.
- Documentation in `docs/README_circular_buffer.md`.
- Updates to the CMake build system.